### PR TITLE
feat(plugin): dedicated Logs tab with Aurora-dark colorized viewer

### DIFF
--- a/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/UnraidMCP.page
+++ b/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/UnraidMCP.page
@@ -18,8 +18,13 @@ $mcp_csrf = $var['csrf_token'] ?? '';
 if ($mcp_csrf === '') {
     $mcp_csrf = @parse_ini_file('/usr/local/emhttp/state/var.ini')['csrf_token'] ?? '';
 }
+// Cache-bust the bundle by its mtime: the asset filename is stable, so without
+// this the browser serves a stale bundle after every plugin update. mtime
+// changes on each redeploy and is otherwise stable (so normal caching holds).
+$mcp_web = '/usr/local/emhttp/plugins/unraid-mcp/web';
+$mcp_v = @filemtime("$mcp_web/unraid-mcp-settings.js") ?: '0';
 ?>
 <script>window.csrf_token = "<?= htmlspecialchars($mcp_csrf, ENT_QUOTES) ?>";</script>
-<link rel="stylesheet" href="/plugins/unraid-mcp/web/unraid-mcp-settings.css">
+<link rel="stylesheet" href="/plugins/unraid-mcp/web/unraid-mcp-settings.css?v=<?= $mcp_v ?>">
 <unraid-mcp-settings-app></unraid-mcp-settings-app>
-<script type="module" src="/plugins/unraid-mcp/web/unraid-mcp-settings.js"></script>
+<script type="module" src="/plugins/unraid-mcp/web/unraid-mcp-settings.js?v=<?= $mcp_v ?>"></script>

--- a/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/UnraidMCPDashboard.page
+++ b/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/UnraidMCPDashboard.page
@@ -1,0 +1,19 @@
+Menu="Dashboard"
+Title="Unraid MCP"
+Icon="unraid-mcp.png"
+Tag="plug"
+Nchan="unraid_mcp"
+Cond="(preg_match('/DASHBOARD_WIDGET_ENABLE\s*=\s*[\x22\x27]false[\x22\x27]/', @file_get_contents('/boot/config/plugins/unraid-mcp/unraid-mcp.cfg') ?: '') !== 1)"
+---
+<?php
+/*
+ * Main → Dashboard status tile. Deliberately its own tiny bundle
+ * (unraid-mcp-widget.js) — NOT the ~240 KB settings-app — because it renders on
+ * every dashboard view. Live status arrives via the nchan "unraid_mcp" channel
+ * (see nchan/unraid_mcp); the Nchan= header above keeps that publisher alive
+ * while this tile is visible. Cache-bust by the widget bundle's mtime.
+ */
+$mcp_widget_v = @filemtime('/usr/local/emhttp/plugins/unraid-mcp/web/unraid-mcp-widget.js') ?: '0';
+?>
+<unraid-mcp-widget></unraid-mcp-widget>
+<script type="module" src="/plugins/unraid-mcp/web/unraid-mcp-widget.js?v=<?= $mcp_widget_v ?>"></script>

--- a/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp
+++ b/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp
@@ -1,0 +1,36 @@
+#!/bin/bash
+# nchan publisher for the Unraid MCP dashboard widget.
+#
+# monitor_nchan discovers and runs this (it manages every
+# /usr/local/emhttp/*/nchan/* process) ONLY while the dashboard has a live
+# subscriber, pausing it otherwise. It publishes the server's status as JSON to
+# the "unraid_mcp" channel over nginx's local pub socket; buffer_length=1 means
+# a freshly-opened dashboard immediately receives the last status.
+
+socket="/var/run/nginx.socket"
+chan="http://localhost/pub/unraid_mcp?buffer_length=1"
+pidfile="/var/run/unraid-mcp.pid"
+interval=3
+
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+status_json() {
+    local pid running=false cpu=0 mem=0 uptime=0 version
+    pid="$(cat "$pidfile" 2>/dev/null)"
+    if [[ -n "$pid" && -d "/proc/$pid" ]]; then
+        running=true
+        # %cpu, rss(KiB), elapsed seconds for the server process.
+        read -r cpu rss uptime < <(ps -o %cpu=,rss=,etimes= -p "$pid" 2>/dev/null | awk '{print $1, $2, $3}')
+        cpu="${cpu:-0}"
+        mem=$(( ${rss:-0} / 1024 ))
+        uptime="${uptime:-0}"
+    fi
+    version="$(/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh installed 2>/dev/null)"
+    printf '{"running":%s,"pid":%s,"cpu":%s,"memMB":%s,"uptime":%s,"version":"%s"}' \
+        "$running" "${pid:-0}" "${cpu:-0}" "${mem:-0}" "${uptime:-0}" "$(json_escape "${version:-unknown}")"
+}
+
+while :; do
+    curl -s --max-time 2 --unix-socket "$socket" -d "$(status_json)" "$chan" >/dev/null 2>&1
+    sleep "$interval"
+done

--- a/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp
+++ b/unraid-plugin/source/usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp
@@ -12,7 +12,10 @@ chan="http://localhost/pub/unraid_mcp?buffer_length=1"
 pidfile="/var/run/unraid-mcp.pid"
 interval=3
 
-json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+# Escape for a JSON string: backslash, quote, and — per RFC 8259 §7 — strip any
+# control characters (a malformed version string must degrade to plain text, not
+# an invalid frame that wedges the widget).
+json_escape() { printf '%s' "$1" | tr -d '\000-\037' | sed 's/\\/\\\\/g; s/"/\\"/g'; }
 
 status_json() {
     local pid running=false cpu=0 mem=0 uptime=0 version
@@ -25,12 +28,12 @@ status_json() {
         mem=$(( ${rss:-0} / 1024 ))
         uptime="${uptime:-0}"
     fi
-    version="$(/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh installed 2>/dev/null)"
+    version="$(timeout 5 /usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh installed 2>/dev/null)"
     printf '{"running":%s,"pid":%s,"cpu":%s,"memMB":%s,"uptime":%s,"version":"%s"}' \
         "$running" "${pid:-0}" "${cpu:-0}" "${mem:-0}" "${uptime:-0}" "$(json_escape "${version:-unknown}")"
 }
 
 while :; do
-    curl -s --max-time 2 --unix-socket "$socket" -d "$(status_json)" "$chan" >/dev/null 2>&1
+    curl -s --max-time 2 --unix-socket "$socket" --data-raw "$(status_json)" "$chan" >/dev/null 2>&1
     sleep "$interval"
 done

--- a/unraid-plugin/unraid-mcp.plg
+++ b/unraid-plugin/unraid-mcp.plg
@@ -89,7 +89,7 @@ if [ ! -f "&plugin;/.env" ]; then
 fi
 
 # Wire the service + event scripts (rootfs is RAM — re-done every install/boot).
-chmod +x "&emhttp;/scripts/"*.sh "&emhttp;/scripts/rc.unraid-mcp" "&emhttp;/event/"* 2>/dev/null || true
+chmod +x "&emhttp;/scripts/"*.sh "&emhttp;/scripts/rc.unraid-mcp" "&emhttp;/event/"* "&emhttp;/nchan/"* 2>/dev/null || true
 ln -sf "&emhttp;/scripts/rc.unraid-mcp" /etc/rc.d/rc.unraid-mcp
 
 # If the array is already mounted (plugin installed on a running system) and

--- a/unraid-plugin/web/package.json
+++ b/unraid-plugin/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && vite build -c vite.widget.config.ts",
     "dev": "vite",
     "typecheck": "vue-tsc --noEmit",
     "test": "vitest run"

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -75,6 +75,9 @@ function secretConfigured(key: string): boolean {
 
 // ── Dirty tracking + validation ───────────────────────────────────────────
 const dirty = computed(() => {
+  // Before the first successful load, form is {} and the snapshot is "" — that
+  // mismatch would spuriously read as dirty (and enable Apply on an empty form).
+  if (!payload.value) return false;
   if (JSON.stringify(form) !== initialSnapshot.value) return true;
   return secretKeys.some((k) => {
     const e = secretEdits[k];
@@ -93,8 +96,11 @@ function fieldError(key: string): string {
   if (URL_KEYS.has(key) && !/^https?:\/\/.+/i.test(v)) return "Must start with http:// or https://";
   return "";
 }
+// Only validate sections whose fields are actually visible — otherwise an
+// invalid value inside a collapsed/gated section could disable Apply globally
+// with no error text on screen to explain why.
 const hasErrors = computed(() =>
-  SECTIONS.some((s) => s.fields.some((f) => fieldError(f.key) !== "")),
+  SECTIONS.some((s) => sectionShowsFields(s) && s.fields.some((f) => fieldError(f.key) !== "")),
 );
 
 // ── Google OAuth gate: keep the section compact until opted in ─────────────
@@ -114,9 +120,12 @@ function sparkPoints(hist: number[]): string {
   return hist.map((v, i) => `${(i / (n - 1)) * 100},${23 - (v / max) * 21}`).join(" ");
 }
 
-const apiKeyMissing = computed(
-  () => Boolean(payload.value) && !secretConfigured("UNRAID_API_KEY"),
-);
+const apiKeyMissing = computed(() => {
+  if (!payload.value) return false;
+  const edit = secretEdits.UNRAID_API_KEY;
+  if (edit?.value && !edit.clear) return false; // a key was typed but not yet saved
+  return !secretConfigured("UNRAID_API_KEY");
+});
 
 const service = computed(() => payload.value?.service ?? { enabled: false, running: false });
 const tailscale = computed(
@@ -168,7 +177,12 @@ async function copyEndpoint() {
 async function copyConfig() {
   if (!endpoint.value) return;
   let token = "<your bearer token>";
-  if (secretConfigured("UNRAID_MCP_BEARER_TOKEN")) {
+  // Prefer an unsaved edit so the copied config matches what's in the field,
+  // not the last-persisted value.
+  const edit = secretEdits.UNRAID_MCP_BEARER_TOKEN;
+  if (edit?.value && !edit.clear) {
+    token = edit.value;
+  } else if (!edit?.clear && secretConfigured("UNRAID_MCP_BEARER_TOKEN")) {
     try {
       token = await revealSecret("UNRAID_MCP_BEARER_TOKEN");
     } catch {
@@ -288,6 +302,11 @@ async function pollStats() {
     if (s.process && s.service.running) {
       cpuHist.value = [...cpuHist.value, s.process.cpu].slice(-40);
       memHist.value = [...memHist.value, s.process.memMB].slice(-40);
+    } else if (!s.service.running) {
+      // Drop history on stop so a later restart doesn't draw a line bridging
+      // the gap as if it were a continuous trend.
+      cpuHist.value = [];
+      memHist.value = [];
     }
     statFails = 0;
     statsStale.value = false;

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, reactive, ref } from "vue";
 import { Badge, Button, HelpText, Input, Label, Select, Switch } from "./components/ui";
-import { SECTIONS, type FieldDef } from "./fields";
+import { SECTIONS, type FieldDef, type Section } from "./fields";
 import LogView from "./LogView.vue";
 import {
   checkUpdate,
@@ -37,6 +37,12 @@ const statsStale = ref(false);
 const latestVersion = ref("");
 const checkingUpdate = ref(false);
 const updating = ref(false);
+const copiedConfig = ref(false);
+const initialSnapshot = ref(""); // form state at last load, for dirty detection
+const cpuHist = ref<number[]>([]); // rolling samples for sparklines
+const memHist = ref<number[]>([]);
+const gateOpen = reactive<Record<string, boolean>>({}); // opted-in gated sections
+const TABS: Tab[] = ["dashboard", "logs", "settings"];
 
 const secretKeys = SECTIONS.flatMap((s) => s.fields)
   .filter((f) => f.kind === "secret")
@@ -60,11 +66,57 @@ function hydrate(p: ConfigPayload) {
       }
     }
   }
+  initialSnapshot.value = JSON.stringify(form);
 }
 
 function secretConfigured(key: string): boolean {
   return Boolean(payload.value?.config[`${key}_configured`]);
 }
+
+// ── Dirty tracking + validation ───────────────────────────────────────────
+const dirty = computed(() => {
+  if (JSON.stringify(form) !== initialSnapshot.value) return true;
+  return secretKeys.some((k) => {
+    const e = secretEdits[k];
+    return Boolean(e && (e.clear || (e.value !== "" && e.value !== e.original)));
+  });
+});
+
+const URL_KEYS = new Set(["UNRAID_API_URL", "UNRAID_MCP_GOOGLE_BASE_URL"]);
+function fieldError(key: string): string {
+  const v = form[key] ?? "";
+  if (v === "") return "";
+  if (key === "UNRAID_MCP_PORT") {
+    const n = Number(v);
+    if (!Number.isInteger(n) || n < 1 || n > 65535) return "Port must be 1–65535";
+  }
+  if (URL_KEYS.has(key) && !/^https?:\/\/.+/i.test(v)) return "Must start with http:// or https://";
+  return "";
+}
+const hasErrors = computed(() =>
+  SECTIONS.some((s) => s.fields.some((f) => fieldError(f.key) !== "")),
+);
+
+// ── Google OAuth gate: keep the section compact until opted in ─────────────
+const oauthConfigured = computed(
+  () => Boolean(form.UNRAID_MCP_GOOGLE_CLIENT_ID) || secretConfigured("UNRAID_MCP_GOOGLE_CLIENT_SECRET"),
+);
+function sectionShowsFields(section: Section): boolean {
+  if (!section.gated) return true;
+  return Boolean(gateOpen[section.title]) || oauthConfigured.value;
+}
+
+// ── Sparklines: normalise a rolling series to a 100×24 polyline ────────────
+function sparkPoints(hist: number[]): string {
+  if (hist.length < 2) return "";
+  const max = Math.max(...hist, 1);
+  const n = hist.length;
+  return hist.map((v, i) => `${(i / (n - 1)) * 100},${23 - (v / max) * 21}`).join(" ");
+}
+
+const apiKeyMissing = computed(
+  () => Boolean(payload.value) && !secretConfigured("UNRAID_API_KEY"),
+);
 
 const service = computed(() => payload.value?.service ?? { enabled: false, running: false });
 const tailscale = computed(
@@ -107,6 +159,31 @@ async function copyEndpoint() {
     await navigator.clipboard.writeText(endpoint.value);
     copied.value = true;
     setTimeout(() => (copied.value = false), 1500);
+  } catch {
+    /* clipboard unavailable over plain http */
+  }
+}
+
+/** Copy a ready-to-paste MCP client config (mcpServers block) with the token. */
+async function copyConfig() {
+  if (!endpoint.value) return;
+  let token = "<your bearer token>";
+  if (secretConfigured("UNRAID_MCP_BEARER_TOKEN")) {
+    try {
+      token = await revealSecret("UNRAID_MCP_BEARER_TOKEN");
+    } catch {
+      /* fall back to the placeholder */
+    }
+  }
+  const cfg = {
+    mcpServers: {
+      unraid: { url: endpoint.value, headers: { Authorization: `Bearer ${token}` } },
+    },
+  };
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(cfg, null, 2));
+    copiedConfig.value = true;
+    setTimeout(() => (copiedConfig.value = false), 1800);
   } catch {
     /* clipboard unavailable over plain http */
   }
@@ -208,6 +285,10 @@ async function pollStats() {
       payload.value.service = s.service;
       if (s.process) payload.value.process = s.process;
     }
+    if (s.process && s.service.running) {
+      cpuHist.value = [...cpuHist.value, s.process.cpu].slice(-40);
+      memHist.value = [...memHist.value, s.process.memMB].slice(-40);
+    }
     statFails = 0;
     statsStale.value = false;
   } catch {
@@ -227,8 +308,24 @@ function setStatsPolling(on: boolean) {
 }
 
 function switchTab(t: Tab) {
+  // Guard against silently discarding edits (Apply restarts the service).
+  if (tab.value === "settings" && t !== "settings" && dirty.value && payload.value) {
+    if (!window.confirm("Discard unsaved settings changes?")) return;
+    hydrate(payload.value); // revert form to last-loaded config
+  }
   tab.value = t;
   setStatsPolling(t === "dashboard");
+}
+
+function onTabKey(e: KeyboardEvent, current: Tab) {
+  const i = TABS.indexOf(current);
+  if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+    e.preventDefault();
+    switchTab(TABS[(i + 1) % TABS.length]);
+  } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+    e.preventDefault();
+    switchTab(TABS[(i + TABS.length - 1) % TABS.length]);
+  }
 }
 
 onMounted(async () => {
@@ -245,16 +342,22 @@ onBeforeUnmount(() => {
 <template>
   <div class="unapi @container w-full text-foreground flex flex-col gap-3 pb-4">
     <!-- Tab bar -->
-    <div class="flex items-center gap-1 border-b border-border">
+    <div role="tablist" aria-label="Unraid MCP sections" class="flex items-center gap-1 border-b border-border">
       <button
-        v-for="t in (['dashboard', 'logs', 'settings'] as Tab[])"
+        v-for="t in TABS"
+        :id="`tab-${t}`"
         :key="t"
         type="button"
-        class="px-4 py-2 text-sm font-medium capitalize border-b-2 -mb-px transition-colors"
+        role="tab"
+        :aria-selected="tab === t"
+        :tabindex="tab === t ? 0 : -1"
+        class="px-4 py-2 text-sm font-medium capitalize border-b-2 -mb-px transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-t-sm flex items-center gap-1.5"
         :class="tab === t ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
         @click="switchTab(t)"
+        @keydown="onTabKey($event, t)"
       >
         {{ t }}
+        <span v-if="t === 'settings' && dirty" class="h-1.5 w-1.5 rounded-full bg-primary" title="Unsaved changes"></span>
       </button>
     </div>
 
@@ -282,24 +385,35 @@ onBeforeUnmount(() => {
               <span class="text-xs uppercase tracking-wide shrink-0" :class="copied ? 'text-unraid-green-500' : 'text-primary'">{{ copied ? "copied" : "copy" }}</span>
             </button>
             <span v-else class="text-sm text-muted-foreground">stdio transport — no network endpoint</span>
+            <div v-if="endpoint" class="flex items-center gap-2">
+              <Button size="sm" variant="outline" @click="copyConfig">
+                {{ copiedConfig ? "Config copied" : "Copy MCP client config" }}
+              </Button>
+              <span class="text-xs text-muted-foreground">mcpServers block with your bearer token, ready to paste</span>
+            </div>
             <p class="text-xs text-muted-foreground">
-              Transport <span class="font-mono text-foreground">{{ form.UNRAID_MCP_TRANSPORT }}</span> ·
-              authenticate with the bearer token from Settings
+              Transport <span class="font-mono text-foreground">{{ form.UNRAID_MCP_TRANSPORT }}</span>
             </p>
           </section>
 
           <section class="rounded-lg border border-border bg-card p-4 flex flex-col gap-3">
             <h3 class="text-base font-semibold">Resources</h3>
             <div class="grid grid-cols-3 gap-2">
-              <div class="rounded-md bg-background border border-border p-2 text-center">
+              <div class="rounded-md bg-background border border-border p-2 text-center flex flex-col gap-1">
                 <div class="text-lg font-semibold tabular-nums">{{ service.running ? proc.cpu.toFixed(1) + "%" : "—" }}</div>
+                <svg v-if="cpuHist.length > 1" viewBox="0 0 100 24" preserveAspectRatio="none" class="h-5 w-full">
+                  <polyline :points="sparkPoints(cpuHist)" fill="none" stroke="#29b6f6" stroke-width="1.5" vector-effect="non-scaling-stroke" />
+                </svg>
                 <div class="text-xs text-muted-foreground">CPU</div>
               </div>
-              <div class="rounded-md bg-background border border-border p-2 text-center">
+              <div class="rounded-md bg-background border border-border p-2 text-center flex flex-col gap-1">
                 <div class="text-lg font-semibold tabular-nums">{{ service.running ? proc.memMB.toFixed(0) + " MB" : "—" }}</div>
+                <svg v-if="memHist.length > 1" viewBox="0 0 100 24" preserveAspectRatio="none" class="h-5 w-full">
+                  <polyline :points="sparkPoints(memHist)" fill="none" stroke="#a78bfa" stroke-width="1.5" vector-effect="non-scaling-stroke" />
+                </svg>
                 <div class="text-xs text-muted-foreground">Memory</div>
               </div>
-              <div class="rounded-md bg-background border border-border p-2 text-center">
+              <div class="rounded-md bg-background border border-border p-2 text-center flex flex-col justify-center">
                 <div class="text-lg font-semibold tabular-nums">{{ uptimeText }}</div>
                 <div class="text-xs text-muted-foreground">Uptime</div>
               </div>
@@ -362,9 +476,22 @@ onBeforeUnmount(() => {
 
     <!-- ── SETTINGS ──────────────────────────────────────────────── -->
     <template v-else>
+      <div
+        v-if="apiKeyMissing"
+        class="rounded-md border border-primary/40 bg-primary/10 px-3 py-2 text-sm"
+      >
+        No Unraid API key is set — the server can't reach the Unraid API. Auto-provisioning may have
+        failed at install; generate one with
+        <span class="font-mono">unraid-api apikey --create --name unraidmcp -r admin --json</span>
+        and paste it below.
+      </div>
+
       <div class="flex items-center justify-end gap-3">
         <span v-if="savedFlash" class="text-sm text-unraid-green-500">Saved — restarted</span>
-        <Button size="sm" :disabled="saving" @click="apply">{{ saving ? "Applying…" : "Apply" }}</Button>
+        <span v-else-if="dirty" class="text-sm text-muted-foreground">Unsaved changes</span>
+        <Button size="sm" :disabled="saving || !dirty || hasErrors" @click="apply">
+          {{ saving ? "Applying…" : "Apply" }}
+        </Button>
       </div>
 
       <!-- Three independent columns so each stacks freely (no row-alignment
@@ -387,7 +514,17 @@ onBeforeUnmount(() => {
               {{ section.title }}
             </h3>
 
-            <div class="grid grid-cols-[9.5rem_minmax(0,1fr)] items-center gap-x-3 gap-y-2" :class="section.collapsed ? 'mt-2' : ''">
+            <!-- Gated section (Google OAuth): compact until enabled. -->
+            <div v-if="!sectionShowsFields(section)" class="flex items-center gap-2 mt-1">
+              <Switch :model-value="false" @update:model-value="gateOpen[section.title] = $event" />
+              <span class="text-sm text-muted-foreground">Enable — optional, for claude.ai web connector</span>
+            </div>
+
+            <div
+              v-if="sectionShowsFields(section)"
+              class="grid grid-cols-[9.5rem_minmax(0,1fr)] items-center gap-x-3 gap-y-2"
+              :class="section.collapsed ? 'mt-2' : ''"
+            >
               <template v-for="field in section.fields" :key="field.key">
                 <Label :for="field.key" class="text-sm self-center leading-tight">{{ field.label }}</Label>
 
@@ -439,6 +576,7 @@ onBeforeUnmount(() => {
                 />
 
                 <div class="col-span-2">
+                  <p v-if="fieldError(field.key)" class="text-xs text-destructive mb-0.5">{{ fieldError(field.key) }}</p>
                   <HelpText>{{ field.help }}</HelpText>
                 </div>
               </template>

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -16,7 +16,7 @@ import {
   type ServiceOp,
 } from "./lib/config-client";
 
-type Tab = "dashboard" | "logs" | "settings";
+type Tab = "dashboard" | "settings";
 const tab = ref<Tab>("dashboard");
 
 const payload = ref<ConfigPayload | null>(null);
@@ -42,7 +42,7 @@ const initialSnapshot = ref(""); // form state at last load, for dirty detection
 const cpuHist = ref<number[]>([]); // rolling samples for sparklines
 const memHist = ref<number[]>([]);
 const gateOpen = reactive<Record<string, boolean>>({}); // opted-in gated sections
-const TABS: Tab[] = ["dashboard", "logs", "settings"];
+const TABS: Tab[] = ["dashboard", "settings"];
 
 const secretKeys = SECTIONS.flatMap((s) => s.fields)
   .filter((f) => f.kind === "secret")
@@ -367,11 +367,34 @@ onBeforeUnmount(() => {
 
     <div v-if="loading" class="text-sm text-muted-foreground">Loading…</div>
 
-    <!-- ── DASHBOARD ─────────────────────────────────────────────── -->
+    <!-- ── DASHBOARD (status cards + live log, one viewport) ─────── -->
     <template v-else-if="tab === 'dashboard'">
-      <div class="grid gap-3 @min-[880px]:grid-cols-2 items-start">
-        <!-- LEFT: Connection, then Resources -->
-        <div class="flex flex-col gap-3">
+      <div
+        class="flex flex-col @min-[900px]:flex-row gap-3"
+        style="height: calc(100vh - 150px); min-height: 420px"
+      >
+        <!-- LEFT: status cards (scroll internally if short viewport) -->
+        <div class="flex flex-col gap-3 overflow-auto @min-[900px]:w-[430px] @min-[900px]:shrink-0">
+          <section class="rounded-lg border border-border bg-card p-4 flex flex-col gap-3">
+            <div class="flex items-center gap-2">
+              <h3 class="text-base font-semibold">Server</h3>
+              <Badge :variant="service.running ? 'green' : 'gray'" size="sm">
+                {{ service.running ? "Running" : "Stopped" }}
+              </Badge>
+              <Badge v-if="boolVal('UNRAID_MCP_TAILSCALE_SERVE') && tailscale.available" variant="orange" size="sm">tailnet</Badge>
+            </div>
+            <div class="flex items-center gap-2">
+              <Button size="sm" variant="outline" :disabled="busy" @click="svc(service.running ? 'stop' : 'start')">
+                {{ service.running ? "Stop" : "Start" }}
+              </Button>
+              <Button size="sm" variant="outline" :disabled="busy || !service.running" @click="svc('restart')">Restart</Button>
+              <div class="ms-auto flex items-center gap-1.5" :title="service.enabled ? 'Starts with the array' : 'Does not start with the array'">
+                <Switch :model-value="service.enabled" :disabled="busy" @update:model-value="svc($event ? 'enable' : 'disable')" />
+                <span class="text-sm text-muted-foreground">Autostart</span>
+              </div>
+            </div>
+          </section>
+
           <section class="rounded-lg border border-border bg-card p-4 flex flex-col gap-2">
             <h3 class="text-base font-semibold">Connection</h3>
             <button
@@ -423,29 +446,6 @@ onBeforeUnmount(() => {
               <span :style="statsStale ? 'color:#c6a36b' : ''">{{ statsStale ? "stale — can't reach server" : "updates live" }}</span>
             </p>
           </section>
-        </div>
-
-        <!-- RIGHT: Server, then Version -->
-        <div class="flex flex-col gap-3">
-          <section class="rounded-lg border border-border bg-card p-4 flex flex-col gap-3">
-            <div class="flex items-center gap-2">
-              <h3 class="text-base font-semibold">Server</h3>
-              <Badge :variant="service.running ? 'green' : 'gray'" size="sm">
-                {{ service.running ? "Running" : "Stopped" }}
-              </Badge>
-              <Badge v-if="boolVal('UNRAID_MCP_TAILSCALE_SERVE') && tailscale.available" variant="orange" size="sm">tailnet</Badge>
-            </div>
-            <div class="flex items-center gap-2">
-              <Button size="sm" variant="outline" :disabled="busy" @click="svc(service.running ? 'stop' : 'start')">
-                {{ service.running ? "Stop" : "Start" }}
-              </Button>
-              <Button size="sm" variant="outline" :disabled="busy || !service.running" @click="svc('restart')">Restart</Button>
-              <div class="ms-auto flex items-center gap-1.5" :title="service.enabled ? 'Starts with the array' : 'Does not start with the array'">
-                <Switch :model-value="service.enabled" :disabled="busy" @update:model-value="svc($event ? 'enable' : 'disable')" />
-                <span class="text-sm text-muted-foreground">Autostart</span>
-              </div>
-            </div>
-          </section>
 
           <section class="rounded-lg border border-border bg-card p-4 flex flex-col gap-2">
             <div class="flex items-center gap-2">
@@ -468,11 +468,11 @@ onBeforeUnmount(() => {
             </div>
           </section>
         </div>
+
+        <!-- RIGHT: live log fills the remaining width + full height -->
+        <LogView class="flex-1 min-w-0 min-h-0" />
       </div>
     </template>
-
-    <!-- ── LOGS ──────────────────────────────────────────────────── -->
-    <LogView v-else-if="tab === 'logs'" />
 
     <!-- ── SETTINGS ──────────────────────────────────────────────── -->
     <template v-else>

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -2,9 +2,9 @@
 import { computed, onBeforeUnmount, onMounted, reactive, ref } from "vue";
 import { Badge, Button, HelpText, Input, Label, Select, Switch } from "./components/ui";
 import { SECTIONS, type FieldDef } from "./fields";
+import LogView from "./LogView.vue";
 import {
   checkUpdate,
-  fetchLogs,
   fetchStats,
   loadConfig,
   resetServer,
@@ -16,7 +16,7 @@ import {
   type ServiceOp,
 } from "./lib/config-client";
 
-type Tab = "dashboard" | "settings";
+type Tab = "dashboard" | "logs" | "settings";
 const tab = ref<Tab>("dashboard");
 
 const payload = ref<ConfigPayload | null>(null);
@@ -30,9 +30,6 @@ const busy = ref(false);
 const error = ref("");
 const savedFlash = ref(false);
 const copied = ref(false);
-const logText = ref("");
-const logAuto = ref(false);
-let logTimer: ReturnType<typeof setInterval> | null = null;
 let statsTimer: ReturnType<typeof setInterval> | null = null;
 const latestVersion = ref("");
 const checkingUpdate = ref(false);
@@ -198,25 +195,6 @@ async function doReset() {
   updating.value = false;
 }
 
-async function refreshLogs() {
-  try {
-    logText.value = (await fetchLogs(300)) || "(log is empty)";
-  } catch (e) {
-    logText.value = `failed to fetch log: ${e instanceof Error ? e.message : e}`;
-  }
-}
-function setLogAuto(on: boolean) {
-  logAuto.value = on;
-  if (logTimer) {
-    clearInterval(logTimer);
-    logTimer = null;
-  }
-  if (on) {
-    void refreshLogs();
-    logTimer = setInterval(() => void refreshLogs(), 3000);
-  }
-}
-
 /** Poll cheap process stats while the dashboard is visible. */
 async function pollStats() {
   try {
@@ -240,18 +218,15 @@ function setStatsPolling(on: boolean) {
 function switchTab(t: Tab) {
   tab.value = t;
   setStatsPolling(t === "dashboard");
-  if (t !== "dashboard") setLogAuto(false);
 }
 
 onMounted(async () => {
   await run(() => loadConfig());
   loading.value = false;
-  void refreshLogs();
   void doCheckUpdate();
   setStatsPolling(true);
 });
 onBeforeUnmount(() => {
-  setLogAuto(false);
   setStatsPolling(false);
 });
 </script>
@@ -261,7 +236,7 @@ onBeforeUnmount(() => {
     <!-- Tab bar -->
     <div class="flex items-center gap-1 border-b border-border">
       <button
-        v-for="t in (['dashboard', 'settings'] as Tab[])"
+        v-for="t in (['dashboard', 'logs', 'settings'] as Tab[])"
         :key="t"
         type="button"
         class="px-4 py-2 text-sm font-medium capitalize border-b-2 -mb-px transition-colors"
@@ -366,24 +341,10 @@ onBeforeUnmount(() => {
           </section>
         </div>
       </div>
-
-      <!-- Log viewer (full width) -->
-      <section class="rounded-lg border border-border bg-card p-3 flex flex-col gap-2">
-        <div class="flex items-center justify-between">
-          <h3 class="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground">
-            Server log <span class="normal-case tracking-normal font-normal">/var/log/unraid-mcp/server.log</span>
-          </h3>
-          <div class="flex items-center gap-2">
-            <div class="flex items-center gap-1.5">
-              <Switch :model-value="logAuto" @update:model-value="setLogAuto($event)" />
-              <span class="text-xs text-muted-foreground">Follow</span>
-            </div>
-            <Button size="sm" variant="ghost" class="px-2" @click="refreshLogs">Refresh</Button>
-          </div>
-        </div>
-        <pre class="max-h-80 overflow-auto rounded-md bg-background border border-border p-2 font-mono text-xs leading-relaxed whitespace-pre-wrap">{{ logText }}</pre>
-      </section>
     </template>
+
+    <!-- ── LOGS ──────────────────────────────────────────────────── -->
+    <LogView v-else-if="tab === 'logs'" />
 
     <!-- ── SETTINGS ──────────────────────────────────────────────── -->
     <template v-else>

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -243,7 +243,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="unapi @container w-full max-w-[1400px] text-foreground flex flex-col gap-3 pb-4">
+  <div class="unapi @container w-full text-foreground flex flex-col gap-3 pb-4">
     <!-- Tab bar -->
     <div class="flex items-center gap-1 border-b border-border">
       <button

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -31,6 +31,9 @@ const error = ref("");
 const savedFlash = ref(false);
 const copied = ref(false);
 let statsTimer: ReturnType<typeof setInterval> | null = null;
+let statsBusy = false;
+let statFails = 0;
+const statsStale = ref(false);
 const latestVersion = ref("");
 const checkingUpdate = ref(false);
 const updating = ref(false);
@@ -197,14 +200,22 @@ async function doReset() {
 
 /** Poll cheap process stats while the dashboard is visible. */
 async function pollStats() {
+  if (statsBusy) return; // drop overlapping ticks
+  statsBusy = true;
   try {
     const s = await fetchStats();
     if (payload.value) {
       payload.value.service = s.service;
-      payload.value.process = s.process;
+      if (s.process) payload.value.process = s.process;
     }
+    statFails = 0;
+    statsStale.value = false;
   } catch {
-    /* transient; next tick retries */
+    // A single miss is a blip; after a few, mark the tiles stale so they stop
+    // asserting live values the poll can no longer verify.
+    if (++statFails >= 3) statsStale.value = true;
+  } finally {
+    statsBusy = false;
   }
 }
 function setStatsPolling(on: boolean) {
@@ -293,7 +304,10 @@ onBeforeUnmount(() => {
                 <div class="text-xs text-muted-foreground">Uptime</div>
               </div>
             </div>
-            <p class="text-xs text-muted-foreground">PID {{ proc.pid || "—" }} · updates live</p>
+            <p class="text-xs text-muted-foreground">
+              PID {{ proc.pid || "—" }} ·
+              <span :style="statsStale ? 'color:#c6a36b' : ''">{{ statsStale ? "stale — can't reach server" : "updates live" }}</span>
+            </p>
           </section>
         </div>
 

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -367,10 +367,10 @@ onBeforeUnmount(() => {
         <Button size="sm" :disabled="saving" @click="apply">{{ saving ? "Applying…" : "Apply" }}</Button>
       </div>
 
-      <!-- Explicit left/right columns so each stacks independently (no
-           row-alignment gaps); Google OAuth lives in the right column. -->
-      <div class="grid gap-3 @min-[880px]:grid-cols-2 items-start">
-        <div v-for="col in (['left', 'right'] as const)" :key="col" class="flex flex-col gap-3 min-w-0">
+      <!-- Three independent columns so each stacks freely (no row-alignment
+           gaps); Google OAuth lives in the third column. -->
+      <div class="grid gap-3 @min-[700px]:grid-cols-2 @min-[1100px]:grid-cols-3 items-start">
+        <div v-for="col in (['a', 'b', 'c'] as const)" :key="col" class="flex flex-col gap-3 min-w-0">
           <component
             :is="section.collapsed ? 'details' : 'section'"
             v-for="section in SECTIONS.filter((s) => s.col === col)"

--- a/unraid-plugin/web/src/App.vue
+++ b/unraid-plugin/web/src/App.vue
@@ -367,80 +367,84 @@ onBeforeUnmount(() => {
         <Button size="sm" :disabled="saving" @click="apply">{{ saving ? "Applying…" : "Apply" }}</Button>
       </div>
 
+      <!-- Explicit left/right columns so each stacks independently (no
+           row-alignment gaps); Google OAuth lives in the right column. -->
       <div class="grid gap-3 @min-[880px]:grid-cols-2 items-start">
-        <component
-          :is="section.collapsed ? 'details' : 'section'"
-          v-for="section in SECTIONS"
-          :key="section.title"
-          class="rounded-lg border border-border bg-card p-3 flex flex-col gap-2 min-w-0"
-        >
-          <summary
-            v-if="section.collapsed"
-            class="cursor-pointer select-none text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground marker:text-primary"
+        <div v-for="col in (['left', 'right'] as const)" :key="col" class="flex flex-col gap-3 min-w-0">
+          <component
+            :is="section.collapsed ? 'details' : 'section'"
+            v-for="section in SECTIONS.filter((s) => s.col === col)"
+            :key="section.title"
+            class="rounded-lg border border-border bg-card p-3 flex flex-col gap-2 min-w-0"
           >
-            {{ section.title }}
-          </summary>
-          <h3 v-else class="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground">
-            {{ section.title }}
-          </h3>
+            <summary
+              v-if="section.collapsed"
+              class="cursor-pointer select-none text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground marker:text-primary"
+            >
+              {{ section.title }}
+            </summary>
+            <h3 v-else class="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground">
+              {{ section.title }}
+            </h3>
 
-          <div class="grid grid-cols-[9.5rem_minmax(0,1fr)] items-center gap-x-3 gap-y-2" :class="section.collapsed ? 'mt-2' : ''">
-            <template v-for="field in section.fields" :key="field.key">
-              <Label :for="field.key" class="text-sm self-center leading-tight">{{ field.label }}</Label>
+            <div class="grid grid-cols-[9.5rem_minmax(0,1fr)] items-center gap-x-3 gap-y-2" :class="section.collapsed ? 'mt-2' : ''">
+              <template v-for="field in section.fields" :key="field.key">
+                <Label :for="field.key" class="text-sm self-center leading-tight">{{ field.label }}</Label>
 
-              <div v-if="field.kind === 'secret'" class="flex items-center gap-1.5 min-w-0">
+                <div v-if="field.kind === 'secret'" class="flex items-center gap-1.5 min-w-0">
+                  <Input
+                    :id="field.key"
+                    v-model="secretEdits[field.key].value"
+                    :type="secretEdits[field.key].show ? 'text' : 'password'"
+                    class="h-8 font-mono text-sm flex-1 min-w-0"
+                    :placeholder="secretConfigured(field.key) ? '•••••• configured' : 'not set'"
+                    :disabled="secretEdits[field.key].clear"
+                    autocomplete="new-password"
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-bwignore="true"
+                    data-form-type="other"
+                  />
+                  <Button size="sm" variant="ghost" class="px-2" @click="toggleSecret(field.key)">
+                    {{ secretEdits[field.key].show ? "Hide" : "Show" }}
+                  </Button>
+                  <Button
+                    v-if="secretConfigured(field.key)"
+                    size="sm"
+                    :variant="secretEdits[field.key].clear ? 'destructive' : 'ghost'"
+                    class="px-2"
+                    @click="secretEdits[field.key].clear = !secretEdits[field.key].clear"
+                  >
+                    {{ secretEdits[field.key].clear ? "Will clear" : "Clear" }}
+                  </Button>
+                </div>
+
+                <div v-else-if="field.kind === 'toggle'" class="flex items-center gap-2">
+                  <Switch :id="field.key" :model-value="boolVal(field.key)" :disabled="fieldDisabled(field)" @update:model-value="setBool(field.key, $event)" />
+                  <span v-if="fieldDisabled(field)" class="text-xs text-muted-foreground">Tailscale plugin not detected</span>
+                </div>
+
+                <Select v-else-if="field.kind === 'select'" :id="field.key" v-model="form[field.key]" class="[&>select]:h-8 [&>select]:py-1">
+                  <option v-for="opt in field.options" :key="opt" :value="opt">{{ opt }}</option>
+                </Select>
+
                 <Input
+                  v-else
                   :id="field.key"
-                  v-model="secretEdits[field.key].value"
-                  :type="secretEdits[field.key].show ? 'text' : 'password'"
-                  class="h-8 font-mono text-sm flex-1 min-w-0"
-                  :placeholder="secretConfigured(field.key) ? '•••••• configured' : 'not set'"
-                  :disabled="secretEdits[field.key].clear"
-                  autocomplete="new-password"
-                  data-1p-ignore
-                  data-lpignore="true"
-                  data-bwignore="true"
-                  data-form-type="other"
+                  v-model="form[field.key]"
+                  :type="field.kind === 'number' ? 'number' : 'text'"
+                  class="h-8 text-sm"
+                  :class="field.mono ? 'font-mono' : ''"
+                  :placeholder="field.placeholder ?? ''"
                 />
-                <Button size="sm" variant="ghost" class="px-2" @click="toggleSecret(field.key)">
-                  {{ secretEdits[field.key].show ? "Hide" : "Show" }}
-                </Button>
-                <Button
-                  v-if="secretConfigured(field.key)"
-                  size="sm"
-                  :variant="secretEdits[field.key].clear ? 'destructive' : 'ghost'"
-                  class="px-2"
-                  @click="secretEdits[field.key].clear = !secretEdits[field.key].clear"
-                >
-                  {{ secretEdits[field.key].clear ? "Will clear" : "Clear" }}
-                </Button>
-              </div>
 
-              <div v-else-if="field.kind === 'toggle'" class="flex items-center gap-2">
-                <Switch :id="field.key" :model-value="boolVal(field.key)" :disabled="fieldDisabled(field)" @update:model-value="setBool(field.key, $event)" />
-                <span v-if="fieldDisabled(field)" class="text-xs text-muted-foreground">Tailscale plugin not detected</span>
-              </div>
-
-              <Select v-else-if="field.kind === 'select'" :id="field.key" v-model="form[field.key]" class="[&>select]:h-8 [&>select]:py-1">
-                <option v-for="opt in field.options" :key="opt" :value="opt">{{ opt }}</option>
-              </Select>
-
-              <Input
-                v-else
-                :id="field.key"
-                v-model="form[field.key]"
-                :type="field.kind === 'number' ? 'number' : 'text'"
-                class="h-8 text-sm"
-                :class="field.mono ? 'font-mono' : ''"
-                :placeholder="field.placeholder ?? ''"
-              />
-
-              <div class="col-span-2">
-                <HelpText>{{ field.help }}</HelpText>
-              </div>
-            </template>
-          </div>
-        </component>
+                <div class="col-span-2">
+                  <HelpText>{{ field.help }}</HelpText>
+                </div>
+              </template>
+            </div>
+          </component>
+        </div>
       </div>
 
       <p v-if="payload && Object.keys(payload.extra).length" class="text-xs text-muted-foreground px-1">

--- a/unraid-plugin/web/src/LogView.vue
+++ b/unraid-plugin/web/src/LogView.vue
@@ -128,7 +128,12 @@ const lines = computed(() => {
     .map((l) => ({ rail: lineLevel(l), segs: tokenize(l) }));
 });
 
-const totalLines = computed(() => raw.value.replace(/\n+$/, "").split("\n").filter(Boolean).length);
+// Count the same population `lines` splits from (no Boolean filter), so the
+// filtered "showing N of M" can never report N > M.
+const totalLines = computed(() => {
+  const text = raw.value.replace(/\n+$/, "");
+  return text ? text.split("\n").length : 0;
+});
 
 async function refresh(scroll = true) {
   // Drop overlapping ticks: only one request is ever in flight, which also

--- a/unraid-plugin/web/src/LogView.vue
+++ b/unraid-plugin/web/src/LogView.vue
@@ -174,7 +174,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-2 rounded-lg border p-3" style="background: #07131c; border-color: #1d3d4e; height: calc(100vh - 190px); min-height: 320px">
+  <div class="flex flex-col gap-2 rounded-lg border p-3 h-full" style="background: #07131c; border-color: #1d3d4e; min-height: 320px">
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-2">
         <span class="text-[11px] font-semibold tracking-[0.08em] uppercase" style="color: #a7bcc9">Server log</span>

--- a/unraid-plugin/web/src/LogView.vue
+++ b/unraid-plugin/web/src/LogView.vue
@@ -12,7 +12,7 @@ import { fetchLogs } from "./lib/config-client";
 
 const raw = ref("");
 const logError = ref("");
-const auto = ref(false);
+const auto = ref(true); // Follow on by default
 const loading = ref(false);
 const lineCount = ref(300);
 const pane = ref<HTMLElement | null>(null);
@@ -136,14 +136,14 @@ function setAuto(on: boolean) {
   }
 }
 
-onMounted(() => void refresh());
+onMounted(() => setAuto(true)); // start following immediately
 onBeforeUnmount(() => {
   if (timer) clearInterval(timer);
 });
 </script>
 
 <template>
-  <div class="flex flex-col gap-2 rounded-lg border p-3" style="background: #07131c; border-color: #1d3d4e">
+  <div class="flex flex-col gap-2 rounded-lg border p-3" style="background: #07131c; border-color: #1d3d4e; height: calc(100vh - 190px); min-height: 320px">
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-2">
         <span class="text-[11px] font-semibold tracking-[0.08em] uppercase" style="color: #a7bcc9">Server log</span>
@@ -184,8 +184,8 @@ onBeforeUnmount(() => {
 
     <div
       ref="pane"
-      class="overflow-auto rounded-md font-mono text-xs leading-relaxed"
-      style="background: #07111a; border: 1px solid #142a37; height: min(70vh, 640px)"
+      class="flex-1 min-h-0 overflow-auto rounded-md font-mono text-xs leading-relaxed"
+      style="background: #07111a; border: 1px solid #142a37"
     >
       <div
         v-for="(ln, i) in lines"

--- a/unraid-plugin/web/src/LogView.vue
+++ b/unraid-plugin/web/src/LogView.vue
@@ -11,14 +11,14 @@ import { Button, Switch } from "./components/ui";
 import { fetchLogs } from "./lib/config-client";
 
 const raw = ref("");
+const logError = ref("");
 const auto = ref(false);
 const loading = ref(false);
 const lineCount = ref(300);
+const pane = ref<HTMLElement | null>(null);
 let timer: ReturnType<typeof setInterval> | null = null;
-let pane: HTMLElement | null = null;
-const paneRef = (el: unknown) => {
-  pane = el as HTMLElement | null;
-};
+let fails = 0;
+const MAX_FOLLOW_FAILS = 5;
 
 // Aurora dark tokens (registry/aurora/styles/aurora.css) + CLI violet.
 const C = {
@@ -34,7 +34,8 @@ const C = {
   ok: "#7dd3c7",
 };
 
-const LEVEL_COLOR: Record<string, string> = {
+type Level = "DEBUG" | "INFO" | "NOTICE" | "WARNING" | "WARN" | "ERROR" | "CRITICAL" | "FATAL";
+const LEVEL_COLOR: Record<Level, string> = {
   DEBUG: C.debug,
   INFO: C.info,
   NOTICE: C.notice,
@@ -44,6 +45,7 @@ const LEVEL_COLOR: Record<string, string> = {
   CRITICAL: C.critical,
   FATAL: C.critical,
 };
+const BOLD: ReadonlySet<string> = new Set(["ERROR", "CRITICAL", "FATAL"]);
 
 interface Seg {
   t: string;
@@ -51,9 +53,12 @@ interface Seg {
   b?: boolean;
 }
 
-// One combined scanner; classify each match by which group hit.
+// One combined scanner with named groups; classify each match by which fired.
+// The http-status branch captures its `"<space>` prefix separately (emitted as
+// message text) instead of a lookbehind, so the pattern parses on older
+// engines too.
 const TOKEN_RE =
-  /(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?)|\b(DEBUG|INFO|NOTICE|WARNING|WARN|ERROR|CRITICAL|FATAL)\b|(?<=" )([1-5]\d{2})\b|\b((?:unraid_mcp|rc\.unraid-mcp|uvicorn|fastmcp)[\w.-]*)/g;
+  /(?<ts>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?)|\b(?<lvl>DEBUG|INFO|NOTICE|WARNING|WARN|ERROR|CRITICAL|FATAL)\b|(?<pre>"\s+)(?<status>[1-5]\d{2})\b|\b(?<mod>(?:unraid_mcp|rc\.unraid-mcp|uvicorn|fastmcp)[\w.-]*)/g;
 
 function tokenize(line: string): Seg[] {
   const segs: Seg[] = [];
@@ -61,18 +66,19 @@ function tokenize(line: string): Seg[] {
   let m: RegExpExecArray | null;
   TOKEN_RE.lastIndex = 0;
   while ((m = TOKEN_RE.exec(line)) !== null) {
+    const g = m.groups!;
     if (m.index > last) segs.push({ t: line.slice(last, m.index), c: C.msg });
-    if (m[1]) {
-      segs.push({ t: m[1], c: C.ts });
-    } else if (m[2]) {
-      const col = LEVEL_COLOR[m[2]] ?? C.msg;
-      segs.push({ t: m[2], c: col, b: col === C.error || col === C.critical });
-    } else if (m[3]) {
-      const code = Number(m[3]);
+    if (g.ts) {
+      segs.push({ t: g.ts, c: C.ts });
+    } else if (g.lvl) {
+      segs.push({ t: g.lvl, c: LEVEL_COLOR[g.lvl as Level], b: BOLD.has(g.lvl) });
+    } else if (g.status) {
+      segs.push({ t: g.pre, c: C.msg }); // the "<space> prefix, uncolored
+      const code = Number(g.status);
       const col = code < 300 ? C.ok : code < 400 ? C.info : code < 500 ? C.warn : C.error;
-      segs.push({ t: m[3], c: col, b: code >= 500 });
-    } else if (m[4]) {
-      segs.push({ t: m[4], c: C.module });
+      segs.push({ t: g.status, c: col, b: code >= 500 });
+    } else if (g.mod) {
+      segs.push({ t: g.mod, c: C.module });
     }
     last = m.index + m[0].length;
   }
@@ -84,7 +90,7 @@ function tokenize(line: string): Seg[] {
 /** Severity of a whole line, for the left accent rail. */
 function lineLevel(line: string): string {
   const m = line.match(/\b(DEBUG|INFO|NOTICE|WARNING|WARN|ERROR|CRITICAL|FATAL)\b/);
-  return m ? (LEVEL_COLOR[m[1]] ?? "transparent") : "transparent";
+  return m ? LEVEL_COLOR[m[1] as Level] : "transparent";
 }
 
 const lines = computed(() => {
@@ -94,14 +100,27 @@ const lines = computed(() => {
 });
 
 async function refresh(scroll = true) {
+  // Drop overlapping ticks: only one request is ever in flight, which also
+  // rules out an older response clobbering a newer one. The next Follow tick
+  // retries in 3s.
+  if (loading.value) return;
   loading.value = true;
   try {
     raw.value = (await fetchLogs(lineCount.value)) || "(log is empty)";
+    logError.value = "";
+    fails = 0;
   } catch (e) {
-    raw.value = `failed to fetch log: ${e instanceof Error ? e.message : e}`;
+    // Keep the last-good logs on screen; surface the failure as a banner.
+    logError.value = `failed to fetch log: ${e instanceof Error ? e.message : e}`;
+    // Stop hammering a dead endpoint (expired session / service down) forever.
+    if (auto.value && ++fails >= MAX_FOLLOW_FAILS) setAuto(false);
+  } finally {
+    loading.value = false;
   }
-  loading.value = false;
-  if (scroll && pane) requestAnimationFrame(() => (pane!.scrollTop = pane!.scrollHeight));
+  if (scroll && pane.value) {
+    const el = pane.value;
+    requestAnimationFrame(() => (el.scrollTop = el.scrollHeight));
+  }
 }
 
 function setAuto(on: boolean) {
@@ -111,6 +130,7 @@ function setAuto(on: boolean) {
     timer = null;
   }
   if (on) {
+    fails = 0;
     void refresh();
     timer = setInterval(() => void refresh(), 3000);
   }
@@ -154,7 +174,16 @@ onBeforeUnmount(() => {
     </div>
 
     <div
-      :ref="paneRef"
+      v-if="logError"
+      role="alert"
+      class="rounded-md px-2.5 py-1.5 text-xs"
+      style="background: #2a1720; border: 1px solid #6e3a46; color: #d9909a"
+    >
+      {{ logError }}
+    </div>
+
+    <div
+      ref="pane"
       class="overflow-auto rounded-md font-mono text-xs leading-relaxed"
       style="background: #07111a; border: 1px solid #142a37; height: min(70vh, 640px)"
     >

--- a/unraid-plugin/web/src/LogView.vue
+++ b/unraid-plugin/web/src/LogView.vue
@@ -15,6 +15,18 @@ const logError = ref("");
 const auto = ref(true); // Follow on by default
 const loading = ref(false);
 const lineCount = ref(300);
+const search = ref("");
+const minLevel = ref(""); // "" = all; else DEBUG|INFO|WARNING|ERROR
+const LEVEL_RANK: Record<string, number> = {
+  DEBUG: 10,
+  INFO: 20,
+  NOTICE: 20,
+  WARNING: 30,
+  WARN: 30,
+  ERROR: 40,
+  CRITICAL: 50,
+  FATAL: 50,
+};
 const pane = ref<HTMLElement | null>(null);
 let timer: ReturnType<typeof setInterval> | null = null;
 let fails = 0;
@@ -93,11 +105,30 @@ function lineLevel(line: string): string {
   return m ? LEVEL_COLOR[m[1] as Level] : "transparent";
 }
 
+/** Numeric severity of a line for the min-level filter (0 = none detected). */
+function lineRank(line: string): number {
+  const m = line.match(/\b(DEBUG|INFO|NOTICE|WARNING|WARN|ERROR|CRITICAL|FATAL)\b/);
+  return m ? (LEVEL_RANK[m[1]] ?? 0) : 0;
+}
+
 const lines = computed(() => {
   const text = raw.value.replace(/\n+$/, "");
   if (!text) return [];
-  return text.split("\n").map((l) => ({ rail: lineLevel(l), segs: tokenize(l) }));
+  const q = search.value.trim().toLowerCase();
+  const floor = minLevel.value ? LEVEL_RANK[minLevel.value] : 0;
+  return text
+    .split("\n")
+    .filter((l) => {
+      if (q && !l.toLowerCase().includes(q)) return false;
+      // Level filter keeps matching lines plus continuation lines (rank 0),
+      // so a wrapped multi-line record isn't chopped mid-entry.
+      if (floor && lineRank(l) !== 0 && lineRank(l) < floor) return false;
+      return true;
+    })
+    .map((l) => ({ rail: lineLevel(l), segs: tokenize(l) }));
 });
+
+const totalLines = computed(() => raw.value.replace(/\n+$/, "").split("\n").filter(Boolean).length);
 
 async function refresh(scroll = true) {
   // Drop overlapping ticks: only one request is ever in flight, which also
@@ -150,6 +181,24 @@ onBeforeUnmount(() => {
         <span class="font-mono text-xs" style="color: #7c93a1">/var/log/unraid-mcp/server.log</span>
       </div>
       <div class="flex items-center gap-3">
+        <input
+          v-model="search"
+          type="search"
+          placeholder="filter…"
+          class="h-7 w-40 rounded-md border bg-transparent px-2 text-xs"
+          style="border-color: #1d3d4e; color: #e6f4fb"
+        />
+        <select
+          v-model="minLevel"
+          class="h-7 rounded-md border bg-transparent px-1.5 text-xs"
+          style="border-color: #1d3d4e; color: #e6f4fb"
+          title="Minimum severity"
+        >
+          <option value="">all levels</option>
+          <option value="INFO">info+</option>
+          <option value="WARNING">warning+</option>
+          <option value="ERROR">error+</option>
+        </select>
         <label class="flex items-center gap-1.5 text-xs" style="color: #a7bcc9">
           lines
           <select
@@ -198,7 +247,13 @@ onBeforeUnmount(() => {
           <span v-for="(s, j) in ln.segs" :key="j" :style="{ color: s.c, fontWeight: s.b ? 600 : 400 }">{{ s.t }}</span>
         </code>
       </div>
-      <div v-if="lines.length === 0" class="px-2 py-1" style="color: #7c93a1">(log is empty)</div>
+      <div v-if="lines.length === 0" class="px-2 py-1" style="color: #7c93a1">
+        {{ totalLines === 0 ? "(log is empty)" : "no lines match the filter" }}
+      </div>
     </div>
+
+    <p v-if="search || minLevel" class="text-xs" style="color: #7c93a1">
+      showing {{ lines.length }} of {{ totalLines }} lines
+    </p>
   </div>
 </template>

--- a/unraid-plugin/web/src/LogView.vue
+++ b/unraid-plugin/web/src/LogView.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+/**
+ * Server log viewer — a self-contained Aurora-dark terminal panel. It owns its
+ * own palette (Aurora dark tokens, https://aurora.tootie.tv) and stays dark
+ * regardless of the surrounding Unraid webGUI theme, the way a terminal should.
+ * Lines are tokenized and colorized by severity, timestamp, HTTP status, and
+ * logger name.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { Button, Switch } from "./components/ui";
+import { fetchLogs } from "./lib/config-client";
+
+const raw = ref("");
+const auto = ref(false);
+const loading = ref(false);
+const lineCount = ref(300);
+let timer: ReturnType<typeof setInterval> | null = null;
+let pane: HTMLElement | null = null;
+const paneRef = (el: unknown) => {
+  pane = el as HTMLElement | null;
+};
+
+// Aurora dark tokens (registry/aurora/styles/aurora.css) + CLI violet.
+const C = {
+  ts: "#7c93a1",
+  msg: "#e6f4fb",
+  debug: "#6f8492",
+  info: "#72c8f5",
+  notice: "#67cbfa",
+  warn: "#c6a36b",
+  error: "#c78490",
+  critical: "#d9909a",
+  module: "#a78bfa",
+  ok: "#7dd3c7",
+};
+
+const LEVEL_COLOR: Record<string, string> = {
+  DEBUG: C.debug,
+  INFO: C.info,
+  NOTICE: C.notice,
+  WARNING: C.warn,
+  WARN: C.warn,
+  ERROR: C.error,
+  CRITICAL: C.critical,
+  FATAL: C.critical,
+};
+
+interface Seg {
+  t: string;
+  c?: string;
+  b?: boolean;
+}
+
+// One combined scanner; classify each match by which group hit.
+const TOKEN_RE =
+  /(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?)|\b(DEBUG|INFO|NOTICE|WARNING|WARN|ERROR|CRITICAL|FATAL)\b|(?<=" )([1-5]\d{2})\b|\b((?:unraid_mcp|rc\.unraid-mcp|uvicorn|fastmcp)[\w.-]*)/g;
+
+function tokenize(line: string): Seg[] {
+  const segs: Seg[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  TOKEN_RE.lastIndex = 0;
+  while ((m = TOKEN_RE.exec(line)) !== null) {
+    if (m.index > last) segs.push({ t: line.slice(last, m.index), c: C.msg });
+    if (m[1]) {
+      segs.push({ t: m[1], c: C.ts });
+    } else if (m[2]) {
+      const col = LEVEL_COLOR[m[2]] ?? C.msg;
+      segs.push({ t: m[2], c: col, b: col === C.error || col === C.critical });
+    } else if (m[3]) {
+      const code = Number(m[3]);
+      const col = code < 300 ? C.ok : code < 400 ? C.info : code < 500 ? C.warn : C.error;
+      segs.push({ t: m[3], c: col, b: code >= 500 });
+    } else if (m[4]) {
+      segs.push({ t: m[4], c: C.module });
+    }
+    last = m.index + m[0].length;
+  }
+  if (last < line.length) segs.push({ t: line.slice(last), c: C.msg });
+  if (segs.length === 0) segs.push({ t: line || " ", c: C.msg });
+  return segs;
+}
+
+/** Severity of a whole line, for the left accent rail. */
+function lineLevel(line: string): string {
+  const m = line.match(/\b(DEBUG|INFO|NOTICE|WARNING|WARN|ERROR|CRITICAL|FATAL)\b/);
+  return m ? (LEVEL_COLOR[m[1]] ?? "transparent") : "transparent";
+}
+
+const lines = computed(() => {
+  const text = raw.value.replace(/\n+$/, "");
+  if (!text) return [];
+  return text.split("\n").map((l) => ({ rail: lineLevel(l), segs: tokenize(l) }));
+});
+
+async function refresh(scroll = true) {
+  loading.value = true;
+  try {
+    raw.value = (await fetchLogs(lineCount.value)) || "(log is empty)";
+  } catch (e) {
+    raw.value = `failed to fetch log: ${e instanceof Error ? e.message : e}`;
+  }
+  loading.value = false;
+  if (scroll && pane) requestAnimationFrame(() => (pane!.scrollTop = pane!.scrollHeight));
+}
+
+function setAuto(on: boolean) {
+  auto.value = on;
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  if (on) {
+    void refresh();
+    timer = setInterval(() => void refresh(), 3000);
+  }
+}
+
+onMounted(() => void refresh());
+onBeforeUnmount(() => {
+  if (timer) clearInterval(timer);
+});
+</script>
+
+<template>
+  <div class="flex flex-col gap-2 rounded-lg border p-3" style="background: #07131c; border-color: #1d3d4e">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <span class="text-[11px] font-semibold tracking-[0.08em] uppercase" style="color: #a7bcc9">Server log</span>
+        <span class="font-mono text-xs" style="color: #7c93a1">/var/log/unraid-mcp/server.log</span>
+      </div>
+      <div class="flex items-center gap-3">
+        <label class="flex items-center gap-1.5 text-xs" style="color: #a7bcc9">
+          lines
+          <select
+            v-model.number="lineCount"
+            class="h-7 rounded-md border bg-transparent px-1.5 text-xs"
+            style="border-color: #1d3d4e; color: #e6f4fb"
+            @change="refresh()"
+          >
+            <option value="100">100</option>
+            <option value="300">300</option>
+            <option value="1000">1000</option>
+          </select>
+        </label>
+        <div class="flex items-center gap-1.5">
+          <Switch :model-value="auto" @update:model-value="setAuto($event)" />
+          <span class="text-xs" style="color: #a7bcc9">Follow</span>
+        </div>
+        <Button size="sm" variant="ghost" class="px-2" :disabled="loading" @click="refresh()">
+          {{ loading ? "…" : "Refresh" }}
+        </Button>
+      </div>
+    </div>
+
+    <div
+      :ref="paneRef"
+      class="overflow-auto rounded-md font-mono text-xs leading-relaxed"
+      style="background: #07111a; border: 1px solid #142a37; height: min(70vh, 640px)"
+    >
+      <div
+        v-for="(ln, i) in lines"
+        :key="i"
+        class="flex gap-2 px-2 py-[1px] whitespace-pre-wrap break-words hover:bg-[#0c1a24]"
+        style="border-left: 2px solid"
+        :style="{ borderLeftColor: ln.rail }"
+      >
+        <code class="flex-1">
+          <span v-for="(s, j) in ln.segs" :key="j" :style="{ color: s.c, fontWeight: s.b ? 600 : 400 }">{{ s.t }}</span>
+        </code>
+      </div>
+      <div v-if="lines.length === 0" class="px-2 py-1" style="color: #7c93a1">(log is empty)</div>
+    </div>
+  </div>
+</template>

--- a/unraid-plugin/web/src/Widget.vue
+++ b/unraid-plugin/web/src/Widget.vue
@@ -38,7 +38,18 @@ function connect() {
   es.onopen = () => (connected.value = true);
   es.onmessage = (e) => {
     try {
-      status.value = JSON.parse(e.data) as Status;
+      const d = JSON.parse(e.data) as Partial<Status>;
+      // Validate before trusting fields the template calls .toFixed() on — a
+      // future publisher change or partial frame must not throw in render.
+      if (typeof d.running !== "boolean") return;
+      status.value = {
+        running: d.running,
+        pid: Number(d.pid) || 0,
+        cpu: Number(d.cpu) || 0,
+        memMB: Number(d.memMB) || 0,
+        uptime: Number(d.uptime) || 0,
+        version: typeof d.version === "string" ? d.version : "unknown",
+      };
     } catch {
       /* ignore malformed frames */
     }

--- a/unraid-plugin/web/src/Widget.vue
+++ b/unraid-plugin/web/src/Widget.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+/**
+ * Compact Main → Dashboard status tile. Self-contained and dependency-light
+ * (no Tailwind / component kit) since it ships in its own minimal bundle that
+ * loads on every dashboard view. Live status is pushed over the nchan
+ * "unraid_mcp" channel — with buffer_length=1 the last status arrives the
+ * moment we subscribe, so there is no polling and no initial fetch. Inline
+ * styles keep it readable in any Unraid webGUI theme.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+
+interface Status {
+  running: boolean;
+  pid: number;
+  cpu: number;
+  memMB: number;
+  uptime: number;
+  version: string;
+}
+
+const status = ref<Status | null>(null);
+const connected = ref(false);
+let es: EventSource | null = null;
+
+const uptimeText = computed(() => {
+  const s = status.value?.uptime ?? 0;
+  if (!s || !status.value?.running) return "—";
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (d) return `${d}d ${h}h`;
+  if (h) return `${h}h ${m}m`;
+  return `${m}m`;
+});
+
+function connect() {
+  es = new EventSource("/sub/unraid_mcp");
+  es.onopen = () => (connected.value = true);
+  es.onmessage = (e) => {
+    try {
+      status.value = JSON.parse(e.data) as Status;
+    } catch {
+      /* ignore malformed frames */
+    }
+  };
+  es.onerror = () => {
+    connected.value = false; // EventSource auto-reconnects
+  };
+}
+
+onMounted(connect);
+onBeforeUnmount(() => es?.close());
+</script>
+
+<template>
+  <div style="display: flex; flex-direction: column; gap: 6px; padding: 4px 2px; font-size: 1.3rem">
+    <div style="display: flex; align-items: center; gap: 8px">
+      <span
+        :style="{
+          display: 'inline-block',
+          width: '9px',
+          height: '9px',
+          borderRadius: '50%',
+          background: status?.running ? '#63a659' : '#8a8a8a',
+        }"
+      ></span>
+      <strong>{{ status?.running ? "Running" : status ? "Stopped" : "Connecting…" }}</strong>
+      <span v-if="status" style="opacity: 0.7">v{{ status.version }}</span>
+      <a href="/Settings/UnraidMCP" style="margin-left: auto; font-size: 1.15rem">Settings ›</a>
+    </div>
+
+    <div v-if="status?.running" style="display: flex; gap: 18px; opacity: 0.9">
+      <span><b>{{ status.cpu.toFixed(1) }}%</b> cpu</span>
+      <span><b>{{ status.memMB }}</b> MB</span>
+      <span><b>{{ uptimeText }}</b> up</span>
+      <span style="opacity: 0.6">pid {{ status.pid }}</span>
+    </div>
+    <div v-else-if="status" style="opacity: 0.7">Service is not running.</div>
+  </div>
+</template>

--- a/unraid-plugin/web/src/fields.ts
+++ b/unraid-plugin/web/src/fields.ts
@@ -12,15 +12,15 @@ export interface FieldDef {
 export interface Section {
   title: string;
   collapsed?: boolean;
-  /** Which settings column this section renders in. */
-  col: "left" | "right";
+  /** Which of the three settings columns this section renders in. */
+  col: "a" | "b" | "c";
   fields: FieldDef[];
 }
 
 export const SECTIONS: Section[] = [
   {
     title: "Unraid API",
-    col: "left",
+    col: "a",
     fields: [
       {
         key: "UNRAID_API_URL",
@@ -52,7 +52,7 @@ export const SECTIONS: Section[] = [
   },
   {
     title: "MCP server",
-    col: "right",
+    col: "b",
     fields: [
       {
         key: "UNRAID_MCP_TRANSPORT",
@@ -86,7 +86,7 @@ export const SECTIONS: Section[] = [
   },
   {
     title: "Authentication",
-    col: "left",
+    col: "a",
     fields: [
       {
         key: "UNRAID_MCP_BEARER_TOKEN",
@@ -110,7 +110,7 @@ export const SECTIONS: Section[] = [
   },
   {
     title: "Tuning",
-    col: "right",
+    col: "b",
     fields: [
       {
         key: "UNRAID_MCP_LOG_LEVEL",
@@ -144,7 +144,7 @@ export const SECTIONS: Section[] = [
   {
     title: "Subscription tuning",
     collapsed: true,
-    col: "left",
+    col: "c",
     fields: [
       {
         key: "UNRAID_SUBSCRIPTION_COLLECT_MAX_EVENTS",
@@ -199,7 +199,7 @@ export const SECTIONS: Section[] = [
   },
   {
     title: "Google OAuth (claude.ai)",
-    col: "right",
+    col: "c",
     fields: [
       {
         key: "UNRAID_MCP_GOOGLE_CLIENT_ID",

--- a/unraid-plugin/web/src/fields.ts
+++ b/unraid-plugin/web/src/fields.ts
@@ -199,7 +199,6 @@ export const SECTIONS: Section[] = [
   },
   {
     title: "Google OAuth (claude.ai)",
-    collapsed: true,
     col: "right",
     fields: [
       {

--- a/unraid-plugin/web/src/fields.ts
+++ b/unraid-plugin/web/src/fields.ts
@@ -14,6 +14,8 @@ export interface Section {
   collapsed?: boolean;
   /** Which of the three settings columns this section renders in. */
   col: "a" | "b" | "c";
+  /** Gated sections stay collapsed to an enable toggle until opted in. */
+  gated?: boolean;
   fields: FieldDef[];
 }
 
@@ -200,6 +202,7 @@ export const SECTIONS: Section[] = [
   {
     title: "Google OAuth (claude.ai)",
     col: "c",
+    gated: true,
     fields: [
       {
         key: "UNRAID_MCP_GOOGLE_CLIENT_ID",

--- a/unraid-plugin/web/src/fields.ts
+++ b/unraid-plugin/web/src/fields.ts
@@ -12,12 +12,15 @@ export interface FieldDef {
 export interface Section {
   title: string;
   collapsed?: boolean;
+  /** Which settings column this section renders in. */
+  col: "left" | "right";
   fields: FieldDef[];
 }
 
 export const SECTIONS: Section[] = [
   {
     title: "Unraid API",
+    col: "left",
     fields: [
       {
         key: "UNRAID_API_URL",
@@ -49,6 +52,7 @@ export const SECTIONS: Section[] = [
   },
   {
     title: "MCP server",
+    col: "right",
     fields: [
       {
         key: "UNRAID_MCP_TRANSPORT",
@@ -82,6 +86,7 @@ export const SECTIONS: Section[] = [
   },
   {
     title: "Authentication",
+    col: "left",
     fields: [
       {
         key: "UNRAID_MCP_BEARER_TOKEN",
@@ -105,6 +110,7 @@ export const SECTIONS: Section[] = [
   },
   {
     title: "Tuning",
+    col: "right",
     fields: [
       {
         key: "UNRAID_MCP_LOG_LEVEL",
@@ -138,6 +144,7 @@ export const SECTIONS: Section[] = [
   {
     title: "Subscription tuning",
     collapsed: true,
+    col: "left",
     fields: [
       {
         key: "UNRAID_SUBSCRIPTION_COLLECT_MAX_EVENTS",
@@ -193,6 +200,7 @@ export const SECTIONS: Section[] = [
   {
     title: "Google OAuth (claude.ai)",
     collapsed: true,
+    col: "right",
     fields: [
       {
         key: "UNRAID_MCP_GOOGLE_CLIENT_ID",

--- a/unraid-plugin/web/src/lib/config-client.ts
+++ b/unraid-plugin/web/src/lib/config-client.ts
@@ -49,7 +49,7 @@ export interface ConfigPayload {
 
 export interface StatsPayload {
   service: ServiceState;
-  process: ProcessState;
+  process?: ProcessState;
 }
 
 async function csrfToken(): Promise<string> {

--- a/unraid-plugin/web/src/widget.ts
+++ b/unraid-plugin/web/src/widget.ts
@@ -1,0 +1,9 @@
+import { defineCustomElement } from "vue";
+import Widget from "./Widget.vue";
+
+// Light DOM so it inherits the Unraid dashboard tile's fonts/theme.
+const UnraidMcpWidget = defineCustomElement(Widget, { shadowRoot: false });
+
+if (!customElements.get("unraid-mcp-widget")) {
+  customElements.define("unraid-mcp-widget", UnraidMcpWidget);
+}

--- a/unraid-plugin/web/vite.widget.config.ts
+++ b/unraid-plugin/web/vite.widget.config.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath, URL } from "node:url";
+import vue from "@vitejs/plugin-vue";
+import { defineConfig } from "vite";
+
+// Separate, minimal build for the Main → Dashboard widget. Deliberately NOT
+// vite.config.ts's settings bundle (Tailwind + reka-ui + the whole form UI,
+// ~240 KB) — this loads on every dashboard view, so it stays a tiny,
+// dependency-light IIFE. Writes alongside the settings bundle (emptyOutDir
+// false so it doesn't wipe it — this build runs second).
+export default defineConfig({
+  plugins: [vue({ customElement: true })],
+  resolve: {
+    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+  },
+  define: { "process.env.NODE_ENV": JSON.stringify("production") },
+  build: {
+    outDir: "../source/usr/local/emhttp/plugins/unraid-mcp/web",
+    emptyOutDir: false,
+    cssCodeSplit: false,
+    lib: {
+      entry: fileURLToPath(new URL("./src/widget.ts", import.meta.url)),
+      name: "UnraidMcpWidget",
+      formats: ["iife"],
+      fileName: () => "unraid-mcp-widget.js",
+    },
+    rollupOptions: {
+      output: { assetFileNames: "unraid-mcp-widget.[ext]" },
+    },
+  },
+});


### PR DESCRIPTION
Moves the server log out of the Dashboard into its own **Logs** tab, rebuilt as a self-contained Aurora-dark terminal panel (tokens from registry/aurora/styles/aurora.css) that stays dark regardless of the Unraid webGUI theme.

Each line is tokenized and colorized: **severity** (INFO cyan, DEBUG slate, WARNING sand, ERROR/CRITICAL rose — bold, with a left severity rail), **timestamps** dimmed, **logger names** in violet, **HTTP status** green/amber/rose by class. Plus a line-count selector (100/300/1000), Follow (3s poll), and Refresh. Extracted to LogView.vue.

Screenshot-verified; deployed live to tootie.