### PR TITLE
docs: update auth docs for OAuth+bearer coexistence and claude.ai connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ just setup
 | `UNRAID_MCP_BEARER_TOKEN` | Conditional | — | Static Bearer token for HTTP transports; auto-generated on first start if unset |
 | `UNRAID_MCP_DISABLE_HTTP_AUTH` | No | `false` | Set `true` to skip Bearer auth (use behind a reverse proxy that handles auth) |
 | `UNRAID_MCP_TRUST_PROXY` | Conditional | `false` | Required when disabling HTTP auth while binding a non-loopback interface |
-| `UNRAID_MCP_GOOGLE_CLIENT_ID` | No | — | Google OAuth client ID; setting both client ID and secret replaces Bearer auth for HTTP transports |
+| `UNRAID_MCP_GOOGLE_CLIENT_ID` | No | — | Google OAuth client ID; setting both client ID and secret enables OAuth for HTTP transports (required for claude.ai connectors). An explicitly set `UNRAID_MCP_BEARER_TOKEN` stays valid alongside OAuth |
 | `UNRAID_MCP_GOOGLE_CLIENT_SECRET` | No | — | Google OAuth client secret |
 | `UNRAID_MCP_GOOGLE_BASE_URL` | Conditional | — | Public server base URL, required when Google OAuth is enabled |
 | `UNRAID_MCP_GOOGLE_REQUIRED_SCOPES` | No | `openid` + `userinfo.email` | Comma/space-separated OAuth scopes |

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -78,10 +78,26 @@ environment:
 ## Google OAuth (optional)
 
 Set **both** `UNRAID_MCP_GOOGLE_CLIENT_ID` and `UNRAID_MCP_GOOGLE_CLIENT_SECRET` to
-delegate HTTP authentication to Google OAuth (FastMCP's `GoogleProvider`) instead of
-the static bearer token. When active, the bearer-token middleware is **not** installed
-and clients authenticate via the standard OAuth browser flow — there's no static token
-to distribute. Leave these unset to keep bearer-token auth (the default).
+delegate HTTP authentication to Google OAuth (FastMCP's `GoogleProvider`). When
+active, the bearer-token middleware is **not** installed and clients authenticate via
+the standard OAuth browser flow. Leave these unset to keep bearer-token auth (the
+default).
+
+**Coexistence:** if `UNRAID_MCP_BEARER_TOKEN` is *also* explicitly set while OAuth is
+enabled, the static token stays valid alongside OAuth tokens (compared in constant
+time before Google verification). This lets OAuth clients (claude.ai) and
+static-token clients (Claude Code, scripts, gateways) share the same endpoint. The
+token is never auto-generated in OAuth mode — setting it is the opt-in.
+
+### Using with claude.ai custom connectors
+
+claude.ai's custom connector UI only supports OAuth 2.1 with dynamic client
+registration — it cannot send a static bearer token. Enabling Google OAuth mode makes
+the server fully claude.ai-compatible: it serves OAuth discovery metadata
+(`/.well-known/oauth-authorization-server`) and a registration endpoint, so adding
+`https://<your-host>/mcp` as a custom connector walks you through Google sign-in
+(restricted to your allowlist). No client ID needs to be entered in claude.ai's
+connector form.
 
 ### Setup
 


### PR DESCRIPTION
Follow-up to #197: AUTHENTICATION.md and the README still said Google OAuth *replaces* bearer auth. Updated both for the coexistence opt-in, and added a short 'Using with claude.ai custom connectors' section — the exact scenario from #191 — explaining that claude.ai only speaks OAuth 2.1 + DCR and that Google OAuth mode makes the server compatible out of the box.