### PR TITLE
fix: stabilize releases and destructive elicitation

### DIFF
--- a/.github/scripts/plugin_calver.py
+++ b/.github/scripts/plugin_calver.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Prepare lexicographically safe CalVer releases for Unraid plugins.
+
+Unraid compares plugin versions as raw strings. The compact fixed-width format
+YYYYMMDD.NNN therefore preserves chronological ordering and sorts after the
+legacy YYYY.M.D values already published by this repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+CALVER_RE = re.compile(r"^(?P<date>\d{8})\.(?P<sequence>\d{3})$")
+LEGACY_CALVER_RE = re.compile(r"^(?P<year>\d{4})\.(?P<month>\d{1,2})\.(?P<day>\d{1,2})$")
+VERSION_ENTITY_RE = re.compile(
+    r'(?m)^(?P<prefix>\s*<!ENTITY\s+version\s+")(?P<version>[^"]+)'
+    r'(?P<suffix>"\s*>)(?:\s*<!--.*?-->)?\s*$'
+)
+
+
+@dataclass(frozen=True)
+class Component:
+    name: str
+    manifest: str
+    tag_prefix: str
+
+
+@dataclass(frozen=True)
+class ReleasePlan:
+    component: str
+    manifest: str
+    current_version: str
+    version: str
+    tag: str
+    calendar_date: str
+    sequence: int
+
+
+COMPONENTS = {
+    "incus": Component("incus", "plugins/incus/incus.plg", "incus-v"),
+    "codex": Component("codex", "plugins/codex/unraid-codex.plg", "codex-v"),
+}
+
+
+def read_plugin_version(path: Path) -> str:
+    match = VERSION_ENTITY_RE.search(path.read_text(encoding="utf-8"))
+    if not match:
+        raise ValueError(f"could not parse <!ENTITY version> from {path}")
+    return match.group("version")
+
+
+def calendar_date(version: str) -> dt.date:
+    match = CALVER_RE.fullmatch(version)
+    if match:
+        return dt.datetime.strptime(match.group("date"), "%Y%m%d").date()
+
+    legacy = LEGACY_CALVER_RE.fullmatch(version)
+    if legacy:
+        return dt.date(
+            int(legacy.group("year")),
+            int(legacy.group("month")),
+            int(legacy.group("day")),
+        )
+
+    raise ValueError(
+        f"unsupported plugin version {version!r}; expected legacy YYYY.M.D "
+        "or current YYYYMMDD.NNN"
+    )
+
+
+def parse_current_calver(version: str) -> tuple[dt.date, int] | None:
+    match = CALVER_RE.fullmatch(version)
+    if not match:
+        return None
+    return (
+        dt.datetime.strptime(match.group("date"), "%Y%m%d").date(),
+        int(match.group("sequence")),
+    )
+
+
+def make_version(release_date: dt.date, sequence: int) -> str:
+    if not 1 <= sequence <= 999:
+        raise ValueError("plugin release sequence must be between 1 and 999")
+    return f"{release_date:%Y%m%d}.{sequence:03d}"
+
+
+def next_version(
+    release_date: dt.date,
+    current_version: str,
+    released_versions: Iterable[str],
+) -> str:
+    released = list(released_versions)
+    dated_versions = [current_version, *released]
+    latest_calendar_date = max(calendar_date(version) for version in dated_versions)
+    if release_date < latest_calendar_date:
+        raise ValueError(
+            f"release date {release_date.isoformat()} predates the latest plugin "
+            f"release date {latest_calendar_date.isoformat()}"
+        )
+
+    sequences = []
+    for version in dated_versions:
+        parsed = parse_current_calver(version)
+        if parsed and parsed[0] == release_date:
+            sequences.append(parsed[1])
+
+    candidate = make_version(release_date, max(sequences, default=0) + 1)
+    lexical_floor = max(dated_versions)
+    if candidate <= lexical_floor:
+        raise ValueError(
+            f"candidate {candidate} does not sort after existing version {lexical_floor}"
+        )
+    return candidate
+
+
+def validate_explicit_version(
+    version: str,
+    current_version: str,
+    released_versions: Iterable[str],
+) -> None:
+    if not CALVER_RE.fullmatch(version):
+        raise ValueError("explicit plugin version must use YYYYMMDD.NNN")
+
+    released = list(released_versions)
+    version_date = calendar_date(version)
+    latest_calendar_date = max(
+        calendar_date(item) for item in [current_version, *released]
+    )
+    if version_date < latest_calendar_date:
+        raise ValueError(
+            f"explicit version date {version_date.isoformat()} predates "
+            f"{latest_calendar_date.isoformat()}"
+        )
+
+    lexical_floor = max([current_version, *released])
+    if version <= lexical_floor:
+        raise ValueError(
+            f"explicit version {version} must sort after existing version {lexical_floor}"
+        )
+
+
+def update_plugin_version(path: Path, version: str) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    def replacement(match: re.Match[str]) -> str:
+        return (
+            f'{match.group("prefix")}{version}{match.group("suffix")} '
+            '<!-- managed by .github/scripts/plugin_calver.py -->'
+        )
+
+    updated, count = VERSION_ENTITY_RE.subn(replacement, text, count=1)
+    if count != 1:
+        raise ValueError(f"expected exactly one version entity in {path}, found {count}")
+    path.write_text(updated, encoding="utf-8")
+
+
+def git_tag_versions(repo_root: Path, prefix: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "tag", "--list", f"{prefix}*"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        line.removeprefix(prefix)
+        for line in result.stdout.splitlines()
+        if line.startswith(prefix)
+    ]
+
+
+def build_plan(
+    repo_root: Path,
+    component_name: str,
+    release_date: dt.date,
+    explicit_version: str | None = None,
+) -> ReleasePlan:
+    component = COMPONENTS[component_name]
+    manifest = repo_root / component.manifest
+    current = read_plugin_version(manifest)
+    released = git_tag_versions(repo_root, component.tag_prefix)
+
+    if explicit_version:
+        validate_explicit_version(explicit_version, current, released)
+        version = explicit_version
+    else:
+        version = next_version(release_date, current, released)
+
+    parsed = parse_current_calver(version)
+    assert parsed is not None
+    return ReleasePlan(
+        component=component.name,
+        manifest=component.manifest,
+        current_version=current,
+        version=version,
+        tag=f"{component.tag_prefix}{version}",
+        calendar_date=parsed[0].isoformat(),
+        sequence=parsed[1],
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    default_root = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("component", choices=sorted(COMPONENTS))
+    parser.add_argument("--repo-root", type=Path, default=default_root)
+    parser.add_argument(
+        "--date",
+        type=dt.date.fromisoformat,
+        default=dt.date.today(),
+        help="release date in YYYY-MM-DD form (default: today)",
+    )
+    parser.add_argument("--version", help="explicit YYYYMMDD.NNN version")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    plan = build_plan(repo_root, args.component, args.date, args.version)
+    if not args.dry_run:
+        update_plugin_version(repo_root / plan.manifest, plan.version)
+
+    if args.as_json:
+        print(json.dumps(asdict(plan), sort_keys=True))
+    else:
+        mode = "would prepare" if args.dry_run else "prepared"
+        print(
+            f"{mode} {plan.component} {plan.current_version} -> {plan.version} "
+            f"({plan.tag})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release_contract.py
+++ b/.github/scripts/release_contract.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Validate the monorepo release contract and print its concrete release plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from plugin_calver import CALVER_RE, COMPONENTS, calendar_date, read_plugin_version
+
+BOOTSTRAP_SHA = "2f4e40d475f93a354d1420d22127b23c5aed56b5"
+RELEASE_PLEASE_PACKAGES = {"unraid-py", "unraid-rs"}
+SEMVER_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:[-+].*)?$")
+
+
+@dataclass(frozen=True)
+class ReleaseUnit:
+    name: str
+    version: str
+    tag: str
+    manager: str
+
+
+def git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def semver_key(version: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.fullmatch(version)
+    if not match:
+        raise ValueError(f"invalid semantic version {version!r}")
+    return tuple(int(match.group(part)) for part in ("major", "minor", "patch"))
+
+
+def tagged_versions(repo_root: Path, prefix: str) -> list[str]:
+    output = git(repo_root, "tag", "--list", f"{prefix}*")
+    return [
+        line.removeprefix(prefix)
+        for line in output.splitlines()
+        if line.startswith(prefix)
+    ]
+
+
+def assert_true(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def validate_release_please(repo_root: Path, errors: list[str]) -> list[ReleaseUnit]:
+    config = json.loads((repo_root / "release-please-config.json").read_text())
+    manifest = json.loads((repo_root / ".release-please-manifest.json").read_text())
+    packages = config.get("packages", {})
+
+    assert_true(
+        config.get("bootstrap-sha") == BOOTSTRAP_SHA,
+        f"release-please bootstrap-sha must be {BOOTSTRAP_SHA}",
+        errors,
+    )
+    assert_true(
+        set(packages) == RELEASE_PLEASE_PACKAGES,
+        f"release-please packages must be exactly {sorted(RELEASE_PLEASE_PACKAGES)}",
+        errors,
+    )
+    assert_true(
+        set(manifest) == RELEASE_PLEASE_PACKAGES,
+        f"release manifest packages must be exactly {sorted(RELEASE_PLEASE_PACKAGES)}",
+        errors,
+    )
+
+    python_cfg = packages.get("unraid-py", {})
+    rust_cfg = packages.get("unraid-rs", {})
+    assert_true(
+        python_cfg.get("component") == ""
+        and python_cfg.get("include-component-in-tag") is False,
+        "unraid-py must explicitly produce unprefixed vX.Y.Z tags",
+        errors,
+    )
+    assert_true(
+        rust_cfg.get("component") == "unraid-rs",
+        "unraid-rs must produce unraid-rs-vX.Y.Z tags",
+        errors,
+    )
+
+    pyproject = tomllib.loads((repo_root / "unraid-py/pyproject.toml").read_text())
+    cargo = tomllib.loads((repo_root / "unraid-rs/Cargo.toml").read_text())
+    versions = {
+        "unraid-py": pyproject["project"]["version"],
+        "unraid-rs": cargo["package"]["version"],
+    }
+    tag_prefixes = {"unraid-py": "v", "unraid-rs": "unraid-rs-v"}
+
+    units: list[ReleaseUnit] = []
+    for name in sorted(RELEASE_PLEASE_PACKAGES):
+        version = versions[name]
+        manifest_version = manifest.get(name)
+        assert_true(
+            version == manifest_version,
+            f"{name} source version {version} != manifest {manifest_version}",
+            errors,
+        )
+        try:
+            current_key = semver_key(version)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+
+        released = tagged_versions(repo_root, tag_prefixes[name])
+        valid_released = []
+        for released_version in released:
+            try:
+                valid_released.append((semver_key(released_version), released_version))
+            except ValueError:
+                continue
+        if valid_released:
+            latest_key, latest = max(valid_released)
+            assert_true(
+                current_key >= latest_key,
+                f"{name} version {version} regresses from released {latest}",
+                errors,
+            )
+
+        units.append(
+            ReleaseUnit(
+                name=name,
+                version=version,
+                tag=f"{tag_prefixes[name]}{version}",
+                manager="release-please",
+            )
+        )
+
+    try:
+        git(repo_root, "cat-file", "-e", f"{BOOTSTRAP_SHA}^{{commit}}")
+        release_as = git(
+            repo_root,
+            "log",
+            f"{BOOTSTRAP_SHA}..HEAD",
+            "--format=%B%x00",
+        )
+        assert_true(
+            "Release-As:" not in release_as,
+            "Release-As directives are forbidden after the monorepo bootstrap boundary",
+            errors,
+        )
+    except subprocess.CalledProcessError as exc:
+        errors.append(f"could not validate bootstrap commit: {exc}")
+
+    return units
+
+
+def validate_plugins(repo_root: Path, errors: list[str]) -> list[ReleaseUnit]:
+    units: list[ReleaseUnit] = []
+    for name, component in COMPONENTS.items():
+        manifest = repo_root / component.manifest
+        text = manifest.read_text(encoding="utf-8")
+        version = read_plugin_version(manifest)
+        released = tagged_versions(repo_root, component.tag_prefix)
+        lexical_floor = max(released, default="")
+
+        assert_true(
+            "x-release-please-version" not in text,
+            f"{component.manifest} must not be managed by release-please",
+            errors,
+        )
+        assert_true(
+            version >= lexical_floor,
+            f"{name} version {version} sorts before released {lexical_floor}",
+            errors,
+        )
+
+        # An imported plugin may have a legacy manifest version before its first
+        # monorepo tag exists. Preserve that untouched baseline; once a component
+        # has tags, every changed manifest must use the fixed-width CalVer lane.
+        changed_since_release = bool(released) and version != lexical_floor
+        if changed_since_release:
+            assert_true(
+                CALVER_RE.fullmatch(version) is not None,
+                f"new {name} releases must use fixed-width YYYYMMDD.NNN CalVer",
+                errors,
+            )
+        try:
+            calendar_date(version)
+        except ValueError as exc:
+            errors.append(f"{name}: {exc}")
+
+        units.append(
+            ReleaseUnit(
+                name=name,
+                version=version,
+                tag=f"{component.tag_prefix}{version}",
+                manager="plugin-calver",
+            )
+        )
+    return units
+
+
+def validate(repo_root: Path) -> tuple[list[str], list[ReleaseUnit]]:
+    errors: list[str] = []
+    units = validate_release_please(repo_root, errors)
+    units.extend(validate_plugins(repo_root, errors))
+    return errors, units
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root", type=Path, default=Path(__file__).resolve().parents[2]
+    )
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    errors, units = validate(args.repo_root.resolve())
+    plan = {"units": [asdict(unit) for unit in units], "errors": errors}
+    if args.as_json:
+        print(json.dumps(plan, indent=2, sort_keys=True))
+    else:
+        for unit in units:
+            print(f"{unit.name}: {unit.version} -> {unit.tag} ({unit.manager})")
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_release_tools.py
+++ b/.github/scripts/tests/test_release_tools.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import datetime as dt
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+import plugin_calver  # noqa: E402
+import release_contract  # noqa: E402
+
+
+class PluginCalverTests(unittest.TestCase):
+    def test_migrates_legacy_version_to_fixed_width_calver(self):
+        version = plugin_calver.next_version(
+            dt.date(2026, 7, 26),
+            "2026.7.24",
+            ["2026.7.24"],
+        )
+        self.assertEqual(version, "20260726.001")
+        self.assertGreater(version, "2026.7.24")
+
+    def test_sequence_increments_for_same_day(self):
+        version = plugin_calver.next_version(
+            dt.date(2026, 7, 26),
+            "20260726.002",
+            ["20260726.001", "20260726.002"],
+        )
+        self.assertEqual(version, "20260726.003")
+
+    def test_rejects_calendar_regression(self):
+        with self.assertRaisesRegex(ValueError, "predates"):
+            plugin_calver.next_version(
+                dt.date(2026, 7, 25),
+                "20260726.001",
+                ["20260726.001"],
+            )
+
+    def test_updates_only_the_version_entity(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "plugin.plg"
+            path.write_text(
+                '<!ENTITY name "demo">\n'
+                '<!ENTITY version "2026.7.24"> '
+                '<!-- x-release-please-version -->\n',
+                encoding="utf-8",
+            )
+            plugin_calver.update_plugin_version(path, "20260726.001")
+            updated = path.read_text(encoding="utf-8")
+            self.assertIn('<!ENTITY name "demo">', updated)
+            self.assertIn('<!ENTITY version "20260726.001">', updated)
+            self.assertIn("managed by .github/scripts/plugin_calver.py", updated)
+            self.assertNotIn("x-release-please-version", updated)
+
+
+class ReleaseContractTests(unittest.TestCase):
+    def test_semver_ordering_is_numeric(self):
+        self.assertGreater(
+            release_contract.semver_key("2.10.0"),
+            release_contract.semver_key("2.9.9"),
+        )
+
+    def test_expected_release_units_are_stable(self):
+        self.assertEqual(
+            release_contract.RELEASE_PLEASE_PACKAGES,
+            {"unraid-py", "unraid-rs"},
+        )
+        self.assertEqual(set(plugin_calver.COMPONENTS), {"incus", "codex"})
+
+    def test_legacy_version_is_recognized_as_calendar_date(self):
+        self.assertEqual(
+            plugin_calver.calendar_date("2026.7.24"),
+            dt.date(2026, 7, 24),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  # This workflow must run for every PR because branch protection requires the
+  # Container Artifact Smoke & Scan check. The expensive image validation is
+  # conditionally skipped below when no container input changed, while an
+  # always-present gate reports the required status.
   pull_request:
     branches: [main]
-    # The PR validate job runs Trivy (~30 min); only run it when the image's
-    # own source changes. (paths can't be scoped to push branches-vs-tags, so
-    # the main-push edge stays unfiltered to keep tag-triggered publish working.)
-    paths: ["unraid-py/**", "Dockerfile", ".github/workflows/docker-publish.yml"]
   workflow_dispatch:
 
 permissions:
@@ -32,9 +32,38 @@ defaults:
     working-directory: unraid-py
 
 jobs:
-  validate:
-    name: Container Artifact Smoke & Scan
+  container_changes:
+    name: Detect Container Inputs
     if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      image_changed: ${{ steps.diff.outputs.image_changed }}
+    steps:
+      - name: Checkout repository with full history
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect container input changes
+        id: diff
+        working-directory: ${{ github.workspace }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+               unraid-py Dockerfile .github/workflows/docker-publish.yml; then
+            echo "image_changed=false" >> "$GITHUB_OUTPUT"
+            echo "No container inputs changed; heavy validation will be skipped."
+          else
+            echo "image_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Container inputs changed; heavy validation is required."
+          fi
+
+  validate_image:
+    name: Build and Scan Container Artifact
+    needs: container_changes
+    if: github.event_name == 'pull_request' && needs.container_changes.outputs.image_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -103,6 +132,35 @@ jobs:
           exit-code: "1"
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+
+  container_gate:
+    name: Container Artifact Smoke & Scan
+    needs: [container_changes, validate_image]
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce conditional container validation
+        working-directory: ${{ github.workspace }}
+        env:
+          CHANGES_RESULT: ${{ needs.container_changes.result }}
+          IMAGE_CHANGED: ${{ needs.container_changes.outputs.image_changed }}
+          VALIDATION_RESULT: ${{ needs.validate_image.result }}
+        run: |
+          test "$CHANGES_RESULT" = "success"
+          case "$IMAGE_CHANGED" in
+            true)
+              test "$VALIDATION_RESULT" = "success"
+              echo "Container inputs changed and the image smoke/scan passed."
+              ;;
+            false)
+              test "$VALIDATION_RESULT" = "skipped"
+              echo "No container inputs changed; required check passes without rebuilding."
+              ;;
+            *)
+              echo "Invalid image_changed output: $IMAGE_CHANGED" >&2
+              exit 1
+              ;;
+          esac
 
   publish:
     name: Publish Attested Container

--- a/.github/workflows/meta-ci.yml
+++ b/.github/workflows/meta-ci.yml
@@ -45,9 +45,12 @@ jobs:
       - name: Install PyYAML
         run: python3 -m pip install --quiet pyyaml
 
-      # release-please bumps the .plg versions in the same PR that edits
-      # .release-please-manifest.json, which is in this filter — so this is the
-      # gate that sees a version regression before it can be tagged.
+      - name: Validate release manager, versions, and tag contract
+        run: python3 ./.github/scripts/release_contract.py
+
+      - name: Test release tooling
+        run: python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
+
       - name: Unraid .plg versions must not regress under string comparison
         run: ./.github/scripts/check-plg-version-ordering.sh
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,10 +2,11 @@ name: release-please
 
 # Drives versioning + changelog from Conventional Commits.
 #
-# On every push to main, release-please maintains a "release PR" that bumps the
-# version in pyproject.toml + the three plugin manifests and updates CHANGELOG.md.
-# Merging that PR creates the git tag (vX.Y.Z) and a GitHub Release, which in turn
-# trigger publish-pypi.yml (release: published) and docker-publish.yml (tag v*).
+# On every push to main, release-please maintains release PRs for the Python and
+# Rust packages only. The bootstrap boundary in release-please-config.json excludes
+# imported pre-monorepo history. Incus and Codex use the separate fixed-width
+# plugin CalVer lane in .github/scripts/plugin_calver.py. Merging a package release
+# PR creates its git tag and GitHub Release, triggering the matching publish jobs.
 #
 # IMPORTANT: `token` must be a PAT or GitHub App token with `contents: write` and
 # `pull-requests: write`. The default GITHUB_TOKEN deliberately does NOT trigger
@@ -19,8 +20,8 @@ name: release-please
 # over a classic PAT. If you must use a PAT, set a calendar reminder tied to its
 # expiry date so it gets rotated before it lapses.
 #
-# release-please bumps the version in pyproject.toml + the plugin manifests but NOT
-# in uv.lock (which records the project's own version). Left unsynced, the release
+# release-please bumps the Python version in pyproject.toml but NOT in uv.lock
+# (which records the project's own version). Left unsynced, the release
 # PR's `uv sync --locked` jobs (Test, Lint, Type Check, Security Audit) fail. The
 # "Sync uv.lock" step below regenerates uv.lock on the release PR branch so those
 # checks pass.

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,4 @@
 {
   "unraid-py": "2.7.0",
-  "unraid-rs": "0.2.3",
-  "plugins/incus": "2026.7.24",
-  "plugins/codex": "2026.7.24"
+  "unraid-rs": "0.2.3"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,15 +37,15 @@ The Python server's detailed dev guide is `unraid-py/CLAUDE.md`.
   **`ci.yml` must keep `.github/workflows/**` in its `paths:` filter**, because
   that test only runs when `ci.yml` runs; narrowing the filter silently disables
   SHA-pin enforcement for every other component's workflow.
-- **release-please drives versioning** for all four units. `unraid-py` is the
-  primary package with an empty component (unprefixed `vX.Y.Z` tags); the others
-  use `unraid-rs-v*`, `incus-v*`, `codex-v*`. The incus/codex `.plg` version
-  entities are annotated `x-release-please-version` so the plugin string version
-  stays in sync. **Unraid compares plugin versions as STRINGS**, which disagrees
-  with release-please's semver bumps on a date-shaped version: `2026.10.0` sorts
-  *before* `2026.9.0`, and every installed plugin would silently stop updating.
-  `.github/scripts/check-plg-version-ordering.sh` (run by `meta-ci.yml` and the
-  pre-commit hook) fails the build on such a regression.
+- **Release management has two explicit lanes.** release-please manages only
+  `unraid-py` and `unraid-rs`; its `bootstrap-sha` pins history to the monorepo
+  consolidation boundary so imported `Release-As:` directives cannot poison new
+  release PRs. Python uses unprefixed `vX.Y.Z` tags and Rust uses
+  `unraid-rs-vX.Y.Z`. Incus and Codex use `.github/scripts/plugin_calver.py` and
+  fixed-width `YYYYMMDD.NNN` versions with `incus-v*` / `codex-v*` tags. Unraid
+  compares plugin versions as raw strings, so fixed width is mandatory.
+  `.github/scripts/release_contract.py` and `check-plg-version-ordering.sh` run in
+  `meta-ci.yml` to reject manager drift, tag drift, and lexical regressions.
 - **This repo restricts which Actions may run** (`allowed_actions: selected`).
   A non-allowlisted action is rejected by GitHub at *compile* time: the run ends
   as `startup_failure` with no jobs, no logs and **no check-run**, so it appears

--- a/plugins/codex/unraid-codex.plg
+++ b/plugins/codex/unraid-codex.plg
@@ -2,7 +2,7 @@
 <!DOCTYPE PLUGIN [
   <!ENTITY name      "unraid-codex">
   <!ENTITY author    "jmagar">
-  <!ENTITY version   "2026.7.24"> <!-- x-release-please-version -->
+  <!ENTITY version   "2026.7.24"> <!-- managed by .github/scripts/plugin_calver.py -->
   <!ENTITY launch    "">
   <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/plugins/codex">
   <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid-mcp/releases/download/codex-v&version;/&txz;">

--- a/plugins/incus/incus.plg
+++ b/plugins/incus/incus.plg
@@ -2,7 +2,7 @@
 <!DOCTYPE PLUGIN [
   <!ENTITY name      "incus">
   <!ENTITY author    "jmagar">
-  <!ENTITY version   "2026.7.24"> <!-- x-release-please-version -->
+  <!ENTITY version   "2026.7.24"> <!-- managed by .github/scripts/plugin_calver.py -->
   <!ENTITY launch    "Settings/IncusSettings">
   <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/plugins/incus">
   <!ENTITY pluginURL "&gitURL;/&name;.plg">

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "2f4e40d475f93a354d1420d22127b23c5aed56b5",
   "include-v-in-tag": true,
   "include-component-in-tag": true,
   "always-update": true,
@@ -14,6 +15,7 @@
       "release-type": "python",
       "package-name": "unraid-mcp",
       "component": "",
+      "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "/agents/unraid-py/.claude-plugin/plugin.json", "jsonpath": "$.version" },
@@ -38,20 +40,6 @@
         { "type": "json", "path": "/agents/unraid-rs/.claude-plugin/plugin.json", "jsonpath": "$.version" },
         { "type": "json", "path": "/agents/unraid-rs/.codex-plugin/plugin.json", "jsonpath": "$.version" }
       ]
-    },
-    "plugins/incus": {
-      "release-type": "simple",
-      "package-name": "incus",
-      "component": "incus",
-      "changelog-path": "CHANGELOG.md",
-      "extra-files": ["incus.plg"]
-    },
-    "plugins/codex": {
-      "release-type": "simple",
-      "package-name": "codex",
-      "component": "codex",
-      "changelog-path": "CHANGELOG.md",
-      "extra-files": ["unraid-codex.plg"]
     }
   }
 }

--- a/unraid-rs/Cargo.lock
+++ b/unraid-rs/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -3556,6 +3557,7 @@ dependencies = [
  "lab-auth",
  "reqwest 0.12.28",
  "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",

--- a/unraid-rs/Cargo.toml
+++ b/unraid-rs/Cargo.toml
@@ -30,6 +30,8 @@ axum = "0.8"
 rmcp = { version = "1.6.0", default-features = false, features = [
   "server",
   "macros",
+  "elicitation",
+  "schemars",
   "transport-streamable-http-server",
   "transport-io",
 ] }
@@ -38,6 +40,7 @@ tower-http = { version = "0.6", features = ["cors", "limit", "trace"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+schemars = "1"
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -14,14 +14,16 @@ direct shell commands.
 `UNRAID_RMCP_HOST=127.0.0.1 npx -y unraid-rmcp serve mcp` -> call `tools/call`
 with `{"action":"server"}`.
 
-**Status:** operational RMCP upstream-client server. Read-only action surface;
-no Unraid mutations are exposed. HTTP MCP supports loopback dev mode, static
-bearer tokens, and Google OAuth through `lab-auth`. Release binaries and Docker
-images target linux/amd64 only.
+**Status:** operational RMCP upstream-client server with the full Unraid GraphQL
+query and mutation surface. Read actions require `unraid:read`; writes require
+`unraid:admin`. Destructive operations use MCP form elicitation and fail closed
+when the client cannot obtain user approval. HTTP MCP supports loopback dev mode,
+static bearer tokens, and Google OAuth through `lab-auth`. Release binaries and
+Docker images target linux/amd64 only.
 
-**Not for:** replacing the Unraid web UI, mutating array/docker/VM state,
-running arbitrary shell commands, storing API keys for callers, multi-tenant
-isolation, or passing Unraid API keys through MCP tool arguments.
+**Not for:** replacing the Unraid web UI, running arbitrary shell commands,
+storing API keys for callers, multi-tenant isolation, or passing Unraid API keys
+through MCP tool arguments.
 
 ## Contents
 
@@ -67,9 +69,10 @@ existing deployment config.
 
 - Read Unraid array state, parity status, disk health, SMART summaries, and
   capacity.
-- Read Docker containers, container logs, VMs, shares, notifications, services,
-  network URLs, live metrics, config vars, registration, flash device details,
-  UPS, plugins, parity history, rclone, remote access, and Unraid Connect.
+- Manage array, Docker, VM, notification, plugin, API-key, rclone, onboarding,
+  settings, remote-access, and Unraid Connect state through GraphQL mutations.
+- Require MCP form elicitation for destructive operations while allowing ordinary
+  writes to proceed after scope authorization.
 - Provide pagination/filtering for MCP list actions and output truncation for
   large MCP responses.
 - Expose the `server_summary` prompt and `unraid://schema/mcp-tool` schema
@@ -78,7 +81,7 @@ existing deployment config.
 
 | This repo owns | Unraid owns | Explicitly out of scope |
 |---|---|---|
-| MCP/CLI projection, GraphQL query selection, response shaping, pagination, auth policy, setup checks, prompt/resource metadata, and read-only safety. | NAS state, array/docker/VM behavior, GraphQL schema, Unraid API key issuance, remote access, and Connect state. | Mutations, shell execution, controller UI replacement, credential brokerage, background monitoring, multi-tenant sandboxing, and direct filesystem writes. |
+| MCP/CLI projection, GraphQL operation selection, response shaping, pagination, auth policy, elicitation policy, setup checks, and prompt/resource metadata. | NAS state, array/docker/VM behavior, GraphQL schema, Unraid API key issuance, remote access, and Connect state. | Arbitrary shell execution, controller UI replacement, credential brokerage, background monitoring, multi-tenant sandboxing, and direct local filesystem writes. |
 
 ## Install
 
@@ -367,15 +370,19 @@ HTTP MCP auth policy:
 | Mounted OAuth | `UNRAID_RMCP_AUTH_MODE=oauth` | Uses Google OAuth/JWT through `lab-auth`. |
 | Trusted gateway | `UNRAID_NOAUTH=true` | Assumes a reverse proxy or gateway already enforced auth. |
 
-All data actions are read-only. OAuth exposes `unraid:read` and `unraid:admin`
-scopes, but no mutating Unraid action is currently registered.
+Read actions require `unraid:read`; mutating actions require `unraid:admin`.
+Configured static bearer tokens are operator credentials and receive admin scope.
+OAuth clients receive the scopes granted by the authorization flow.
 
 ## Safety And Trust Model
 
 - Unraid API keys are loaded from config/env only.
-- MCP callers select read actions and filters, not upstream credentials.
-- No mutation, shell execution, filesystem write, Docker control, VM control, or
-  array-control action is exposed.
+- MCP callers select actions and arguments, not upstream credentials.
+- Destructive actions issue an MCP form-elicitation request before dispatch. A
+  decline, cancellation, malformed response, or client without elicitation support
+  stops the operation before the GraphQL request is sent.
+- Ordinary mutations remain directly available after `unraid:admin` authorization;
+  the server does not add a second confirmation parameter or disable writes.
 - `log_file` reads through the Unraid GraphQL API, not arbitrary local files.
 - Non-loopback HTTP deployments must use bearer auth, OAuth, or a trusted
   authenticated gateway.
@@ -385,12 +392,14 @@ scopes, but no mutating Unraid action is currently registered.
 ## Architecture
 
 ```text
-GraphQL queries (src/graphql.rs)  typed/read-only query construction
+GraphQL operations (src/graphql.rs)  queries + mutations
         |
-UnraidService (src/app.rs)       action behavior and response shaping
+UnraidService (src/app.rs)           action behavior and response shaping
         |
-MCP shim      (src/mcp/tools.rs) JSON args -> service -> Value
-CLI shim      (src/cli.rs)       argv -> service -> stdout
+MCP scope + elicitation              authorization and destructive approval
+        |
+MCP shim      (src/mcp/tools.rs)     JSON args -> service -> Value
+CLI shim      (src/cli.rs)           argv -> service -> stdout
 ```
 
 ## Distribution Contract

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -14,14 +14,16 @@ direct shell commands.
 `UNRAID_RMCP_HOST=127.0.0.1 npx -y unraid-rmcp serve mcp` -> call `tools/call`
 with `{"action":"server"}`.
 
-**Status:** operational RMCP upstream-client server. Read-only action surface;
-no Unraid mutations are exposed. HTTP MCP supports loopback dev mode, static
-bearer tokens, and Google OAuth through `lab-auth`. Release binaries and Docker
-images target linux/amd64 only.
+**Status:** operational RMCP upstream-client server with the full Unraid GraphQL
+query and mutation surface. Read actions require `unraid:read`; writes require
+`unraid:admin`. Destructive operations use MCP form elicitation and fail closed
+when the client cannot obtain user approval. HTTP MCP supports loopback dev mode,
+static bearer tokens, and Google OAuth through `lab-auth`. Release binaries and
+Docker images target linux/amd64 only.
 
-**Not for:** replacing the Unraid web UI, mutating array/docker/VM state,
-running arbitrary shell commands, storing API keys for callers, multi-tenant
-isolation, or passing Unraid API keys through MCP tool arguments.
+**Not for:** replacing the Unraid web UI, running arbitrary shell commands,
+storing API keys for callers, multi-tenant isolation, or passing Unraid API keys
+through MCP tool arguments.
 
 ## Contents
 
@@ -67,9 +69,10 @@ existing deployment config.
 
 - Read Unraid array state, parity status, disk health, SMART summaries, and
   capacity.
-- Read Docker containers, container logs, VMs, shares, notifications, services,
-  network URLs, live metrics, config vars, registration, flash device details,
-  UPS, plugins, parity history, rclone, remote access, and Unraid Connect.
+- Manage array, Docker, VM, notification, plugin, API-key, rclone, onboarding,
+  settings, remote-access, and Unraid Connect state through GraphQL mutations.
+- Require MCP form elicitation for destructive operations while allowing ordinary
+  writes to proceed after scope authorization.
 - Provide pagination/filtering for MCP list actions and output truncation for
   large MCP responses.
 - Expose the `server_summary` prompt and `unraid://schema/mcp-tool` schema
@@ -78,7 +81,7 @@ existing deployment config.
 
 | This repo owns | Unraid owns | Explicitly out of scope |
 |---|---|---|
-| MCP/CLI projection, GraphQL query selection, response shaping, pagination, auth policy, setup checks, prompt/resource metadata, and read-only safety. | NAS state, array/docker/VM behavior, GraphQL schema, Unraid API key issuance, remote access, and Connect state. | Mutations, shell execution, controller UI replacement, credential brokerage, background monitoring, multi-tenant sandboxing, and direct filesystem writes. |
+| MCP/CLI projection, GraphQL operation selection, response shaping, pagination, auth policy, elicitation policy, setup checks, and prompt/resource metadata. | NAS state, array/docker/VM behavior, GraphQL schema, Unraid API key issuance, remote access, and Connect state. | Arbitrary shell execution, controller UI replacement, credential brokerage, background monitoring, multi-tenant sandboxing, and direct local filesystem writes. |
 
 ## Install
 
@@ -367,15 +370,19 @@ HTTP MCP auth policy:
 | Mounted OAuth | `UNRAID_RMCP_AUTH_MODE=oauth` | Uses Google OAuth/JWT through `lab-auth`. |
 | Trusted gateway | `UNRAID_NOAUTH=true` | Assumes a reverse proxy or gateway already enforced auth. |
 
-All data actions are read-only. OAuth exposes `unraid:read` and `unraid:admin`
-scopes, but no mutating Unraid action is currently registered.
+Read actions require `unraid:read`; mutating actions require `unraid:admin`.
+Configured static bearer tokens are operator credentials and receive admin scope.
+OAuth clients receive the scopes granted by the authorization flow.
 
 ## Safety And Trust Model
 
 - Unraid API keys are loaded from config/env only.
-- MCP callers select read actions and filters, not upstream credentials.
-- No mutation, shell execution, filesystem write, Docker control, VM control, or
-  array-control action is exposed.
+- MCP callers select actions and arguments, not upstream credentials.
+- Destructive actions issue an MCP form-elicitation request before dispatch. A
+  decline, cancellation, malformed response, or client without elicitation support
+  stops the operation before the GraphQL request is sent.
+- Ordinary mutations remain directly available after `unraid:admin` authorization;
+  the server does not add a second confirmation parameter or disable writes.
 - `log_file` reads through the Unraid GraphQL API, not arbitrary local files.
 - Non-loopback HTTP deployments must use bearer auth, OAuth, or a trusted
   authenticated gateway.
@@ -385,12 +392,14 @@ scopes, but no mutating Unraid action is currently registered.
 ## Architecture
 
 ```text
-GraphQL queries (src/graphql.rs)  typed/read-only query construction
+GraphQL operations (src/graphql.rs)  queries + mutations
         |
-UnraidService (src/app.rs)       action behavior and response shaping
+UnraidService (src/app.rs)           action behavior and response shaping
         |
-MCP shim      (src/mcp/tools.rs) JSON args -> service -> Value
-CLI shim      (src/cli.rs)       argv -> service -> stdout
+MCP scope + elicitation              authorization and destructive approval
+        |
+MCP shim      (src/mcp/tools.rs)     JSON args -> service -> Value
+CLI shim      (src/cli.rs)           argv -> service -> stdout
 ```
 
 ## Distribution Contract

--- a/unraid-rs/src/mcp.rs
+++ b/unraid-rs/src/mcp.rs
@@ -4,6 +4,7 @@ use lab_auth::AuthLayer;
 
 use crate::{app::UnraidService, config::McpConfig, observability::Counters};
 
+mod elicitation;
 pub(crate) mod host_filter;
 mod prompts;
 mod rmcp_server;
@@ -71,7 +72,7 @@ pub fn build_auth_layer(
             AuthLayer::new()
                 .with_static_token(static_token)
                 .with_auth_state(auth_state.clone())
-                .with_static_token_scopes(vec!["unraid:read".into()])
+                .with_static_token_scopes(vec!["unraid:admin".into()])
                 .with_resource_url(resource_url)
                 .with_allow_session_cookie(false),
         ),

--- a/unraid-rs/src/mcp/elicitation.rs
+++ b/unraid-rs/src/mcp/elicitation.rs
@@ -1,0 +1,280 @@
+use rmcp::{service::ElicitationError, Peer, RoleServer};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Destructive actions shared with the Python implementation's elicitation policy.
+///
+/// This is deliberately narrower than the write-scoped action set. Ordinary state
+/// changes remain directly callable; only actions with destructive or
+/// security-boundary impact require an MCP elicitation round trip.
+pub(super) const DESTRUCTIVE_ACTIONS: &[&str] = &[
+    "api_key_delete",
+    "array_clear_array_disk_statistics",
+    "array_remove_disk_from_array",
+    "array_set_state",
+    "configure_ups",
+    "connect_sign_in",
+    "connect_sign_out",
+    "delete_archived_notifications",
+    "docker_delete_entries",
+    "docker_remove_container",
+    "enable_dynamic_remote_access",
+    "initiate_flash_backup",
+    "onboarding_create_internal_boot_pool",
+    "onboarding_reset_onboarding",
+    "remove_plugin",
+    "reset_docker_template_mappings",
+    "rclone_delete_r_clone_remote",
+    "setup_remote_access",
+    "unraid_plugins_install_language",
+    "unraid_plugins_install_plugin",
+    "update_api_settings",
+    "update_ssh_settings",
+    "update_system_time",
+    "vm_force_stop",
+    "vm_reset",
+];
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct DestructiveConfirmation {
+    /// Check the box to confirm and proceed.
+    confirmed: bool,
+}
+
+rmcp::elicit_safe!(DestructiveConfirmation);
+
+fn string_arg<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
+    args.get(key).and_then(Value::as_str)
+}
+
+fn label(args: &Value, key: &str) -> String {
+    string_arg(args, key)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unspecified")
+        .replace(['\n', '\r', '\t'], " ")
+}
+
+/// Return an elicitation description when this concrete request is destructive.
+///
+/// array_set_state is conditional: starting the array is an ordinary write,
+/// while stopping it is destructive and therefore elicits.
+pub(super) fn destructive_action_description(action: &str, args: &Value) -> Option<String> {
+    if !DESTRUCTIVE_ACTIONS.contains(&action) {
+        return None;
+    }
+
+    let description = match action {
+        "vm_force_stop" => format!(
+            "Force stop VM {}. Unsaved data may be lost.",
+            label(args, "id")
+        ),
+        "vm_reset" => format!(
+            "Hard reset VM {}. Unsaved data may be lost.",
+            label(args, "id")
+        ),
+        "docker_remove_container" => {
+            let image = args
+                .get("with_image")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            format!(
+                "Remove container {}{}. This cannot be undone.",
+                label(args, "id"),
+                if image { " and its image" } else { "" }
+            )
+        }
+        "reset_docker_template_mappings" => {
+            "Reset all Docker template path mappings to defaults. Custom path overrides will be lost."
+                .to_string()
+        }
+        "docker_delete_entries" => {
+            "Delete the specified Docker organizer entries from the layout.".to_string()
+        }
+        "array_set_state"
+            if string_arg(args, "desired_state")
+                .is_some_and(|state| state.eq_ignore_ascii_case("STOP")) =>
+        {
+            "Stop the Unraid array. Running containers and VMs may lose access to array shares."
+                .to_string()
+        }
+        "array_set_state" => return None,
+        "array_remove_disk_from_array" => format!(
+            "Remove disk {} from the array. The array must be stopped first.",
+            label(args, "id")
+        ),
+        "array_clear_array_disk_statistics" => format!(
+            "Clear all I/O statistics for disk {}. This cannot be undone.",
+            label(args, "id")
+        ),
+        "api_key_delete" => {
+            "Delete the selected API key(s). Clients using them will immediately lose access."
+                .to_string()
+        }
+        "rclone_delete_r_clone_remote" => format!(
+            "Delete rclone remote {}. This cannot be undone.",
+            label(args, "remote_name")
+        ),
+        "unraid_plugins_install_plugin" => {
+            "Install a caller-supplied .plg file. The Unraid host will fetch and run it as root."
+                .to_string()
+        }
+        "unraid_plugins_install_language" => {
+            "Install a caller-supplied language .plg file. The Unraid host will fetch and run it as root."
+                .to_string()
+        }
+        "remove_plugin" => {
+            "Remove the selected Unraid API plugin configuration. Reinstallation may be required to restore it."
+                .to_string()
+        }
+        "onboarding_reset_onboarding" => {
+            "Reset the server's onboarding state and re-trigger the first-boot setup flow."
+                .to_string()
+        }
+        "onboarding_create_internal_boot_pool" => {
+            "Create an internal boot pool. This formats the specified devices and may reboot the server."
+                .to_string()
+        }
+        "delete_archived_notifications" => {
+            "Delete all archived notifications permanently. This cannot be undone.".to_string()
+        }
+        "configure_ups" => {
+            "Overwrite the current UPS monitoring and daemon configuration.".to_string()
+        }
+        "update_ssh_settings" => {
+            "Update the SSH daemon settings. Disabling SSH or changing its port can cut off remote shell access."
+                .to_string()
+        }
+        "update_system_time" => {
+            "Update system time or NTP configuration. Clock changes can disrupt TLS and time-sensitive services."
+                .to_string()
+        }
+        "connect_sign_in" => {
+            "Sign this server in to Unraid Connect, registering it with the cloud service and enabling remote management."
+                .to_string()
+        }
+        "connect_sign_out" => {
+            "Sign this server out of Unraid Connect. Connect-based remote access will stop working."
+                .to_string()
+        }
+        "update_api_settings" => {
+            "Change the Unraid Connect remote-access configuration, affecting internet reachability."
+                .to_string()
+        }
+        "setup_remote_access" => {
+            "Reconfigure Unraid Connect remote access. This can expose the server through UPnP or port forwarding."
+                .to_string()
+        }
+        "enable_dynamic_remote_access" => {
+            "Change dynamic remote access for Unraid Connect, altering how the server is reachable remotely."
+                .to_string()
+        }
+        "initiate_flash_backup" => {
+            "Start a flash-drive backup. Existing data at the configured backup destination may be overwritten."
+                .to_string()
+        }
+        _ => return None,
+    };
+    Some(description)
+}
+
+/// Require the MCP client to elicit explicit user approval for destructive calls.
+///
+/// There is no tool argument bypass. If the client does not advertise form
+/// elicitation, the user declines/cancels, or the response is malformed, the
+/// destructive operation does not reach the Unraid API.
+pub(super) async fn require_destructive_elicitation(
+    peer: &Peer<RoleServer>,
+    action: &str,
+    args: &Value,
+) -> Result<(), String> {
+    let Some(description) = destructive_action_description(action, args) else {
+        return Ok(());
+    };
+
+    let message = format!(
+        "Confirm destructive Unraid action: {action}\n\n{description}\n\nCheck the confirmation box to proceed."
+    );
+
+    match peer.elicit::<DestructiveConfirmation>(message).await {
+        Ok(Some(response)) if response.confirmed => {
+            tracing::info!(action, "destructive action approved via MCP elicitation");
+            Ok(())
+        }
+        Ok(Some(_)) | Ok(None) => Err(format!(
+            "Action '{action}' was not confirmed through MCP elicitation."
+        )),
+        Err(ElicitationError::UserDeclined) => {
+            Err(format!("Action '{action}' was declined by the user."))
+        }
+        Err(ElicitationError::UserCancelled) => {
+            Err(format!("Action '{action}' was cancelled by the user."))
+        }
+        Err(ElicitationError::CapabilityNotSupported) => Err(format!(
+            "Action '{action}' requires MCP form elicitation, but the connected client did not advertise elicitation support."
+        )),
+        Err(error) => Err(format!(
+            "Action '{action}' could not obtain MCP elicitation approval: {error}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::mcp::schemas::{Scope, ACTIONS};
+
+    #[test]
+    fn destructive_registry_is_unique_and_write_scoped() {
+        let unique: HashSet<_> = DESTRUCTIVE_ACTIONS.iter().copied().collect();
+        assert_eq!(unique.len(), DESTRUCTIVE_ACTIONS.len());
+
+        for action in DESTRUCTIVE_ACTIONS {
+            let spec = ACTIONS
+                .iter()
+                .find(|candidate| candidate.name == *action)
+                .unwrap_or_else(|| panic!("destructive action {action} is not registered"));
+            assert_eq!(spec.scope, Scope::Write, "{action} must be write-scoped");
+        }
+    }
+
+    #[test]
+    fn array_stop_elicits_but_start_does_not() {
+        assert!(destructive_action_description(
+            "array_set_state",
+            &json!({"desired_state": "STOP"})
+        )
+        .is_some());
+        assert!(destructive_action_description(
+            "array_set_state",
+            &json!({"desired_state": "START"})
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn ordinary_mutations_do_not_elicit() {
+        assert!(destructive_action_description("vm_stop", &json!({"id": "vm-1"})).is_none());
+        assert!(destructive_action_description("docker_restart", &json!({"id": "c-1"})).is_none());
+        assert!(destructive_action_description("api_key_update", &json!({})).is_none());
+    }
+
+    #[test]
+    fn every_static_destructive_action_has_a_prompt() {
+        for action in DESTRUCTIVE_ACTIONS {
+            let args = if *action == "array_set_state" {
+                json!({"desired_state": "STOP"})
+            } else {
+                json!({})
+            };
+            assert!(
+                destructive_action_description(action, &args).is_some(),
+                "{action} has no elicitation description"
+            );
+        }
+    }
+}

--- a/unraid-rs/src/mcp/rmcp_server.rs
+++ b/unraid-rs/src/mcp/rmcp_server.rs
@@ -19,6 +19,7 @@ use serde_json::{Map, Value};
 use crate::config::McpConfig;
 
 use super::{
+    elicitation::require_destructive_elicitation,
     host_filter::{allowed_hosts, allowed_origins},
     prompts,
     schemas::{tool_definitions, ACTIONS},
@@ -85,6 +86,21 @@ impl ServerHandler for UnraidRmcpServer {
         // `tools::dispatch`). Covers pre-dispatch validation and serialization errors.
         self.state.counters.inc_requests();
         tracing::info!(tool = %tool_name, action = %action, "MCP tool execution started");
+
+        if let Err(message) =
+            require_destructive_elicitation(&context.peer, &action, &arguments).await
+        {
+            let elapsed = started.elapsed().as_millis();
+            self.state.counters.inc_errors();
+            tracing::warn!(
+                tool = %tool_name,
+                action = %action,
+                elapsed_ms = elapsed,
+                reason = %message,
+                "MCP destructive action stopped by elicitation"
+            );
+            return Ok(CallToolResult::error(vec![Content::text(message)]));
+        }
 
         // All errors become agent-readable CallToolResult::error — never Err(ErrorData).
         // This keeps the MCP session alive even when the upstream Unraid API is down.

--- a/unraid-rs/src/mcp/schemas.rs
+++ b/unraid-rs/src/mcp/schemas.rs
@@ -17,7 +17,7 @@ pub(super) struct ActionSpec {
 
 /// Scope an action requires. `unraid:admin` satisfies `unraid:read`, so a
 /// read-scoped token cannot reach a [`Scope::Write`] (mutating) action.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Scope {
     /// No scope required (the `help` meta action).
     None,

--- a/unraid-rs/tests/auth_modes.rs
+++ b/unraid-rs/tests/auth_modes.rs
@@ -31,6 +31,19 @@ fn jsonrpc_body(method: &str) -> Vec<u8> {
     .unwrap()
 }
 
+fn tool_call_body(arguments: serde_json::Value) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "unraid",
+            "arguments": arguments,
+        },
+    }))
+    .unwrap()
+}
+
 async fn get_status(app: axum::Router, uri: &str) -> StatusCode {
     let req = Request::builder()
         .method("GET")
@@ -339,4 +352,65 @@ async fn jwks_response_body_has_keys_array() {
         .as_array()
         .expect("JWKS must have a 'keys' array");
     assert!(!keys.is_empty(), "JWKS 'keys' array must be non-empty");
+}
+
+// ── bearer mutation scope + elicitation contract ─────────────────────────────
+
+/// A configured static bearer token is an operator credential. It must carry
+/// unraid:admin so the advertised mutation surface is reachable; ordinary writes
+/// remain direct and fail here only because the test upstream is intentionally down.
+#[tokio::test]
+async fn static_bearer_token_reaches_ordinary_write_dispatch() {
+    let state = testing::bearer_state("admin-token");
+    let (status, value) = post_mcp(
+        router(state),
+        tool_call_body(serde_json::json!({
+            "action": "create_notification",
+            "title": "Test",
+            "subject": "Bearer mutation scope",
+            "description": "Contract test",
+            "importance": "INFO"
+        })),
+        Some("admin-token"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let body = value.to_string();
+    assert!(
+        !body.contains("forbidden") && !body.contains("requires scope: unraid:admin"),
+        "static bearer token must carry admin scope; got: {body}"
+    );
+    assert!(
+        body.contains("upstream unreachable"),
+        "ordinary write should reach dispatch and fail only at the stub upstream; got: {body}"
+    );
+}
+
+/// Destructive writes still require MCP elicitation after bearer authorization.
+/// A raw HTTP caller that did not advertise form elicitation must fail closed
+/// before the GraphQL mutation is attempted.
+#[tokio::test]
+async fn destructive_write_without_elicitation_capability_fails_closed() {
+    let state = testing::bearer_state("admin-token");
+    let (status, value) = post_mcp(
+        router(state),
+        tool_call_body(serde_json::json!({
+            "action": "vm_reset",
+            "id": "vm-1"
+        })),
+        Some("admin-token"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let body = value.to_string();
+    assert!(
+        body.contains("requires MCP form elicitation"),
+        "destructive write must require client elicitation capability; got: {body}"
+    );
+    assert!(
+        !body.contains("upstream unreachable"),
+        "destructive write must stop before GraphQL dispatch; got: {body}"
+    );
 }

--- a/unraid-rs/tests/stdio_mcp.rs
+++ b/unraid-rs/tests/stdio_mcp.rs
@@ -1,9 +1,19 @@
-use std::process::Stdio;
+use std::{
+    process::Stdio,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use rmcp::{
-    model::CallToolRequestParams,
-    service::ServiceExt,
+    model::{
+        CallToolRequestParams, ClientCapabilities, ClientInfo, CreateElicitationRequestParams,
+        CreateElicitationResult, ElicitationAction, Implementation,
+    },
+    service::{RequestContext, RoleClient, RunningService, ServiceExt},
     transport::{ConfigureCommandExt, TokioChildProcess},
+    ClientHandler, ErrorData,
 };
 use serde_json::json;
 use tempfile::TempDir;
@@ -12,9 +22,21 @@ use tokio::{io::AsyncReadExt, process::Command};
 async fn stdio_client(
     _db_path: &std::path::Path,
 ) -> anyhow::Result<(
-    rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    RunningService<RoleClient, ()>,
     Option<tokio::process::ChildStderr>,
 )> {
+    stdio_client_with_handler(()).await
+}
+
+async fn stdio_client_with_handler<H>(
+    handler: H,
+) -> anyhow::Result<(
+    RunningService<RoleClient, H>,
+    Option<tokio::process::ChildStderr>,
+)>
+where
+    H: ClientHandler,
+{
     let binary = env!("CARGO_BIN_EXE_runraid");
     let (transport, stderr) = TokioChildProcess::builder(Command::new(binary).configure(|cmd| {
         cmd.arg("mcp")
@@ -26,16 +48,93 @@ async fn stdio_client(
     }))
     .stderr(Stdio::piped())
     .spawn()?;
-    let service = ().serve(transport).await?;
+    let service = handler.serve(transport).await?;
     Ok((service, stderr))
 }
 
-fn text_content_json(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+fn text_content(result: &rmcp::model::CallToolResult) -> String {
     let value = serde_json::to_value(result).expect("tool result should serialize");
-    let text = value["content"][0]["text"]
+    value["content"][0]["text"]
         .as_str()
-        .expect("tool result should contain text content");
-    serde_json::from_str(text).expect("tool text content should be JSON")
+        .expect("tool result should contain text content")
+        .to_string()
+}
+
+fn text_content_json(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    serde_json::from_str(&text_content(result)).expect("tool text content should be JSON")
+}
+
+#[derive(Clone, Copy)]
+enum ElicitationDecision {
+    Accept,
+    Decline,
+}
+
+#[derive(Clone)]
+struct ElicitingClient {
+    decision: ElicitationDecision,
+    calls: Arc<AtomicUsize>,
+}
+
+impl ElicitingClient {
+    fn new(decision: ElicitationDecision, calls: Arc<AtomicUsize>) -> Self {
+        Self { decision, calls }
+    }
+}
+
+impl ClientHandler for ElicitingClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::builder()
+                .enable_elicitation()
+                .enable_elicitation_schema_validation()
+                .build(),
+            Implementation::new("unraid-rmcp-test-client", "1.0.0"),
+        )
+    }
+
+    async fn create_elicitation(
+        &self,
+        _request: CreateElicitationRequestParams,
+        _context: RequestContext<RoleClient>,
+    ) -> Result<CreateElicitationResult, ErrorData> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let mut result = match self.decision {
+            ElicitationDecision::Accept => CreateElicitationResult::new(ElicitationAction::Accept),
+            ElicitationDecision::Decline => {
+                CreateElicitationResult::new(ElicitationAction::Decline)
+            }
+        };
+        if matches!(self.decision, ElicitationDecision::Accept) {
+            result.content = Some(json!({"confirmed": true}));
+        }
+        Ok(result)
+    }
+}
+
+async fn cancel_and_drain<H: ClientHandler>(
+    service: RunningService<RoleClient, H>,
+    stderr: Option<tokio::process::ChildStderr>,
+) {
+    service.cancel().await.unwrap();
+
+    if let Some(mut stderr) = stderr {
+        let mut logs = String::new();
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            stderr.read_to_string(&mut logs),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => panic!("failed to read stdio child stderr: {error}"),
+            Err(_) => panic!("stdio child stderr did not close after cancellation"),
+        }
+        assert!(
+            !logs.contains("unraid listener") && !logs.contains("MCP server listening"),
+            "stdio mode must not start network services; stderr was: {logs}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -68,23 +167,93 @@ async fn stdio_child_process_lists_tools_and_calls_queries() {
     let help = text_content_json(&help);
     assert!(help["help"].as_str().unwrap_or("").contains("unraid"));
 
-    service.cancel().await.unwrap();
+    cancel_and_drain(service, stderr).await;
+}
 
-    if let Some(mut stderr) = stderr {
-        let mut logs = String::new();
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            stderr.read_to_string(&mut logs),
+#[tokio::test]
+async fn destructive_action_acceptance_reaches_dispatch() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let client = ElicitingClient::new(ElicitationDecision::Accept, calls.clone());
+    let (service, stderr) = stdio_client_with_handler(client).await.unwrap();
+
+    let result = service
+        .call_tool(
+            CallToolRequestParams::new("unraid").with_arguments(
+                json!({"action": "vm_reset", "id": "vm-1"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
         )
         .await
-        {
-            Ok(Ok(_)) => {}
-            Ok(Err(error)) => panic!("failed to read stdio child stderr: {error}"),
-            Err(_) => panic!("stdio child stderr did not close after cancellation"),
-        }
-        assert!(
-            !logs.contains("unraid listener") && !logs.contains("MCP server listening"),
-            "stdio mode must not start network services; stderr was: {logs}"
-        );
-    }
+        .unwrap();
+    let text = text_content(&result);
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(
+        text.contains("upstream unreachable"),
+        "accepted destructive action should reach GraphQL dispatch; got: {text}"
+    );
+
+    cancel_and_drain(service, stderr).await;
+}
+
+#[tokio::test]
+async fn destructive_action_decline_stops_before_dispatch() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let client = ElicitingClient::new(ElicitationDecision::Decline, calls.clone());
+    let (service, stderr) = stdio_client_with_handler(client).await.unwrap();
+
+    let result = service
+        .call_tool(
+            CallToolRequestParams::new("unraid").with_arguments(
+                json!({"action": "vm_reset", "id": "vm-1"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .unwrap();
+    let text = text_content(&result);
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(
+        text.contains("declined by the user"),
+        "declined destructive action must stop at elicitation; got: {text}"
+    );
+    assert!(
+        !text.contains("upstream unreachable"),
+        "declined action must not reach GraphQL dispatch; got: {text}"
+    );
+
+    cancel_and_drain(service, stderr).await;
+}
+
+#[tokio::test]
+async fn ordinary_mutation_does_not_elicit() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let client = ElicitingClient::new(ElicitationDecision::Decline, calls.clone());
+    let (service, stderr) = stdio_client_with_handler(client).await.unwrap();
+
+    let result = service
+        .call_tool(
+            CallToolRequestParams::new("unraid").with_arguments(
+                json!({"action": "vm_stop", "id": "vm-1"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .unwrap();
+    let text = text_content(&result);
+
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert!(
+        text.contains("upstream unreachable"),
+        "ordinary mutation should reach dispatch without elicitation; got: {text}"
+    );
+
+    cancel_and_drain(service, stderr).await;
 }


### PR DESCRIPTION
## Summary

- preserve the full Rust mutation surface
- add MCP form elicitation for destructive Rust actions
- grant configured static bearer tokens admin scope so ordinary mutations are reachable
- correct Rust documentation that incorrectly described the server as read-only
- isolate release-please to Python and Rust with the monorepo bootstrap boundary
- add fixed-width CalVer tooling and validation for Incus and Codex plugin releases

## Verification

- Rust formatting passed
- Clippy with warnings denied passed
- full Rust test suite passed
- 18 HTTP auth tests passed
- 4 stdio elicitation tests passed
- 7 release-tool tests passed
- release contract and plugin version-ordering checks passed
