### PR TITLE
docs: save session log

### DIFF
--- a/docs/sessions/2026-07-24-release-2.7.0-and-publish-gate.md
+++ b/docs/sessions/2026-07-24-release-2.7.0-and-publish-gate.md
@@ -1,0 +1,127 @@
+---
+date: 2026-07-24 00:42:23 EST
+repo: git@github.com:dinglebear-ai/unraid-mcp.git
+branch: main
+head: 93264ae
+session id: d9fa7b95-7ef2-4c9b-a253-3bb89d20130c
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-unraid-mcp/d9fa7b95-7ef2-4c9b-a253-3bb89d20130c.jsonl
+working directory: /home/jmagar/workspace/unraid-mcp
+pr: #208 "chore(main): release 2.7.0" (merged) — https://github.com/dinglebear-ai/unraid-mcp/pull/208
+beads: none created/closed (unraid-mcp-58o, -hoc, -oha inspected only)
+---
+
+# Release 2.7.0 and the org-move publish gate
+
+## User request
+"What's the repo status now?" → "merge 208" (the release-please PR) → after the release paused on an approval gate the user had never seen before: "approve the release and going forward make it work like it did before where I don't have to manually approve it."
+
+## Session overview
+Reported repo status, then merged the release-please PR #208 to cut **v2.7.0**. The release run paused unexpectedly on a protected `release` environment awaiting manual approval — diagnosed as an org-move side effect (the `required_reviewers` rule that previously didn't stop the repo owner now enforces for `jmagar` as an org member). With explicit authorization, approved the pending deployment (publishing to PyPI, MCP Registry, GitHub Release) and permanently removed the reviewer gate so future releases auto-publish. Verified v2.7.0 live end-to-end and recorded the gotcha to memory. This is the release/publish segment of a larger session whose src-layout refactor was logged separately.
+
+## Sequence of events
+1. Reported repo status: clean `main`, two open automated PRs (#208 release, #186 dependabot python 3.14).
+2. Pre-checked PR #208 (all 10 required checks green, `MERGEABLE`) and squash-merged it → `main` at `93264ae`; pruned the release-please branch.
+3. Confirmed release-please tagged `v2.7.0` and the publish workflows fired.
+4. Watched "Release Artifacts" — build+attest passed, but the three publish channels sat with no step activity; the watch timed out.
+5. Queried `pending_deployments` → run `status=waiting` on the `release` environment (reviewer `jmagar`, `current_user_can_approve: true`).
+6. Investigated: confirmed the gate config pre-dated recent releases, so the org move (not a new config) flipped enforcement on.
+7. On the user's authorization: approved the pending deployment via API, then removed the `required_reviewers` rule from the `release` environment.
+8. Watched the run to success; verified PyPI 2.7.0 live, container/plugin/registry/release all green, reconciliation clean.
+9. Updated the `github-org-move` memory with the gate diagnosis and the approve/remove commands.
+
+## Key findings
+- The run was **waiting on human approval, not stuck**: `gh api repos/dinglebear-ai/unraid-mcp/actions/runs/30066662796/pending_deployments` returned the `release` environment with reviewer `jmagar` and `status=waiting`.
+- The gate is **not new config**: `publish-pypi.yml` (display name "Release Artifacts") has referenced `environment: release` at 3 publish jobs since PR #200, and the `release` environment's `required_reviewers` rule dates to ~2026-07-16 (`environments/release` `updated_at`).
+- **Org move flipped enforcement**: prior releases (v2.4.1–v2.6.0) published without a manual approval; as a repo *owner* on the old `jmagar/unraid-mcp` the rule didn't stop the user, but on the `dinglebear-ai` org repo `jmagar` is a required reviewer whose approval is now actually enforced.
+- Removing protection: `PUT environments/release` with `{"wait_timer":0,"reviewers":null,"deployment_branch_policy":null}` clears all rules → `protection_rules: []`.
+
+## Technical decisions
+- **Did not auto-approve without explicit consent**: publishing to PyPI is irreversible and indexed, so the approval waited for the user's go-ahead even though the token could approve.
+- **Removed the gate entirely** (vs. leaving it): the user explicitly asked for the prior auto-publish behavior; the reviewer rule was an unintended enforcement change, not a deliberate safety choice they wanted.
+- **Recorded to memory rather than a bead**: the fix is complete (no remaining work), but the org-move enforcement quirk is durable operational knowledge worth surfacing next time, so it went into `github_org_move.md`.
+
+## Files changed
+No repository source files were changed in this segment. Changes were to GitHub deployment/environment state (external) and to Claude memory (outside the repo). The release version bumps in `93264ae` were authored by release-please, not this session.
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| created | `docs/sessions/2026-07-24-release-2.7.0-and-publish-gate.md` | — | This session log | — |
+
+External / non-repo state changed:
+- GitHub `release` environment (`dinglebear-ai/unraid-mcp`): `required_reviewers` rule removed → `protection_rules: []`.
+- GitHub Actions run 30066662796: `release` deployment approved.
+- Memory `github_org_move.md`: appended the publish-gate diagnosis + commands.
+
+## Beads activity
+No bead was created, closed, or edited this segment. Inspected only (`bd ready`):
+- **unraid-mcp-58o** (P3, open) — openwiki regeneration check; created in the prior segment, now unblocked/ready, unchanged.
+- **unraid-mcp-hoc** (P1, open) — older review remediation; unrelated, unchanged.
+- **unraid-mcp-oha** (P1, in_progress) — native plugin packaging; the release published its txz+plg but the bead's remaining items (release-CI asset proof, upgrade-path test) are now partially satisfied yet not verified here, so left in_progress.
+
+## Repository maintenance
+- **Plans**: `docs/plans/` does not exist — no-op.
+- **Beads**: read `bd ready`; no state change needed (see Beads activity). No new remaining work from this segment to track — the gate removal is complete.
+- **Worktrees/branches**: `git worktree list` shows only the primary `main` worktree; `git branch -vv` shows only `main`. The release-please branch was auto-deleted at merge and pruned. Remote has only `main` + the active `origin/dependabot/docker/python-3.14.6-slim-bookworm` (PR #186, left alone — active PR). Nothing stale to remove.
+- **Stale docs**: none touched or contradicted by this segment; no updates needed.
+- **Transparency**: the only mutations were external GitHub state (approve + de-gate) and memory; both are recorded above with the exact commands.
+
+## Tools and skills used
+- **Shell (Bash)**: `gh pr checks/merge`, `gh run list/view/watch`, `gh api` (pending_deployments GET+POST, environments PUT), `git` (merge/prune/log), `bd ready`, `curl` PyPI JSON. Issues: `gh run watch` timed out twice (10-min tool cap) on long-running publish jobs — worked around by direct `gh api .../runs/<id>` and `pending_deployments` status polls. One `python3 -c` JSON parse failed on the first approve attempt because `-f "environment_ids[]=..."` didn't produce an integer array; fixed by sending a typed JSON body via `--input -`.
+- **File tools (Write/Edit)**: this session note; memory edit to `github_org_move.md`.
+- **Beads (`bd`)**: tracker reads only.
+- **Skill `/vibin:save-to-md`**: this closeout. No MCP servers, browser tools, or subagents used this segment.
+
+## Commands executed
+| command | result |
+|---|---|
+| `gh pr merge 208 --squash --delete-branch` | merged → `main` `93264ae`; release-please branch deleted+pruned |
+| `git ls-remote --tags origin \| grep v2.7` | `refs/tags/v2.7.0` created |
+| `gh api .../actions/runs/30066662796/pending_deployments` | `release` env awaiting reviewer `jmagar`; run `status=waiting` |
+| `gh api --method POST .../pending_deployments --input -` (`{"environment_ids":[13771055930],"state":"approved"}`) | 3 `release` deployments created (5583726096/97/98) |
+| `gh api --method PUT .../environments/release --input -` (`reviewers:null`) | `protection_rules: []` (gate removed) |
+| `gh run watch 30066662796 --exit-status` | exit 0 — all publish jobs succeeded |
+| `curl -s https://pypi.org/pypi/unraid-mcp/json` | latest on PyPI: **2.7.0** |
+
+## Errors encountered
+- **First approve call failed to parse**: used `-f "environment_ids[]=13771055930"`, which does not yield the integer array the API expects; the follow-up `python3` parse then choked on the error body. Root cause: array-of-int typing via `-f`. Resolved by piping an explicit JSON body to `gh api --method POST --input -`.
+- **`gh run watch` timed out** (twice) at the 10-minute tool cap while the publish jobs ran/waited. Not a failure of the run; worked around with direct status API queries.
+
+## Behavior changes (before/after)
+| area | before | after |
+|---|---|---|
+| Published version | 2.6.0 (PyPI/GHCR/registry) | **2.7.0** across PyPI, GHCR, MCP Registry, GitHub Release, Unraid plugin txz+plg |
+| Release publish flow | paused on `release` environment awaiting manual approval (post org-move enforcement) | auto-publishes — `required_reviewers` rule removed from the `release` environment |
+
+## Verification evidence
+| command | expected | actual | status |
+|---|---|---|---|
+| `gh pr checks 208` | all required green | all pass (2 skipping) | pass |
+| `git ls-remote --tags origin` | `v2.7.0` present | `refs/tags/v2.7.0` | pass |
+| `gh run view 30066662796` | all publish jobs ✓ | build, PyPI, MCP Registry, GitHub Release, Reconciliation all ✓ | pass |
+| `curl pypi.org/pypi/unraid-mcp/json` | latest = 2.7.0 | 2.7.0 | pass |
+| `gh run list ... Container` | container publish success | completed success | pass |
+| `gh api environments/release` | no protection rules | `protection_rules count = 0` | pass |
+
+## Risks and rollback
+- **Removing the reviewer gate lowers the guardrail** on publishing: any future merged release-please PR now publishes to PyPI/GHCR automatically with no human confirm step. This matches the user's explicit request and prior behavior. Rollback: re-add the rule with `PUT environments/release` and a `reviewers` array containing `jmagar` if a manual gate is ever wanted again.
+- **v2.7.0 publish is irreversible** (PyPI is immutable/indexed) — intended and authorized.
+
+## Decisions not taken
+- **Auto-approving before confirmation**: rejected — irreversible external publish; waited for explicit user go-ahead.
+- **Keeping the gate but pre-approving each release**: rejected — the user asked for the prior no-approval behavior, so the rule was removed rather than repeatedly approved.
+- **Merging PR #186 (python 3.14)**: not taken — it's a deliberate supply-chain upgrade project blocked by pinning policy, out of scope for a routine release.
+
+## References
+- PR #208: https://github.com/dinglebear-ai/unraid-mcp/pull/208
+- Release Artifacts run: https://github.com/dinglebear-ai/unraid-mcp/actions/runs/30066662796
+- PyPI: https://pypi.org/project/unraid-mcp/2.7.0/
+- Memory: `github_org_move.md` (org-move publish-gate note)
+
+## Open questions
+- Is there any org-level policy that could re-add environment protection rules automatically (e.g. an org ruleset), or is the `release` environment now permanently ungated until manually changed? Not verified this session.
+
+## Next steps
+1. **Follow-on (not started)**: `unraid-mcp-58o` — after the next `openwiki-update.yml` run, confirm `openwiki/` regenerated with `src/unraid_mcp/` paths.
+2. **Follow-on (not started)**: `unraid-mcp-oha` — verify the release-CI plugin-asset attachment now that v2.7.0 fired, and test the plugin upgrade-path/config-preservation on Unraid 7.3.1.
+3. **Optional**: decide whether PR #186 (python 3.14 base bump) should be scheduled as its own upgrade task.
+4. **Recommended immediate command** if resuming: `bd ready`.


### PR DESCRIPTION
Session log for the v2.7.0 release + publish-gate segment. Docs only.