### PR TITLE
fix(plugin): Show button reveals stored secrets

### DIFF
--- a/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php
+++ b/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php
@@ -164,6 +164,18 @@ if (!is_array($body)) {
 
 $action = $body['action'] ?? 'save';
 
+if ($action === 'reveal') {
+    // Return a stored secret to the (already session+CSRF authenticated)
+    // webGUI admin — the bearer token exists to be copied into MCP clients.
+    $key = $body['key'] ?? '';
+    if (!in_array($key, SECRET_KEYS, true)) {
+        fail(400, 'not a secret key');
+    }
+    $env = read_env(ENV_FILE);
+    echo json_encode(['key' => $key, 'value' => $env[$key] ?? '']);
+    exit;
+}
+
 if ($action === 'service') {
     // {action: "service", op: "start"|"stop"|"restart"|"enable"|"disable"}
     $op = $body['op'] ?? '';

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, reactive, ref } from "vue";
 import { Badge, Button, HelpText, Input, Label, Select, Switch } from "./components/ui";
 import {
   loadConfig,
+  revealSecret,
   saveConfig,
   serviceAction,
   type ConfigPayload,
@@ -125,7 +126,9 @@ const SECTIONS: Section[] = [
 
 const payload = ref<ConfigPayload | null>(null);
 const form = reactive<Record<string, string>>({});
-const secretEdits = reactive<Record<string, { value: string; clear: boolean; show: boolean }>>({});
+const secretEdits = reactive<
+  Record<string, { value: string; clear: boolean; show: boolean; original: string | null }>
+>({});
 const loading = ref(true);
 const saving = ref(false);
 const busy = ref(false);
@@ -143,10 +146,12 @@ function hydrate(p: ConfigPayload) {
     for (const f of section.fields) {
       if (f.kind === "secret") {
         if (!secretEdits[f.key]) {
-          secretEdits[f.key] = { value: "", clear: false, show: false };
+          secretEdits[f.key] = { value: "", clear: false, show: false, original: null };
         } else {
           secretEdits[f.key].value = "";
           secretEdits[f.key].clear = false;
+          secretEdits[f.key].show = false;
+          secretEdits[f.key].original = null;
         }
       } else {
         form[f.key] = String(p.config[f.key] ?? "");
@@ -204,8 +209,8 @@ async function apply() {
   for (const key of secretKeys) {
     const edit = secretEdits[key];
     if (edit?.clear) changes[key] = "";
-    else if (edit?.value) changes[key] = edit.value;
-    // untouched secrets are omitted -> kept server-side
+    else if (edit?.value && edit.value !== edit.original) changes[key] = edit.value;
+    // untouched (or revealed-but-unchanged) secrets are omitted -> kept server-side
   }
   await run(() => saveConfig(changes));
   saving.value = false;
@@ -213,6 +218,31 @@ async function apply() {
     savedFlash.value = true;
     setTimeout(() => (savedFlash.value = false), 2500);
   }
+}
+
+async function toggleSecret(key: string) {
+  const edit = secretEdits[key];
+  if (!edit) return;
+  if (edit.show) {
+    // Re-mask; drop a revealed-but-unedited value so Apply keeps omitting it.
+    edit.show = false;
+    if (edit.value === edit.original) {
+      edit.value = "";
+      edit.original = null;
+    }
+    return;
+  }
+  if (!edit.value && secretConfigured(key)) {
+    try {
+      const v = await revealSecret(key);
+      edit.value = v;
+      edit.original = v;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : String(e);
+      return;
+    }
+  }
+  edit.show = true;
 }
 
 async function svc(op: ServiceOp) {
@@ -301,7 +331,7 @@ onMounted(async () => {
                   :placeholder="secretConfigured(field.key) ? '•••••• configured' : 'not set'"
                   :disabled="secretEdits[field.key].clear"
                 />
-                <Button size="sm" variant="ghost" class="px-2" @click="secretEdits[field.key].show = !secretEdits[field.key].show">
+                <Button size="sm" variant="ghost" class="px-2" @click="toggleSecret(field.key)">
                   {{ secretEdits[field.key].show ? "Hide" : "Show" }}
                 </Button>
                 <Button

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -330,6 +330,11 @@ onMounted(async () => {
                   class="h-8 font-mono text-sm flex-1 min-w-0"
                   :placeholder="secretConfigured(field.key) ? '•••••• configured' : 'not set'"
                   :disabled="secretEdits[field.key].clear"
+                  autocomplete="new-password"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  data-bwignore="true"
+                  data-form-type="other"
                 />
                 <Button size="sm" variant="ghost" class="px-2" @click="toggleSecret(field.key)">
                   {{ secretEdits[field.key].show ? "Hide" : "Show" }}

--- a/unraid-plugin/web/src/lib/config-client.ts
+++ b/unraid-plugin/web/src/lib/config-client.ts
@@ -68,3 +68,21 @@ export type ServiceOp = "start" | "stop" | "restart" | "enable" | "disable";
 export function serviceAction(op: ServiceOp): Promise<ConfigPayload> {
   return post({ action: "service", op });
 }
+
+/** Fetch a stored secret value (session + CSRF gated server-side). */
+export async function revealSecret(key: string): Promise<string> {
+  const res = await fetch(ENDPOINT, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Csrf-Token": await csrfToken(),
+    },
+    body: JSON.stringify({ action: "reveal", key }),
+  });
+  const body = await res.json().catch(() => null);
+  if (!res.ok) {
+    throw new Error(body?.error ?? `reveal failed: HTTP ${res.status}`);
+  }
+  return String(body?.value ?? "");
+}

--- a/unraid-plugin/web/vite.config.ts
+++ b/unraid-plugin/web/vite.config.ts
@@ -1,9 +1,12 @@
 import { fileURLToPath, URL } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
 import vue from "@vitejs/plugin-vue";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  test: {
+    environment: "happy-dom",
+  },
   plugins: [
     vue({
       customElement: true,


### PR DESCRIPTION
The write-only secret pattern (copied from incus) hid stored values from the browser entirely — Show only toggled visibility of newly *typed* text, useless for the bearer token, which exists to be copied into MCP clients.

- New `reveal` action on the settings endpoint: webGUI session + CSRF gated, secret-keys allowlist only — same trust level as Unraid's own API-keys page
- Show now fetches the stored value into the field (editable/copyable); Hide re-masks; a revealed-but-unedited value is still omitted from saves, so Apply semantics are unchanged
- vitest happy-dom env moved into vite.config so component tests run without flags

Deployed and verified on tootie.