### PR TITLE
fix: repair Rust container publication

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -18,10 +18,20 @@ on:
         required: true
         type: string
       source_ref:
-        description: Source ref containing the corrected npm package metadata
+        description: Source ref containing corrected release metadata
         required: true
         default: main
         type: string
+      publish_npm:
+        description: Publish the npm launcher (requires configured npm trusted publishing)
+        required: true
+        default: false
+        type: boolean
+      publish_docker:
+        description: Publish the Rust container image
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -35,8 +45,8 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   # Distinct from the Python server image (ghcr.io/<owner>/unraid-mcp) to avoid
-  # a tag collision.
-  RUST_IMAGE: ghcr.io/${{ github.repository_owner }}/runraid
+  # a tag collision and owned by this monorepo rather than the legacy runraid repo.
+  RUST_IMAGE: ghcr.io/${{ github.repository_owner }}/unraid-rmcp
 
 defaults:
   run:
@@ -96,8 +106,9 @@ jobs:
       always() &&
       (
         (github.event_name == 'release' && needs.build.result == 'success' &&
+          vars.NPM_TRUSTED_PUBLISHING_ENABLED == 'true' &&
           startsWith(github.event.release.tag_name, 'unraid-rs-v')) ||
-        (github.event_name == 'workflow_dispatch' &&
+        (github.event_name == 'workflow_dispatch' && inputs.publish_npm &&
           startsWith(inputs.tag, 'unraid-rs-v'))
       )
     # npm trusted publishing supports GitHub-hosted runners only.
@@ -150,17 +161,26 @@ jobs:
 
   docker:
     needs: build
-    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'unraid-rs-v')
+    if: >-
+      always() &&
+      (
+        (github.event_name == 'release' && needs.build.result == 'success' &&
+          startsWith(github.event.release.tag_name, 'unraid-rs-v')) ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish_docker &&
+          startsWith(inputs.tag, 'unraid-rs-v'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     env:
-      TAG: ${{ github.event.release.tag_name }}
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+      SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ env.SOURCE_REF }}
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Log in to GitHub Container Registry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,9 @@ The Python server's detailed dev guide is `unraid-py/CLAUDE.md`.
   release PRs. Python uses unprefixed `vX.Y.Z` tags and Rust uses
   `unraid-rs-vX.Y.Z`. Rust release-please must update both `version` and
   `binaryVersion` in the npm launcher; `rust-release.yml` publishes npm through
-  GitHub-hosted OIDC trusted publishing. Incus and Codex use
+  GitHub-hosted OIDC trusted publishing only when the
+  `NPM_TRUSTED_PUBLISHING_ENABLED` repository variable is true, and publishes the
+  Rust image as `ghcr.io/dinglebear-ai/unraid-rmcp`. Incus and Codex use
   `.github/scripts/plugin_calver.py` and
   fixed-width `YYYYMMDD.NNN` versions with `incus-v*` / `codex-v*` tags. Unraid
   compares plugin versions as raw strings, so fixed width is mandatory.

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -411,8 +411,10 @@ CLI shim      (src/cli.rs)           argv -> service -> stdout
   launcher.
 - The npm package name is `unraid-rmcp`; binary aliases are `unraid-rmcp` and
   `runraid`. Publishing runs from `.github/workflows/rust-release.yml` on a
-  GitHub-hosted runner using npm OIDC trusted publishing.
-- Docker/OCI metadata uses `ghcr.io/dinglebear-ai/runraid:<version>`.
+  GitHub-hosted runner using npm OIDC trusted publishing. Automatic npm
+  publishing is enabled only when the `NPM_TRUSTED_PUBLISHING_ENABLED` repository
+  variable is `true`.
+- Docker/OCI metadata uses `ghcr.io/dinglebear-ai/unraid-rmcp:<version>`.
 - `agents/unraid-rs/.mcp.json` must launch `npx -y unraid-rmcp mcp` so stdio
   clients start the MCP transport rather than the HTTP server.
 - The root README is curated. `docs/INVENTORY.md` is the curated inventory for

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -411,8 +411,10 @@ CLI shim      (src/cli.rs)           argv -> service -> stdout
   launcher.
 - The npm package name is `unraid-rmcp`; binary aliases are `unraid-rmcp` and
   `runraid`. Publishing runs from `.github/workflows/rust-release.yml` on a
-  GitHub-hosted runner using npm OIDC trusted publishing.
-- Docker/OCI metadata uses `ghcr.io/dinglebear-ai/runraid:<version>`.
+  GitHub-hosted runner using npm OIDC trusted publishing. Automatic npm
+  publishing is enabled only when the `NPM_TRUSTED_PUBLISHING_ENABLED` repository
+  variable is `true`.
+- Docker/OCI metadata uses `ghcr.io/dinglebear-ai/unraid-rmcp:<version>`.
 - `agents/unraid-rs/.mcp.json` must launch `npx -y unraid-rmcp mcp` so stdio
   clients start the MCP transport rather than the HTTP server.
 - The root README is curated. `docs/INVENTORY.md` is the curated inventory for


### PR DESCRIPTION
Summary: move the Rust image to the monorepo-owned ghcr.io/dinglebear-ai/unraid-rmcp package, add explicit npm and Docker manual-repair switches, and keep automatic npm publishing disabled until trusted publishing is configured. Validation: workflow YAML, actionlint, release contract, six-carrier version sync, npm package checks, action policies, and diff checks.