### PR TITLE
fix(ci): wait for PyPI visibility before MCP Registry publish

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -184,6 +184,20 @@ jobs:
             .packages = [.packages[] | if .registryType == "pypi" then .version = $version else . end]
           ' server.json > server.release.json
           mv server.release.json server.json
+      - name: Wait for release version to be visible on PyPI
+        if: steps.state.outputs.published != 'true'
+        run: |
+          version="${RELEASE_TAG#v}"
+          for attempt in {1..20}; do
+            if curl -fsS "https://pypi.org/pypi/unraid-mcp/${version}/json" > /dev/null; then
+              echo "PyPI reports unraid-mcp ${version} (attempt ${attempt})."
+              exit 0
+            fi
+            echo "unraid-mcp ${version} not visible on PyPI yet (attempt ${attempt}/20); retrying in 15s."
+            sleep 15
+          done
+          echo "::error::unraid-mcp ${version} never became visible on PyPI; registry validation would fail"
+          exit 1
       - name: Authenticate to MCP Registry
         if: steps.state.outputs.published != 'true'
         env:
@@ -191,7 +205,18 @@ jobs:
         run: ./mcp-publisher login dns --domain tootie.tv --private-key "$MCP_PRIVATE_KEY"
       - name: Publish MCP Registry channel
         if: steps.state.outputs.published != 'true'
-        run: ./mcp-publisher publish
+        run: |
+          for attempt in {1..3}; do
+            if ./mcp-publisher publish; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "mcp-publisher publish failed (attempt ${attempt}/3); retrying in 30s."
+              sleep 30
+            fi
+          done
+          echo "::error::MCP Registry publish failed after 3 attempts"
+          exit 1
 
   reconcile:
     name: Release Reconciliation


### PR DESCRIPTION
## Problem

The **Publish MCP Registry Channel** job in `publish-pypi.yml` failed on both the v2.4.1 and v2.5.0 releases with:

> registry validation failed for package 0 (unraid-mcp): PyPI package 'unraid-mcp' exists, but version 'X.Y.Z' was not found (status: 404). A newly published release can take a moment to appear on PyPI. Wait and retry

It races the PyPI CDN — the PyPI publish job succeeds, but the registry's server-side validation queries PyPI before the new version is visible. Each occurrence needed a manual `gh run rerun --failed` plus a manual deployment-gate approval.

## Fix

Two changes to the `mcp-registry` job, both gated on `steps.state.outputs.published != 'true'` like the surrounding steps:

1. **Wait for release version to be visible on PyPI** — polls `https://pypi.org/pypi/unraid-mcp/${version}/json` (version derived from `RELEASE_TAG` exactly like the other steps) until HTTP 200, up to 20 attempts x 15s = 5 minutes, failing with a clear `::error::` if the version never appears.
2. **Retry the registry publish** — wraps `./mcp-publisher publish` in a 3-attempt loop, 30s apart, since the registry's own validator may also lag even after PyPI reports the version.

No jobs restructured; no other behavior changed. Well within the job's `timeout-minutes: 10`.

## Testing

- `uv run pytest tests/test_supply_chain_policy.py -q` — 9 passed (no assertions needed updating)
- Workflow YAML validated with `yaml.safe_load`