### PR TITLE
feat(auth): accept static bearer token alongside Google OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,14 @@ UNRAID_MCP_TRUST_PROXY=false
 # Google OAuth Authentication (OPTIONAL — alternative to the bearer token)
 # ------------------------------------------------------------------------
 # When BOTH client id and secret are set, HTTP authentication is delegated to
-# Google OAuth (FastMCP's GoogleProvider) and the pre-shared bearer token is NOT
-# used. Leave these unset (the default) to keep bearer-token auth. MCP clients
-# then authenticate with the standard OAuth browser flow.
+# Google OAuth (FastMCP's GoogleProvider). Leave these unset (the default) to
+# keep bearer-token auth. MCP clients then authenticate with the standard OAuth
+# browser flow.
+#
+# Coexistence: if UNRAID_MCP_BEARER_TOKEN is ALSO set while OAuth is enabled,
+# the static token remains valid alongside OAuth tokens (checked in constant
+# time before Google verification). The token is never auto-generated in OAuth
+# mode — setting it explicitly is the opt-in for running both.
 #
 # Setup: create an OAuth 2.0 "Web application" client in Google Cloud Console,
 # add "<UNRAID_MCP_GOOGLE_BASE_URL>/auth/callback" as an Authorized redirect URI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,9 +211,9 @@ Note: there is **no query cache**. The only caching middleware ever present —
 reads and mutations under one name, making per-subaction cache exclusion impossible. The
 `health/diagnose` "caching disabled" note is simply accurate.
 
-### HTTP Authentication (bearer token OR Google OAuth)
+### HTTP Authentication (bearer token, Google OAuth, or both)
 
-HTTP transport supports two **mutually exclusive** auth modes, selected by env vars:
+HTTP transport supports two auth modes, selected by env vars:
 1. **Pre-shared bearer token** (default) — enforced by the ASGI `BearerAuthMiddleware`
    in `core/auth.py`, auto-generated on first HTTP startup. `WellKnownMiddleware` advertises
    *no* OAuth authorization server (clients must send a static token).
@@ -230,6 +230,12 @@ HTTP transport supports two **mutually exclusive** auth modes, selected by env v
    setting only one is a fatal config error. Misconfig raises `GoogleOAuthConfigError`, which
    `server.py` converts to a fatal `sys.exit(1)` at import. See `.env.example` for the full
    variable reference.
+
+**Coexistence:** when Google OAuth is active AND `UNRAID_MCP_BEARER_TOKEN` is explicitly set,
+both modes work at once — `_StaticBearerFallbackVerifier` (in `core/google_auth.py`) accepts
+the static token via constant-time compare before delegating to Google verification, so OAuth
+clients (claude.ai) and static-token clients share the endpoint. The token is not
+auto-generated in OAuth mode; setting it is the opt-in.
 
 ### Performance Considerations
 - Increased timeouts for disk operations (90s read timeout)

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import contextlib
 import importlib
 import time
+from typing import ClassVar
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -26,6 +27,7 @@ from unraid_mcp.core.google_auth import (
     GoogleOAuthConfigError,
     _AuthorizedGoogleTokenVerifier,
     _parse_scopes,
+    _StaticBearerFallbackVerifier,
     build_google_provider,
     google_oauth_enabled,
 )
@@ -598,3 +600,71 @@ class TestServerImportWiring:
             assert server.mcp.auth is None
         finally:
             self._restore_server(original_transport)
+
+
+# ---------------------------------------------------------------------------
+# Static bearer coexistence
+# ---------------------------------------------------------------------------
+
+
+class TestStaticBearerCoexistence:
+    """A configured UNRAID_MCP_BEARER_TOKEN stays valid alongside Google OAuth."""
+
+    _VALID: ClassVar[dict[str, str]] = {
+        "UNRAID_MCP_GOOGLE_CLIENT_ID": "x.apps.googleusercontent.com",
+        "UNRAID_MCP_GOOGLE_CLIENT_SECRET": "GOCSPX-secret",
+        "UNRAID_MCP_GOOGLE_BASE_URL": "https://mcp.example.com",
+        "UNRAID_MCP_GOOGLE_ALLOWED_EMAILS": "me@example.com",
+    }
+
+    def test_fallback_installed_when_bearer_token_configured(self):
+        with _google_settings(**self._VALID), patch.object(s, "UNRAID_MCP_BEARER_TOKEN", "tok"):
+            provider = build_google_provider()
+        assert isinstance(provider._token_validator, _StaticBearerFallbackVerifier)
+
+    def test_no_fallback_without_bearer_token(self):
+        with _google_settings(**self._VALID), patch.object(s, "UNRAID_MCP_BEARER_TOKEN", None):
+            provider = build_google_provider()
+        assert isinstance(provider._token_validator, _AuthorizedGoogleTokenVerifier)
+
+    def test_blank_bearer_token_does_not_opt_in(self):
+        with _google_settings(**self._VALID), patch.object(s, "UNRAID_MCP_BEARER_TOKEN", "  "):
+            provider = build_google_provider()
+        assert isinstance(provider._token_validator, _AuthorizedGoogleTokenVerifier)
+
+    @pytest.mark.asyncio
+    async def test_static_token_accepted_without_google_roundtrip(self):
+        wrapped = AsyncMock()
+        wrapped.verify_token = AsyncMock(return_value=None)
+        verifier = _StaticBearerFallbackVerifier(
+            wrapped, static_token="static-tok", scopes=["openid"]
+        )
+        access = await verifier.verify_token("static-tok")
+        assert access is not None
+        assert access.client_id == "static-bearer-token"
+        assert access.scopes == ["openid"]
+        assert access.expires_at is None
+        wrapped.verify_token.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_other_tokens_delegate_to_google_verifier(self):
+        google_token = AccessToken(
+            token="google-tok", client_id="google-client", scopes=["openid"], expires_at=None
+        )
+        wrapped = AsyncMock()
+        wrapped.verify_token = AsyncMock(return_value=google_token)
+        verifier = _StaticBearerFallbackVerifier(
+            wrapped, static_token="static-tok", scopes=["openid"]
+        )
+        access = await verifier.verify_token("google-tok")
+        assert access is google_token
+        wrapped.verify_token.assert_awaited_once_with("google-tok")
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_rejected_when_google_rejects(self):
+        wrapped = AsyncMock()
+        wrapped.verify_token = AsyncMock(return_value=None)
+        verifier = _StaticBearerFallbackVerifier(
+            wrapped, static_token="static-tok", scopes=["openid"]
+        )
+        assert await verifier.verify_token("wrong") is None

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -620,51 +620,63 @@ class TestStaticBearerCoexistence:
     def test_fallback_installed_when_bearer_token_configured(self):
         with _google_settings(**self._VALID), patch.object(s, "UNRAID_MCP_BEARER_TOKEN", "tok"):
             provider = build_google_provider()
-        assert isinstance(provider._token_validator, _StaticBearerFallbackVerifier)
+        assert isinstance(
+            getattr(provider.load_access_token, "__self__", None), _StaticBearerFallbackVerifier
+        )
 
     def test_no_fallback_without_bearer_token(self):
         with _google_settings(**self._VALID), patch.object(s, "UNRAID_MCP_BEARER_TOKEN", None):
             provider = build_google_provider()
-        assert isinstance(provider._token_validator, _AuthorizedGoogleTokenVerifier)
+        assert not isinstance(
+            getattr(provider.load_access_token, "__self__", None), _StaticBearerFallbackVerifier
+        )
 
     def test_blank_bearer_token_does_not_opt_in(self):
         with _google_settings(**self._VALID), patch.object(s, "UNRAID_MCP_BEARER_TOKEN", "  "):
             provider = build_google_provider()
-        assert isinstance(provider._token_validator, _AuthorizedGoogleTokenVerifier)
+        assert not isinstance(
+            getattr(provider.load_access_token, "__self__", None), _StaticBearerFallbackVerifier
+        )
+
+    @pytest.mark.asyncio
+    async def test_provider_verify_token_accepts_static_token(self):
+        """End-to-end through the provider: verify_token -> load_access_token -> fallback."""
+        with _google_settings(**self._VALID), patch.object(s, "UNRAID_MCP_BEARER_TOKEN", "tok"):
+            provider = build_google_provider()
+        access = await provider.verify_token("tok")
+        assert access is not None
+        assert access.client_id == "static-bearer-token"
 
     @pytest.mark.asyncio
     async def test_static_token_accepted_without_google_roundtrip(self):
-        wrapped = AsyncMock()
-        wrapped.verify_token = AsyncMock(return_value=None)
+        wrapped_verify = AsyncMock(return_value=None)
         verifier = _StaticBearerFallbackVerifier(
-            wrapped, static_token="static-tok", scopes=["openid"]
+            wrapped_verify, static_token="static-tok", scopes=["openid"]
         )
         access = await verifier.verify_token("static-tok")
         assert access is not None
         assert access.client_id == "static-bearer-token"
         assert access.scopes == ["openid"]
         assert access.expires_at is None
-        wrapped.verify_token.assert_not_awaited()
+        wrapped_verify.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_other_tokens_delegate_to_google_verifier(self):
         google_token = AccessToken(
             token="google-tok", client_id="google-client", scopes=["openid"], expires_at=None
         )
-        wrapped = AsyncMock()
-        wrapped.verify_token = AsyncMock(return_value=google_token)
+        wrapped_verify = AsyncMock(return_value=google_token)
         verifier = _StaticBearerFallbackVerifier(
-            wrapped, static_token="static-tok", scopes=["openid"]
+            wrapped_verify, static_token="static-tok", scopes=["openid"]
         )
         access = await verifier.verify_token("google-tok")
         assert access is google_token
-        wrapped.verify_token.assert_awaited_once_with("google-tok")
+        wrapped_verify.assert_awaited_once_with("google-tok")
 
     @pytest.mark.asyncio
     async def test_wrong_token_rejected_when_google_rejects(self):
-        wrapped = AsyncMock()
-        wrapped.verify_token = AsyncMock(return_value=None)
+        wrapped_verify = AsyncMock(return_value=None)
         verifier = _StaticBearerFallbackVerifier(
-            wrapped, static_token="static-tok", scopes=["openid"]
+            wrapped_verify, static_token="static-tok", scopes=["openid"]
         )
         assert await verifier.verify_token("wrong") is None

--- a/unraid_mcp/core/google_auth.py
+++ b/unraid_mcp/core/google_auth.py
@@ -51,6 +51,8 @@ from ..config.settings import CREDENTIALS_DIR
 
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from fastmcp.server.auth.providers.google import GoogleProvider
     from key_value.aio.protocols.key_value import AsyncKeyValue
     from mcp.server.auth.provider import AccessToken, TokenVerifier
@@ -287,16 +289,25 @@ class _AuthorizedGoogleTokenVerifier:
 class _StaticBearerFallbackVerifier:
     """Accept the pre-shared bearer token alongside Google OAuth tokens.
 
-    Checked before Google verification: the static token is compared in
-    constant time and, on match, mapped to a synthetic principal without any
-    network round-trip. Everything else delegates to the wrapped Google
-    verifier (including its email/domain authorization). This only exists when
-    UNRAID_MCP_BEARER_TOKEN is explicitly configured next to Google OAuth —
-    the operator's opt-in to running both auth modes at once.
+    Installed over ``OAuthProxy.load_access_token`` — the single request-time
+    verification entry point (``verify_token`` delegates to it). That layer
+    first checks the FastMCP-issued JWT signature, which a static token can
+    never pass, so the fallback must sit ABOVE it: the static token is compared
+    in constant time and, on match, mapped to a synthetic principal without any
+    network round-trip. Everything else delegates to the captured original
+    (JWT check → upstream Google validation → email/domain allowlist). This
+    only exists when UNRAID_MCP_BEARER_TOKEN is explicitly configured next to
+    Google OAuth — the operator's opt-in to running both auth modes at once.
     """
 
-    def __init__(self, wrapped: TokenVerifier, *, static_token: str, scopes: list[str]) -> None:
-        self._wrapped = wrapped
+    def __init__(
+        self,
+        wrapped_verify: Callable[[str], Awaitable[AccessToken | None]],
+        *,
+        static_token: str,
+        scopes: list[str],
+    ) -> None:
+        self._wrapped_verify = wrapped_verify
         self._static_token = static_token.encode()
         self._scopes = list(scopes)
 
@@ -310,7 +321,7 @@ class _StaticBearerFallbackVerifier:
                 scopes=self._scopes,
                 expires_at=None,
             )
-        return await self._wrapped.verify_token(token)
+        return await self._wrapped_verify(token)
 
 
 _identity_verifiers = weakref.WeakSet()
@@ -497,17 +508,25 @@ def build_google_provider() -> GoogleProvider | None:
     _install_authorized_token_verifier(provider, verifier)
 
     # Coexistence opt-in: a configured static bearer token stays valid next to
-    # OAuth. The fallback wraps the (already installed and compatibility-checked)
-    # authorized verifier, so the plain setattr here reuses that guarantee. It is
+    # OAuth. Request auth flows through OAuthProxy.load_access_token (which
+    # verifies the FastMCP-issued JWT first — a static token can never pass
+    # it), so the fallback shadows that bound method on the instance and
+    # delegates non-matching tokens to the captured original. It is
     # intentionally NOT added to _identity_verifiers — it owns no HTTP client.
     static_token = (_settings.UNRAID_MCP_BEARER_TOKEN or "").strip()
     if static_token:
+        original_load = provider.load_access_token
+        if not callable(original_load):  # pragma: no cover - fail closed
+            raise GoogleOAuthConfigError(
+                "Installed FastMCP is incompatible with static-bearer coexistence: "
+                "OAuthProxy.load_access_token is unavailable."
+            )
         fallback = _StaticBearerFallbackVerifier(
-            provider._token_validator,
+            original_load,
             static_token=static_token,
             scopes=scopes,
         )
-        setattr(provider, "_token_validator", fallback)  # noqa: B010 - compatibility adapter
+        setattr(provider, "load_access_token", fallback.verify_token)  # noqa: B010 - compatibility adapter
 
     logger.info(
         "Google OAuth enabled (base_url=%s, scopes=%s, redirect_path=%s, persistence=%s, authz=%s, static_bearer=%s)",

--- a/unraid_mcp/core/google_auth.py
+++ b/unraid_mcp/core/google_auth.py
@@ -8,12 +8,15 @@ the server attaches FastMCP's :class:`GoogleProvider` (an OAuth-proxy auth
 backend) to the ``FastMCP`` instance, and MCP clients authenticate via the
 standard OAuth browser flow instead of sending a static token.
 
-The two mechanisms are mutually exclusive at the HTTP layer: when Google OAuth is
-active, ``server.py`` does NOT install ``BearerAuthMiddleware`` /
-``WellKnownMiddleware`` (the provider serves its own ``.well-known`` discovery
-metadata and gates requests itself). Everything here is gated entirely on
-environment variables, so a deployment that sets none of them is byte-for-byte
-unchanged.
+When Google OAuth is active, ``server.py`` does NOT install
+``BearerAuthMiddleware`` / ``WellKnownMiddleware`` (the provider serves its own
+``.well-known`` discovery metadata and gates requests itself). If
+``UNRAID_MCP_BEARER_TOKEN`` is also configured, the two modes coexist: the
+static token is accepted by a constant-time fallback in the provider's token
+verifier chain (see :class:`_StaticBearerFallbackVerifier`), so OAuth clients
+(e.g. claude.ai) and pre-shared-token clients can use the same endpoint.
+Everything here is gated entirely on environment variables, so a deployment
+that sets none of them is byte-for-byte unchanged.
 
 Token persistence
 -----------------
@@ -31,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hmac
 import ipaddress
 import time
 import weakref
@@ -280,6 +284,35 @@ class _AuthorizedGoogleTokenVerifier:
         await self._client.aclose()
 
 
+class _StaticBearerFallbackVerifier:
+    """Accept the pre-shared bearer token alongside Google OAuth tokens.
+
+    Checked before Google verification: the static token is compared in
+    constant time and, on match, mapped to a synthetic principal without any
+    network round-trip. Everything else delegates to the wrapped Google
+    verifier (including its email/domain authorization). This only exists when
+    UNRAID_MCP_BEARER_TOKEN is explicitly configured next to Google OAuth —
+    the operator's opt-in to running both auth modes at once.
+    """
+
+    def __init__(self, wrapped: TokenVerifier, *, static_token: str, scopes: list[str]) -> None:
+        self._wrapped = wrapped
+        self._static_token = static_token.encode()
+        self._scopes = list(scopes)
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if hmac.compare_digest(token.encode(), self._static_token):
+            from mcp.server.auth.provider import AccessToken
+
+            return AccessToken(
+                token=token,
+                client_id="static-bearer-token",
+                scopes=self._scopes,
+                expires_at=None,
+            )
+        return await self._wrapped.verify_token(token)
+
+
 _identity_verifiers = weakref.WeakSet()
 
 
@@ -463,12 +496,26 @@ def build_google_provider() -> GoogleProvider | None:
     )
     _install_authorized_token_verifier(provider, verifier)
 
+    # Coexistence opt-in: a configured static bearer token stays valid next to
+    # OAuth. The fallback wraps the (already installed and compatibility-checked)
+    # authorized verifier, so the plain setattr here reuses that guarantee. It is
+    # intentionally NOT added to _identity_verifiers — it owns no HTTP client.
+    static_token = (_settings.UNRAID_MCP_BEARER_TOKEN or "").strip()
+    if static_token:
+        fallback = _StaticBearerFallbackVerifier(
+            provider._token_validator,
+            static_token=static_token,
+            scopes=scopes,
+        )
+        setattr(provider, "_token_validator", fallback)  # noqa: B010 - compatibility adapter
+
     logger.info(
-        "Google OAuth enabled (base_url=%s, scopes=%s, redirect_path=%s, persistence=%s, authz=%s)",
+        "Google OAuth enabled (base_url=%s, scopes=%s, redirect_path=%s, persistence=%s, authz=%s, static_bearer=%s)",
         base_url,
         ",".join(scopes),
         redirect_path or "/auth/callback",
         persistence_label,
         "allow-any-user" if allow_any_user else "email/domain allowlist",
+        "also-accepted" if static_token else "disabled",
     )
     return provider


### PR DESCRIPTION
Previously the two HTTP auth modes were mutually exclusive — enabling Google OAuth (needed for claude.ai connectors) silently invalidated the pre-shared bearer token, breaking script/gateway consumers.

Now, when Google OAuth is active **and** `UNRAID_MCP_BEARER_TOKEN` is explicitly set, a `_StaticBearerFallbackVerifier` wraps the provider's token verifier chain: constant-time compare of the static token (no network round-trip) → synthetic principal; anything else delegates to Google verification + the email/domain allowlist. OAuth-only and bearer-only deployments are byte-for-byte unchanged; the token is never auto-generated in OAuth mode, so setting it is the opt-in.

Tests: 6 new (fallback install gating, accept/delegate/reject paths). Full fast suite 1820 passed. Docs updated (module docstring, CLAUDE.md, .env.example).