### PR TITLE
fix: repair npm release contract

### DIFF
--- a/.github/scripts/release_contract.py
+++ b/.github/scripts/release_contract.py
@@ -93,14 +93,37 @@ def validate_release_please(repo_root: Path, errors: list[str]) -> list[ReleaseU
         "unraid-rs must produce unraid-rs-vX.Y.Z tags",
         errors,
     )
+    rust_extra_files = {
+        (entry.get("path"), entry.get("jsonpath"))
+        for entry in rust_cfg.get("extra-files", [])
+        if isinstance(entry, dict)
+    }
+    assert_true(
+        ("packages/unraid-rmcp/package.json", "$.binaryVersion") in rust_extra_files,
+        "release-please must update the npm launcher's binaryVersion",
+        errors,
+    )
 
     pyproject = tomllib.loads((repo_root / "unraid-py/pyproject.toml").read_text())
     cargo = tomllib.loads((repo_root / "unraid-rs/Cargo.toml").read_text())
+    npm_package = json.loads(
+        (repo_root / "unraid-rs/packages/unraid-rmcp/package.json").read_text()
+    )
     versions = {
         "unraid-py": pyproject["project"]["version"],
         "unraid-rs": cargo["package"]["version"],
     }
     tag_prefixes = {"unraid-py": "v", "unraid-rs": "unraid-rs-v"}
+    assert_true(
+        npm_package.get("version") == versions["unraid-rs"],
+        f"npm package version {npm_package.get('version')} != Rust {versions['unraid-rs']}",
+        errors,
+    )
+    assert_true(
+        npm_package.get("binaryVersion") == versions["unraid-rs"],
+        f"npm binaryVersion {npm_package.get('binaryVersion')} != Rust {versions['unraid-rs']}",
+        errors,
+    )
 
     units: list[ReleaseUnit] = []
     for name in sorted(RELEASE_PLEASE_PACKAGES):

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -11,12 +11,23 @@ name: rust-release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing unraid-rs-vX.Y.Z release tag to publish
+        required: true
+        type: string
+      source_ref:
+        description: Source ref containing the corrected npm package metadata
+        required: true
+        default: main
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: rust-release-${{ github.event.release.tag_name }}
+  group: rust-release-${{ github.event.release.tag_name || inputs.tag }}
   cancel-in-progress: false
 
 env:
@@ -33,7 +44,7 @@ defaults:
 
 jobs:
   build:
-    if: startsWith(github.event.release.tag_name, 'unraid-rs-v')
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'unraid-rs-v')
     runs-on: [self-hosted, unraid]
     permissions:
       contents: write
@@ -81,21 +92,34 @@ jobs:
 
   npm:
     needs: build
-    if: startsWith(github.event.release.tag_name, 'unraid-rs-v')
-    runs-on: [self-hosted, unraid]
+    if: >-
+      always() &&
+      (
+        (github.event_name == 'release' && needs.build.result == 'success' &&
+          startsWith(github.event.release.tag_name, 'unraid-rs-v')) ||
+        (github.event_name == 'workflow_dispatch' &&
+          startsWith(inputs.tag, 'unraid-rs-v'))
+      )
+    # npm trusted publishing supports GitHub-hosted runners only.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     env:
-      TAG: ${{ github.event.release.tag_name }}
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+      SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ env.SOURCE_REF }}
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Install npm with trusted-publishing support
+        run: npm install --global npm@11.5.1
 
       - name: Verify npm package version matches release tag
         id: npm-version
@@ -114,20 +138,19 @@ jobs:
         run: npm run check --prefix packages/unraid-rmcp
 
       - name: Publish npm package if not already present
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           version="${{ steps.npm-version.outputs.version }}"
           if npm view "unraid-rmcp@${version}" version >/dev/null 2>&1; then
             echo "unraid-rmcp@${version} already published; skipping."
           else
-            npm publish --provenance --access public ./packages/unraid-rmcp
+            # OIDC trusted publishing generates provenance automatically.
+            npm publish --access public ./packages/unraid-rmcp
           fi
 
   docker:
     needs: build
-    if: startsWith(github.event.release.tag_name, 'unraid-rs-v')
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'unraid-rs-v')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,10 @@ The Python server's detailed dev guide is `unraid-py/CLAUDE.md`.
   `unraid-py` and `unraid-rs`; its `bootstrap-sha` pins history to the monorepo
   consolidation boundary so imported `Release-As:` directives cannot poison new
   release PRs. Python uses unprefixed `vX.Y.Z` tags and Rust uses
-  `unraid-rs-vX.Y.Z`. Incus and Codex use `.github/scripts/plugin_calver.py` and
+  `unraid-rs-vX.Y.Z`. Rust release-please must update both `version` and
+  `binaryVersion` in the npm launcher; `rust-release.yml` publishes npm through
+  GitHub-hosted OIDC trusted publishing. Incus and Codex use
+  `.github/scripts/plugin_calver.py` and
   fixed-width `YYYYMMDD.NNN` versions with `incus-v*` / `codex-v*` tags. Unraid
   compares plugin versions as raw strings, so fixed width is mandatory.
   `.github/scripts/release_contract.py` and `check-plg-version-ordering.sh` run in

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,7 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "packages/unraid-rmcp/package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "packages/unraid-rmcp/package.json", "jsonpath": "$.binaryVersion" },
         { "type": "json", "path": "server.json", "jsonpath": "$.version" },
         { "type": "json", "path": "server.json", "jsonpath": "$.packages[0].version" },
         {

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -404,13 +404,14 @@ CLI shim      (src/cli.rs)           argv -> service -> stdout
 
 ## Distribution Contract
 
-- `Cargo.toml`, `Cargo.lock`, `packages/unraid-rmcp/package.json`,
-  `.release-please-manifest.json`, and `server.json` must agree on the released
-  version.
+- `Cargo.toml`, `Cargo.lock`, both `version` and `binaryVersion` in
+  `packages/unraid-rmcp/package.json`, `.release-please-manifest.json`, agent
+  manifests, and `server.json` must agree on the released version.
 - GitHub Releases publish the linux/amd64 `runraid` binary consumed by the npm
   launcher.
 - The npm package name is `unraid-rmcp`; binary aliases are `unraid-rmcp` and
-  `runraid`.
+  `runraid`. Publishing runs from `.github/workflows/rust-release.yml` on a
+  GitHub-hosted runner using npm OIDC trusted publishing.
 - Docker/OCI metadata uses `ghcr.io/dinglebear-ai/runraid:<version>`.
 - `agents/unraid-rs/.mcp.json` must launch `npx -y unraid-rmcp mcp` so stdio
   clients start the MCP transport rather than the HTTP server.

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -404,13 +404,14 @@ CLI shim      (src/cli.rs)           argv -> service -> stdout
 
 ## Distribution Contract
 
-- `Cargo.toml`, `Cargo.lock`, `packages/unraid-rmcp/package.json`,
-  `.release-please-manifest.json`, and `server.json` must agree on the released
-  version.
+- `Cargo.toml`, `Cargo.lock`, both `version` and `binaryVersion` in
+  `packages/unraid-rmcp/package.json`, `.release-please-manifest.json`, agent
+  manifests, and `server.json` must agree on the released version.
 - GitHub Releases publish the linux/amd64 `runraid` binary consumed by the npm
   launcher.
 - The npm package name is `unraid-rmcp`; binary aliases are `unraid-rmcp` and
-  `runraid`.
+  `runraid`. Publishing runs from `.github/workflows/rust-release.yml` on a
+  GitHub-hosted runner using npm OIDC trusted publishing.
 - Docker/OCI metadata uses `ghcr.io/dinglebear-ai/runraid:<version>`.
 - `agents/unraid-rs/.mcp.json` must launch `npx -y unraid-rmcp mcp` so stdio
   clients start the MCP transport rather than the HTTP server.

--- a/unraid-rs/packages/unraid-rmcp/lib/platform.js
+++ b/unraid-rs/packages/unraid-rmcp/lib/platform.js
@@ -14,10 +14,7 @@ function targetFor(platform = process.platform, arch = process.arch) {
   if (platform === "linux" && arch === "x64") {
     return { asset: "runraid-x86_64.tar.gz", binary: "runraid" };
   }
-  if (platform === "win32" && arch === "x64") {
-    return { asset: "runraid-windows-x86_64.tar.gz", binary: "runraid.exe" };
-  }
-  throw new Error(`Unsupported platform ${platform}/${arch}. Supported targets: linux/x64, win32/x64.`);
+  throw new Error(`Unsupported platform ${platform}/${arch}. Supported target: linux/x64.`);
 }
 
 // Release tags in the unraid-mcp monorepo are component-prefixed: the Rust

--- a/unraid-rs/packages/unraid-rmcp/package.json
+++ b/unraid-rs/packages/unraid-rmcp/package.json
@@ -55,7 +55,7 @@
     "oauth"
   ],
   "mcpName": "ai.dinglebear/unraid-rmcp",
-  "binaryVersion": "0.2.2",
+  "binaryVersion": "0.2.4",
   "author": {
     "name": "dinglebear.ai",
     "url": "https://dinglebear.ai"

--- a/unraid-rs/packages/unraid-rmcp/test/platform.test.js
+++ b/unraid-rs/packages/unraid-rmcp/test/platform.test.js
@@ -5,9 +5,11 @@ const { binaryVersion, downloadUrl, releaseBaseUrl, releaseVersion, targetFor } 
 const { binaryVersion: pinnedBinaryVersion } = require("../package.json");
 test("maps supported platforms to release assets", () => {
   assert.deepEqual(targetFor("linux", "x64"), { asset: "runraid-x86_64.tar.gz", binary: "runraid" });
-  assert.deepEqual(targetFor("win32", "x64"), { asset: "runraid-windows-x86_64.tar.gz", binary: "runraid.exe" });
 });
-test("rejects unsupported platforms", () => { assert.throws(() => targetFor("darwin", "arm64"), /Unsupported platform/); });
+test("rejects unsupported platforms", () => {
+  assert.throws(() => targetFor("win32", "x64"), /Unsupported platform/);
+  assert.throws(() => targetFor("darwin", "arm64"), /Unsupported platform/);
+});
 test("uses pinned binary version as the binary tag by default", () => {
   assert.equal(binaryVersion(), pinnedBinaryVersion);
   assert.equal(releaseVersion({}), `unraid-rs-v${pinnedBinaryVersion}`);

--- a/unraid-rs/scripts/check-version-sync.sh
+++ b/unraid-rs/scripts/check-version-sync.sh
@@ -15,10 +15,20 @@ if [ -f "Cargo.toml" ]; then
   [ -n "$v" ] && versions+=("Cargo.toml=$v") && files_checked+=("Cargo.toml")
 fi
 
-if [ -f "package.json" ]; then
-  v=$(python3 -c "import json; print(json.load(open('package.json')).get('version',''))" 2>/dev/null)
-  [ -n "$v" ] && versions+=("package.json=$v") && files_checked+=("package.json")
+npm_manifest="packages/unraid-rmcp/package.json"
+if [ ! -f "$npm_manifest" ]; then
+  echo "[version-sync] FAIL — expected npm manifest is missing: $npm_manifest" >&2
+  exit 1
 fi
+for field in version binaryVersion; do
+  v=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get(sys.argv[2],''))" "$npm_manifest" "$field" 2>/dev/null)
+  if [ -z "$v" ]; then
+    echo "[version-sync] FAIL — $npm_manifest has no $field field" >&2
+    exit 1
+  fi
+  versions+=("$npm_manifest.$field=$v")
+  files_checked+=("$npm_manifest.$field")
+done
 
 if [ -f "pyproject.toml" ]; then
   v=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)".*/\1/')


### PR DESCRIPTION
Summary: manage and validate npm binaryVersion, align the launcher with the Linux artifact surface, move npm publication to GitHub-hosted OIDC trusted publishing, and add a manual repair path for an existing Rust release tag. Validation: release contract and unit tests, six-carrier version sync, npm tests and live asset validation, workflow linting, action policies, and diff checks.