### PR TITLE
fix(plugin): harden install bootstrap after live testing on Unraid 7.3.1

### DIFF
--- a/unraid-plugin/README.md
+++ b/unraid-plugin/README.md
@@ -36,7 +36,7 @@ page. Personal-use distribution for now (no Community Apps).
   `/var/log/unraid-mcp/server.log` (5 MB rotation).
 - Install auto-generates `UNRAID_MCP_BEARER_TOKEN` and, when the
   `unraid-api` CLI is present, auto-provisions `UNRAID_API_KEY` via
-  `unraid-api apikey --create --name unraid-mcp -r admin --json` — zero-paste
+  `unraid-api apikey --create --name unraidmcp -r admin --json` — zero-paste
   setup.
 
 ## Settings page

--- a/unraid-plugin/unraid-mcp.plg
+++ b/unraid-plugin/unraid-mcp.plg
@@ -55,18 +55,31 @@ if [ ! -f "&plugin;/.env" ]; then
   # Auto-generate the MCP bearer token.
   bearer_token="$(head -c 32 /dev/urandom | base64 | tr '+/' '-_' | tr -d '=')"
 
+  # The webGUI may run on a custom HTTP port (ident.cfg PORT) — do not assume 80.
+  # ident.cfg lives on the FAT flash with CRLF line endings: strip \r or the
+  # port lands in the URL with an embedded carriage return.
+  gui_port="$(cat /boot/config/ident.cfg 2>/dev/null | tr -d '\r' | sed -n 's/^PORT="\?\([0-9]*\)"\?.*/\1/p' | head -n1)"
+  case "$gui_port" in
+    ''|*[!0-9]*) gui_port=80 ;;
+  esac
+
   # Auto-provision a local Unraid API key when the unraid-api CLI is present —
-  # zero-paste setup. Falls back to empty (user fills in Settings).
+  # zero-paste setup. Key names may not contain hyphens (letters/numbers/spaces
+  # only). Falls back to empty (user fills in Settings). Reuses an existing key
+  # on reinstall rather than erroring on the duplicate name.
   api_key=""
   if command -v unraid-api >/dev/null 2>&amp;1; then
-    api_key="$(unraid-api apikey --create --name unraid-mcp -r admin --json 2>/dev/null | sed -n 's/.*"key":"\([^"]*\)".*/\1/p')" || api_key=""
+    api_key="$(unraid-api apikey --name unraidmcp --json 2>/dev/null | sed -n 's/.*"key":"\([^"]*\)".*/\1/p')" || api_key=""
+    if [ -z "$api_key" ]; then
+      api_key="$(unraid-api apikey --create --name unraidmcp -r admin --json 2>/dev/null | sed -n 's/.*"key":"\([^"]*\)".*/\1/p')" || api_key=""
+    fi
+    [ -z "$api_key" ] &amp;&amp; echo "unraid-mcp: could not auto-provision an API key — set one in Settings -> Unraid MCP"
   fi
 
   {
     echo "# unraid-mcp configuration — managed by the plugin settings page."
-    echo "UNRAID_API_URL='http://127.0.0.1/graphql'"
+    echo "UNRAID_API_URL='http://127.0.0.1:${gui_port}/graphql'"
     echo "UNRAID_API_KEY='${api_key}'"
-    echo "UNRAID_VERIFY_SSL='false'"
     echo "UNRAID_MCP_TRANSPORT='streamable-http'"
     echo "UNRAID_MCP_HOST='0.0.0.0'"
     echo "UNRAID_MCP_PORT='6970'"


### PR DESCRIPTION
Live install testing on tootie (Unraid 7.3.1) found three bootstrap bugs — all fixed and re-verified with a clean-room install from the release: fresh install → port auto-detected (`:6969`), API key auto-provisioned/reused, service started via `disks_mounted`, MCP handshake + live `system/online` tool call all green with zero manual configuration.

- `unraid-api apikey` rejects hyphens in key names → `unraidmcp`, with reuse-before-create for idempotent reinstalls
- webGUI port read from `ident.cfg` (CRLF-stripped — FAT32 line endings put a literal \r into the URL) instead of assuming 80
- dropped `UNRAID_VERIFY_SSL=false` which tripped the server's own insecure-TLS startup guard

Release assets for v2.5.0 (`unraid-mcp.plg` + txz) rebuilt and re-uploaded.