### PR TITLE
chore: repoint repo self-references to dinglebear-ai/unraid

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,8 +17,8 @@
         "email": "jmagar@users.noreply.github.com",
         "url": "https://github.com/jmagar"
       },
-      "homepage": "https://github.com/dinglebear-ai/unraid-mcp",
-      "repository": "https://github.com/dinglebear-ai/unraid-mcp",
+      "homepage": "https://github.com/dinglebear-ai/unraid",
+      "repository": "https://github.com/dinglebear-ai/unraid",
       "license": "MIT",
       "category": "infrastructure",
       "keywords": [
@@ -40,8 +40,8 @@
         "email": "jmagar@users.noreply.github.com",
         "url": "https://github.com/jmagar"
       },
-      "homepage": "https://github.com/dinglebear-ai/unraid-mcp",
-      "repository": "https://github.com/dinglebear-ai/unraid-mcp",
+      "homepage": "https://github.com/dinglebear-ai/unraid",
+      "repository": "https://github.com/dinglebear-ai/unraid",
       "license": "MIT",
       "category": "infrastructure",
       "keywords": [

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -43,6 +43,11 @@ useDefault = true
 [allowlist]
 description = "Specific docs, generated wiki, and test files that contain placeholder credentials only"
 paths = [
+  # Frozen vendored copy of lab-auth. Its #[cfg(test)] module carries a
+  # TEST_RSA_KEY_PEM keypair used only to sign JWTs in unit tests
+  # (test_rsa_key/test_encoding_key). Ships to crates.io with the crate, as it
+  # does upstream. No path predates the vendoring, so this matches the one file.
+  '''(^|/)crates/lab\-auth/src/authorize\.rs$''',
   '''(^|/)docs/AUTHENTICATION\.md$''',
   '''(^|/)docs/UNRAID_API_REFERENCE\.md$''',
   '''(^|/)docs/unraid/unraid\-os/system\-administration/advanced\-tools/command\-line\-interface\.md$''',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code (claude.ai/code) working in this repository.
 
 ## What this is
 
-A monorepo of Unraid tooling. It keeps the `dinglebear-ai/unraid-mcp` GitHub
+A monorepo of Unraid tooling. It keeps the `dinglebear-ai/unraid` GitHub
 identity and the `unraid-mcp` PyPI name, but internally hosts four release units
 plus two agent-plugin integrations.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- mcp-name: tv.tootie/unraid-mcp -->
 
-[![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-dinglebear--ai%2Funraid--mcp-blue?logo=docker)](https://github.com/dinglebear-ai/unraid-mcp/pkgs/container/unraid-mcp)
+[![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-dinglebear--ai%2Funraid--mcp-blue?logo=docker)](https://github.com/dinglebear-ai/unraid/pkgs/container/unraid-mcp)
 
 A monorepo of Unraid tooling: two MCP servers (Python and Rust) and three Unraid
 OS plugins, plus the Claude/Codex agent integrations that surface them.
@@ -22,7 +22,7 @@ OS plugins, plus the Claude/Codex agent integrations that surface them.
 ## Install the agent plugins (one marketplace command, two manifests)
 
 ```text
-/plugin marketplace add dinglebear-ai/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 /plugin install unraid-mcp@unraid-mcp   # Python server
 /plugin install runraid@unraid-mcp      # Rust server
 ```

--- a/agents/unraid-py/.claude-plugin/README.md
+++ b/agents/unraid-py/.claude-plugin/README.md
@@ -9,7 +9,7 @@ Query, monitor, and manage Unraid servers via GraphQL API using a single consoli
 ## Installation
 
 ```bash
-/plugin marketplace add dinglebear-ai/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 /plugin install unraid-mcp@unraid-mcp
 ```
 
@@ -274,7 +274,7 @@ action list, call `unraid(action="help")` or see `unraid-py/docs/mcp/TOOLS.md`.
 
 ## Support
 
-- **Issues:** https://github.com/dinglebear-ai/unraid-mcp/issues
-- **Repository:** https://github.com/dinglebear-ai/unraid-mcp
+- **Issues:** https://github.com/dinglebear-ai/unraid/issues
+- **Repository:** https://github.com/dinglebear-ai/unraid
 - **Skill docs:** `skills/unraid/SKILL.md`
 - **API reference:** `skills/unraid/references/`

--- a/agents/unraid-py/.claude-plugin/plugin.json
+++ b/agents/unraid-py/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "name": "Jacob Magar",
     "email": "jmagar@users.noreply.github.com"
   },
-  "repository": "https://github.com/dinglebear-ai/unraid-mcp",
-  "homepage": "https://github.com/dinglebear-ai/unraid-mcp",
+  "repository": "https://github.com/dinglebear-ai/unraid",
+  "homepage": "https://github.com/dinglebear-ai/unraid",
   "license": "MIT",
   "keywords": [
     "unraid",

--- a/agents/unraid-py/.codex-plugin/plugin.json
+++ b/agents/unraid-py/.codex-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "unraid-mcp",
   "version": "2.8.0",
   "description": "Unraid server management via MCP.",
-  "homepage": "https://github.com/dinglebear-ai/unraid-mcp",
-  "repository": "https://github.com/dinglebear-ai/unraid-mcp",
+  "homepage": "https://github.com/dinglebear-ai/unraid",
+  "repository": "https://github.com/dinglebear-ai/unraid",
   "license": "MIT",
   "keywords": [
     "unraid",
@@ -41,7 +41,7 @@
       "Read",
       "Write"
     ],
-    "websiteURL": "https://github.com/dinglebear-ai/unraid-mcp",
+    "websiteURL": "https://github.com/dinglebear-ai/unraid",
     "defaultPrompt": [
       "Check my Unraid array status.",
       "List Docker containers on Unraid.",

--- a/agents/unraid-py/skills/unraid/README.md
+++ b/agents/unraid-py/skills/unraid/README.md
@@ -36,7 +36,7 @@ skills/unraid/
 This skill ships with the Unraid MCP plugin. Install via the Claude Code marketplace:
 
 ```bash
-/plugin marketplace add dinglebear-ai/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 /plugin install unraid-mcp @unraid-mcp
 ```
 

--- a/agents/unraid-rs/.claude-plugin/plugin.json
+++ b/agents/unraid-rs/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "jmagar"
   },
-  "repository": "https://github.com/dinglebear-ai/unraid-mcp",
+  "repository": "https://github.com/dinglebear-ai/unraid",
   "license": "MIT",
   "keywords": [
     "unraid",

--- a/agents/unraid-rs/.codex-plugin/plugin.json
+++ b/agents/unraid-rs/.codex-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "runraid",
   "version": "0.2.5",
   "description": "Read-only MCP server for Unraid homelab servers — query array health, Docker containers, VMs, metrics, and more.",
-  "homepage": "https://github.com/dinglebear-ai/unraid-mcp",
-  "repository": "https://github.com/dinglebear-ai/unraid-mcp",
+  "homepage": "https://github.com/dinglebear-ai/unraid",
+  "repository": "https://github.com/dinglebear-ai/unraid",
   "license": "MIT",
   "keywords": [
     "unraid",
@@ -23,7 +23,7 @@
     "capabilities": [
       "Read"
     ],
-    "websiteURL": "https://github.com/dinglebear-ai/unraid-mcp",
+    "websiteURL": "https://github.com/dinglebear-ai/unraid",
     "defaultPrompt": [
       "What is my Unraid array status and how much space is used?",
       "List all running Docker containers on my Unraid server.",

--- a/plugins/codex/unraid-codex.plg
+++ b/plugins/codex/unraid-codex.plg
@@ -4,8 +4,8 @@
   <!ENTITY author    "jmagar">
   <!ENTITY version   "2026.7.24"> <!-- managed by .github/scripts/plugin_calver.py -->
   <!ENTITY launch    "">
-  <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid/main/plugins/codex">
-  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid/releases/download/codex-v&version;/&txz;">
+  <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/plugins/codex">
+  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid-mcp/releases/download/codex-v&version;/&txz;">
   <!ENTITY pluginURL "&gitURL;/unraid-codex.plg">
   <!ENTITY txz       "unraid-codex-&version;-x86_64-15.txz">
   <!ENTITY md5       "69784069fb5e4d285eaaf62d389a904d">

--- a/plugins/codex/unraid-codex.plg
+++ b/plugins/codex/unraid-codex.plg
@@ -4,8 +4,8 @@
   <!ENTITY author    "jmagar">
   <!ENTITY version   "2026.7.24"> <!-- managed by .github/scripts/plugin_calver.py -->
   <!ENTITY launch    "">
-  <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/plugins/codex">
-  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid-mcp/releases/download/codex-v&version;/&txz;">
+  <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid/main/plugins/codex">
+  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid/releases/download/codex-v&version;/&txz;">
   <!ENTITY pluginURL "&gitURL;/unraid-codex.plg">
   <!ENTITY txz       "unraid-codex-&version;-x86_64-15.txz">
   <!ENTITY md5       "69784069fb5e4d285eaaf62d389a904d">

--- a/plugins/incus/DESCRIPTION.md
+++ b/plugins/incus/DESCRIPTION.md
@@ -32,7 +32,7 @@ Install and manage Incus system containers for coding agents and stdio MCP works
 [b]Security — read before use[/b]
 This plugin controls a host-level Incus daemon, firewall policy, and optional host bind mounts. Its default IPv4 policy is deny-list containment, not a complete security boundary. Review every allow-hole and bind mount, test access to your actual NAS, router, tailnet, and internal services, and add stronger controls before running hostile workloads. IPv6 is disabled until equivalent isolation policy exists.
 
-[b]Source &amp; issues:[/b] https://github.com/dinglebear-ai/unraid-mcp
+[b]Source &amp; issues:[/b] https://github.com/dinglebear-ai/unraid
 ```
 
 ## Categories
@@ -41,7 +41,7 @@ This plugin controls a host-level Incus daemon, firewall policy, and optional ho
 
 ## Support and listing screenshots
 
-- Support: https://github.com/dinglebear-ai/unraid-mcp/issues
+- Support: https://github.com/dinglebear-ai/unraid/issues
 - No listing screenshots are included in this draft. Capture sanitized settings, builder, and container-management views before portal submission.
 
 ## Preparation status

--- a/plugins/incus/README.md
+++ b/plugins/incus/README.md
@@ -137,7 +137,7 @@ install it transactionally; older/classic-only artifacts do not. Requirements:
 - release values matching `release-manifest.json`.
 
 1. Install the `.plg` from Community Apps or the anonymous direct URL
-   `https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/plugins/incus/incus.plg` — it lays down
+   `https://raw.githubusercontent.com/dinglebear-ai/unraid/main/plugins/incus/incus.plg` — it lays down
    the repackaged Incus runtime under `/usr/local/incus/` and a default
    `incus.cfg` (never overwriting an existing one).
 2. Check `/var/log/syslog` for either `API plugin installed and verified` or

--- a/plugins/incus/incus.plg
+++ b/plugins/incus/incus.plg
@@ -4,10 +4,10 @@
   <!ENTITY author    "jmagar">
   <!ENTITY version   "2026.7.24"> <!-- managed by .github/scripts/plugin_calver.py -->
   <!ENTITY launch    "Settings/IncusSettings">
-  <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/plugins/incus">
+  <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid/main/plugins/incus">
   <!ENTITY pluginURL "&gitURL;/&name;.plg">
   <!ENTITY txz       "&name;-unraid-7.0.0-55-x86_64-1.txz">
-  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid-mcp/releases/download/incus-v&version;/&txz;">
+  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid/releases/download/incus-v&version;/&txz;">
   <!ENTITY md5       "fe0ac455ac84bc928f9bdadf57c518b7">
   <!ENTITY sha256    "ae3615b26aa980f2331812fa7f8e881d16ed70f03bb0370a21ccb4de6307f157">
   <!ENTITY plugin    "/boot/config/plugins/&name;">

--- a/plugins/incus/incus.plg
+++ b/plugins/incus/incus.plg
@@ -4,10 +4,10 @@
   <!ENTITY author    "jmagar">
   <!ENTITY version   "2026.7.24"> <!-- managed by .github/scripts/plugin_calver.py -->
   <!ENTITY launch    "Settings/IncusSettings">
-  <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid/main/plugins/incus">
+  <!ENTITY gitURL    "https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/plugins/incus">
   <!ENTITY pluginURL "&gitURL;/&name;.plg">
   <!ENTITY txz       "&name;-unraid-7.0.0-55-x86_64-1.txz">
-  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid/releases/download/incus-v&version;/&txz;">
+  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid-mcp/releases/download/incus-v&version;/&txz;">
   <!ENTITY md5       "fe0ac455ac84bc928f9bdadf57c518b7">
   <!ENTITY sha256    "ae3615b26aa980f2331812fa7f8e881d16ed70f03bb0370a21ccb4de6307f157">
   <!ENTITY plugin    "/boot/config/plugins/&name;">

--- a/plugins/mcp/scripts/build-txz.sh
+++ b/plugins/mcp/scripts/build-txz.sh
@@ -99,7 +99,7 @@ unraid-mcp:
 unraid-mcp: Exposes Unraid system control to MCP clients (Claude et al.)
 unraid-mcp: with bearer-token auth and a webGUI settings page.
 unraid-mcp:
-unraid-mcp: https://github.com/dinglebear-ai/unraid-mcp
+unraid-mcp: https://github.com/dinglebear-ai/unraid
 EOF
 
 find "${STAGE}" -type d -exec chmod 755 {} +

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
@@ -19,7 +19,7 @@ PREFIX="/usr/local/unraid-mcp"
 BUNDLED_PY="${PREFIX}/python/bin/python3"
 OVERLAY_DIR="/mnt/user/appdata/unraid-mcp/venv"
 OVERLAY_PY="${OVERLAY_DIR}/bin/python3"
-REPO="dinglebear-ai/unraid-mcp"
+REPO="dinglebear-ai/unraid"
 
 active_python() {
     if [ -x "$OVERLAY_PY" ]; then echo "$OVERLAY_PY"; else echo "$BUNDLED_PY"; fi

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
@@ -19,7 +19,7 @@ PREFIX="/usr/local/unraid-mcp"
 BUNDLED_PY="${PREFIX}/python/bin/python3"
 OVERLAY_DIR="/mnt/user/appdata/unraid-mcp/venv"
 OVERLAY_PY="${OVERLAY_DIR}/bin/python3"
-REPO="dinglebear-ai/unraid"
+REPO="dinglebear-ai/unraid-mcp"
 
 active_python() {
     if [ -x "$OVERLAY_PY" ]; then echo "$OVERLAY_PY"; else echo "$BUNDLED_PY"; fi

--- a/plugins/mcp/unraid-mcp.plg
+++ b/plugins/mcp/unraid-mcp.plg
@@ -5,14 +5,14 @@
   <!ENTITY version   "VERSION_PLACEHOLDER">
   <!ENTITY launch    "Settings/UnraidMCP">
   <!ENTITY txz       "unraid-mcp-VERSION_PLACEHOLDER-x86_64-1.txz">
-  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid-mcp/releases/download/vVERSION_PLACEHOLDER/&txz;">
+  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid/releases/download/vVERSION_PLACEHOLDER/&txz;">
   <!ENTITY md5       "MD5_PLACEHOLDER">
   <!ENTITY sha256    "SHA256_PLACEHOLDER">
   <!ENTITY plugin    "/boot/config/plugins/&name;">
   <!ENTITY emhttp    "/usr/local/emhttp/plugins/&name;">
 ]>
 
-<PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="https://github.com/dinglebear-ai/unraid-mcp/releases/latest/download/unraid-mcp.plg" min="7.0.0">
+<PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="https://github.com/dinglebear-ai/unraid/releases/latest/download/unraid-mcp.plg" min="7.0.0">
 
 <CHANGES>
 ###VERSION_PLACEHOLDER

--- a/plugins/mcp/unraid-mcp.plg
+++ b/plugins/mcp/unraid-mcp.plg
@@ -5,14 +5,14 @@
   <!ENTITY version   "VERSION_PLACEHOLDER">
   <!ENTITY launch    "Settings/UnraidMCP">
   <!ENTITY txz       "unraid-mcp-VERSION_PLACEHOLDER-x86_64-1.txz">
-  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid/releases/download/vVERSION_PLACEHOLDER/&txz;">
+  <!ENTITY txzURL    "https://github.com/dinglebear-ai/unraid-mcp/releases/download/vVERSION_PLACEHOLDER/&txz;">
   <!ENTITY md5       "MD5_PLACEHOLDER">
   <!ENTITY sha256    "SHA256_PLACEHOLDER">
   <!ENTITY plugin    "/boot/config/plugins/&name;">
   <!ENTITY emhttp    "/usr/local/emhttp/plugins/&name;">
 ]>
 
-<PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="https://github.com/dinglebear-ai/unraid/releases/latest/download/unraid-mcp.plg" min="7.0.0">
+<PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="https://github.com/dinglebear-ai/unraid-mcp/releases/latest/download/unraid-mcp.plg" min="7.0.0">
 
 <CHANGES>
 ###VERSION_PLACEHOLDER

--- a/unraid-py/README.md
+++ b/unraid-py/README.md
@@ -2,7 +2,7 @@
 
 <!-- mcp-name: tv.tootie/unraid-mcp -->
 
-[![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Funraid--mcp-blue?logo=docker)](https://github.com/jmagar/unraid-mcp/pkgs/container/unraid-mcp)
+[![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Funraid--mcp-blue?logo=docker)](https://github.com/dinglebear-ai/unraid/pkgs/container/unraid-mcp)
 
 GraphQL-backed MCP server for Unraid. Exposes a unified `unraid` tool for system inspection, management operations, live telemetry, and destructive actions gated by explicit confirmation.
 
@@ -18,7 +18,7 @@ so no local checkout is required once it's installed. You'll need
 Add this repo as a marketplace, then install the plugin:
 
 ```text
-/plugin marketplace add jmagar/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 /plugin install unraid-mcp@unraid-mcp
 ```
 
@@ -32,7 +32,7 @@ persisted to `~/.unraid-mcp/.env` by the SessionStart hook.
 The repo ships a Codex marketplace manifest at `.agents/plugins/marketplace.json`:
 
 ```bash
-codex plugin marketplace add jmagar/unraid-mcp
+codex plugin marketplace add dinglebear-ai/unraid
 # then enable `unraid-mcp@unraid-mcp` from the Codex `/plugins` view
 ```
 
@@ -53,7 +53,7 @@ Install the extension straight from the repo (`gemini extensions install` reads
 `gemini-extension.json` from the repo root):
 
 ```bash
-gemini extensions install https://github.com/jmagar/unraid-mcp
+gemini extensions install https://github.com/dinglebear-ai/unraid
 ```
 
 Gemini prompts for the `UNRAID_API_URL` and `UNRAID_API_KEY` settings on install

--- a/unraid-py/docs/MARKETPLACE.md
+++ b/unraid-py/docs/MARKETPLACE.md
@@ -80,7 +80,7 @@ Once pushed to GitHub, users install via:
 
 ```bash
 # Add the marketplace
-/plugin marketplace add jmagar/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 
 # Install the Unraid plugin
 /plugin install unraid-mcp@unraid-mcp
@@ -104,10 +104,10 @@ Install from a specific branch or commit:
 
 ```bash
 # From specific branch
-/plugin marketplace add jmagar/unraid-mcp#main
+/plugin marketplace add dinglebear-ai/unraid#main
 
 # From specific commit
-/plugin marketplace add jmagar/unraid-mcp#abc123
+/plugin marketplace add dinglebear-ai/unraid#abc123
 ```
 
 ## Validation Script
@@ -240,8 +240,8 @@ Users with the plugin installed will see the update available and can upgrade:
 
 ## Support
 
-- **Repository:** https://github.com/jmagar/unraid-mcp
-- **Issues:** https://github.com/jmagar/unraid-mcp/issues
+- **Repository:** https://github.com/dinglebear-ai/unraid
+- **Issues:** https://github.com/dinglebear-ai/unraid/issues
 - **Destructive Actions:** `docs/DESTRUCTIVE_ACTIONS.md`
 
 - Source path accuracy

--- a/unraid-py/docs/README.md
+++ b/unraid-py/docs/README.md
@@ -2,7 +2,7 @@
 
 <!-- mcp-name: tv.tootie/unraid-mcp -->
 
-[![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Funraid--mcp-blue?logo=docker)](https://github.com/jmagar/unraid-mcp/pkgs/container/unraid-mcp)
+[![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Funraid--mcp-blue?logo=docker)](https://github.com/dinglebear-ai/unraid/pkgs/container/unraid-mcp)
 
 MCP server for Unraid NAS management. Exposes a single unified `unraid` tool with 19 action domains and 178 subactions, backed by Unraid's GraphQL API and real-time WebSocket subscriptions.
 
@@ -76,7 +76,7 @@ unraid(action="help")
 ### Marketplace
 
 ```bash
-/plugin marketplace add jmagar/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 /plugin install unraid-mcp@unraid-mcp
 ```
 

--- a/unraid-py/docs/SETUP.md
+++ b/unraid-py/docs/SETUP.md
@@ -15,7 +15,7 @@ Configuration is collected by the plugin's config form — no interactive wizard
 
 1. Install as a Claude Code plugin:
    ```bash
-   /plugin marketplace add jmagar/unraid-mcp
+   /plugin marketplace add dinglebear-ai/unraid
    /plugin install unraid-mcp@unraid-mcp
    ```
 
@@ -41,7 +41,7 @@ Configuration is collected by the plugin's config form — no interactive wizard
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/jmagar/unraid-mcp.git
+   git clone https://github.com/dinglebear-ai/unraid.git
    cd unraid-mcp
    ```
 
@@ -69,7 +69,7 @@ Configuration is collected by the plugin's config form — no interactive wizard
 
 1. Clone and configure:
    ```bash
-   git clone https://github.com/jmagar/unraid-mcp.git
+   git clone https://github.com/dinglebear-ai/unraid.git
    cd unraid-mcp
    ```
 

--- a/unraid-py/docs/mcp/CICD.md
+++ b/unraid-py/docs/mcp/CICD.md
@@ -31,7 +31,7 @@ GitHub Actions configuration for unraid-mcp.
 
 **Image tags**: `latest` (main branch), `v1.2.3`, `v1.2`, `v1`, `main`, `pr-N`, `sha-<hex>`.
 
-**Registry**: `ghcr.io/jmagar/unraid-mcp`.
+**Registry**: `ghcr.io/dinglebear-ai/unraid`.
 
 ### `release-please.yml` -- Versioning and Changelog
 

--- a/unraid-py/docs/mcp/CONNECT.md
+++ b/unraid-py/docs/mcp/CONNECT.md
@@ -7,7 +7,7 @@ How to connect to the unraid-mcp server from every supported client and transpor
 ### Install from marketplace
 
 ```bash
-/plugin marketplace add jmagar/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 /plugin install unraid-mcp@unraid-mcp
 ```
 
@@ -77,7 +77,7 @@ over `https://`. If the server requires a Bearer token, append
 The repo ships a Codex marketplace manifest at `.agents/plugins/marketplace.json`:
 
 ```bash
-codex plugin marketplace add jmagar/unraid-mcp
+codex plugin marketplace add dinglebear-ai/unraid
 # then enable `unraid-mcp@unraid-mcp` from the Codex `/plugins` view
 ```
 

--- a/unraid-py/docs/mcp/DEPLOY.md
+++ b/unraid-py/docs/mcp/DEPLOY.md
@@ -101,7 +101,7 @@ uvx unraid-mcp
 ## GitHub Container Registry
 
 ```bash
-docker pull ghcr.io/jmagar/unraid-mcp:latest
+docker pull ghcr.io/dinglebear-ai/unraid:latest
 ```
 
 Release tags: `latest`, `1.2.3`, `1.2`, `1`, and `sha-<commit>`. Unreleased `main`

--- a/unraid-py/docs/mcp/DEV.md
+++ b/unraid-py/docs/mcp/DEV.md
@@ -6,7 +6,7 @@ Day-to-day development guide for unraid-mcp.
 
 ```bash
 # Clone
-git clone https://github.com/jmagar/unraid-mcp.git
+git clone https://github.com/dinglebear-ai/unraid.git
 cd unraid-mcp
 
 # Install all dependencies (including dev)

--- a/unraid-py/docs/mcp/PUBLISH.md
+++ b/unraid-py/docs/mcp/PUBLISH.md
@@ -72,10 +72,10 @@ The new tag + Release trigger two independently retryable workflows:
 | Channel | Package | Install command |
 |---------|---------|----------------|
 | PyPI | `unraid-mcp` | `pip install unraid-mcp` or `uvx unraid-mcp` |
-| GHCR release | `ghcr.io/jmagar/unraid-mcp` | `docker pull ghcr.io/jmagar/unraid-mcp:latest` |
-| GHCR prerelease | `ghcr.io/jmagar/unraid-mcp:edge` | `docker pull ghcr.io/jmagar/unraid-mcp:edge` |
+| GHCR release | `ghcr.io/dinglebear-ai/unraid` | `docker pull ghcr.io/dinglebear-ai/unraid:latest` |
+| GHCR prerelease | `ghcr.io/dinglebear-ai/unraid:edge` | `docker pull ghcr.io/dinglebear-ai/unraid:edge` |
 | MCP Registry | `tv.tootie/unraid-mcp` | MCP client auto-discovery |
-| Claude Plugin | `jmagar/unraid-mcp` | `/plugin install unraid-mcp` |
+| Claude Plugin | `dinglebear-ai/unraid` | `/plugin install unraid-mcp` |
 | GitHub Release | Source + wheel | Download from releases page |
 
 ## MCP Registry
@@ -91,10 +91,10 @@ The `server.json` defines the registry entry:
 ## Artifact verification
 
 ```bash
-gh release download vX.Y.Z --repo jmagar/unraid-mcp
+gh release download vX.Y.Z --repo dinglebear-ai/unraid
 sha256sum --check SHA256SUMS
-gh attestation verify unraid_mcp-X.Y.Z-py3-none-any.whl --repo jmagar/unraid-mcp
-docker buildx imagetools inspect ghcr.io/jmagar/unraid-mcp:X.Y.Z
+gh attestation verify unraid_mcp-X.Y.Z-py3-none-any.whl --repo dinglebear-ai/unraid
+docker buildx imagetools inspect ghcr.io/dinglebear-ai/unraid:X.Y.Z
 ```
 
 Pin production containers to the reported digest when immutability is required.

--- a/unraid-py/docs/plugin/MARKETPLACES.md
+++ b/unraid-py/docs/plugin/MARKETPLACES.md
@@ -4,10 +4,10 @@
 
 | Marketplace | Identifier | Install method |
 |-------------|-----------|----------------|
-| Claude Plugin Marketplace | `jmagar/unraid-mcp` | `/plugin install unraid-mcp@unraid-mcp` |
+| Claude Plugin Marketplace | `dinglebear-ai/unraid` | `/plugin install unraid-mcp@unraid-mcp` |
 | MCP Registry | `tv.tootie/unraid-mcp` | Auto-discovery by MCP clients |
 | PyPI | `unraid-mcp` | `pip install unraid-mcp` or `uvx unraid-mcp` |
-| GitHub Container Registry | `ghcr.io/jmagar/unraid-mcp` | `docker pull ghcr.io/jmagar/unraid-mcp` |
+| GitHub Container Registry | `ghcr.io/dinglebear-ai/unraid` | `docker pull ghcr.io/dinglebear-ai/unraid` |
 
 ## Claude Plugin Marketplace
 
@@ -18,7 +18,7 @@ unraid-mcp ships its own Claude Code marketplace manifest at `.claude-plugin/mar
   "unraid-mcp": {
     "source": {
       "type": "git",
-      "url": "https://github.com/jmagar/unraid-mcp"
+      "url": "https://github.com/dinglebear-ai/unraid"
     },
     "category": "infrastructure",
     "description": "Query, monitor, and manage Unraid servers via GraphQL API."
@@ -30,7 +30,7 @@ unraid-mcp ships its own Claude Code marketplace manifest at `.claude-plugin/mar
 
 ```bash
 # Add the marketplace (one-time)
-/plugin marketplace add jmagar/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 
 # Install the plugin
 /plugin install unraid-mcp@unraid-mcp

--- a/unraid-py/docs/repo/REPO.md
+++ b/unraid-py/docs/repo/REPO.md
@@ -1,7 +1,7 @@
 # Repository Structure -- unraid-mcp
 
 > **Scope note (monorepo):** the tree below is rooted at `unraid-py/` within the
-> [dinglebear-ai/unraid-mcp](https://github.com/dinglebear-ai/unraid-mcp) monorepo,
+> [dinglebear-ai/unraid](https://github.com/dinglebear-ai/unraid) monorepo,
 > not at the repository root. The Claude/Codex plugin manifests it lists moved to
 > `agents/unraid-py/` at the repo root during the consolidation.
 

--- a/unraid-py/openwiki/configuration.md
+++ b/unraid-py/openwiki/configuration.md
@@ -190,7 +190,7 @@ Docker-specific variables are set via environment or docker-compose.yaml:
 ```yaml
 services:
   unraid-mcp:
-    image: ghcr.io/jmagar/unraid-mcp:latest
+    image: ghcr.io/dinglebear-ai/unraid:latest
     environment:
       - UNRAID_API_URL=https://tower.local/graphql
       - UNRAID_API_KEY=your-api-key
@@ -211,7 +211,7 @@ See `/docker-compose.yaml` for the official deployment configuration.
 
 ```bash
 # Add marketplace and install
-/plugin marketplace add jmagar/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 /plugin install unraid-mcp@unraid-mcp
 
 # Plugin prompts for URL and key

--- a/unraid-py/openwiki/development.md
+++ b/unraid-py/openwiki/development.md
@@ -13,7 +13,7 @@ Local development workflow for unraid-mcp, including setup, testing, code qualit
 
 ```bash
 # Clone the repository
-git clone https://github.com/jmagar/unraid-mcp
+git clone https://github.com/dinglebear-ai/unraid
 cd unraid-mcp
 
 # Install dependencies and create virtual environment

--- a/unraid-py/openwiki/quickstart.md
+++ b/unraid-py/openwiki/quickstart.md
@@ -21,7 +21,7 @@ The server is built with FastMCP and follows a modular architecture with separat
 Add the marketplace and install the plugin:
 
 ```bash
-/plugin marketplace add jmagar/unraid-mcp
+/plugin marketplace add dinglebear-ai/unraid
 /plugin install unraid-mcp@unraid-mcp
 ```
 
@@ -62,7 +62,7 @@ The Docker image reads configuration from `/app/.env` or `~/.unraid-mcp/.env`.
 ### For Gemini CLI
 
 ```bash
-gemini extensions install https://github.com/jmagar/unraid-mcp
+gemini extensions install https://github.com/dinglebear-ai/unraid
 ```
 
 Gemini prompts for `UNRAID_API_URL` and `UNRAID_API_KEY` on install.

--- a/unraid-py/pyproject.toml
+++ b/unraid-py/pyproject.toml
@@ -100,12 +100,12 @@ dependencies = [
 # Project URLs
 # ============================================================================
 [project.urls]
-Homepage = "https://github.com/jmagar/unraid-mcp"
-Documentation = "https://github.com/jmagar/unraid-mcp#readme"
-Repository = "https://github.com/jmagar/unraid-mcp"
-Issues = "https://github.com/jmagar/unraid-mcp/issues"
-Changelog = "https://github.com/jmagar/unraid-mcp/releases"
-Source = "https://github.com/jmagar/unraid-mcp"
+Homepage = "https://github.com/dinglebear-ai/unraid"
+Documentation = "https://github.com/dinglebear-ai/unraid#readme"
+Repository = "https://github.com/dinglebear-ai/unraid"
+Issues = "https://github.com/dinglebear-ai/unraid/issues"
+Changelog = "https://github.com/dinglebear-ai/unraid/releases"
+Source = "https://github.com/dinglebear-ai/unraid"
 
 # ============================================================================
 # Entry Points

--- a/unraid-py/server.json
+++ b/unraid-py/server.json
@@ -4,7 +4,7 @@
   "title": "Unraid MCP",
   "description": "MCP server for Unraid API — provides tools to interact with an Unraid server's GraphQL API.",
   "repository": {
-    "url": "https://github.com/jmagar/unraid-mcp",
+    "url": "https://github.com/dinglebear-ai/unraid",
     "source": "github"
   },
   "version": "0.0.0",

--- a/unraid-rs/Cargo.toml
+++ b/unraid-rs/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 rust-version = "1.90"
 categories = ["command-line-utilities", "development-tools"]
 keywords = ["mcp", "unraid", "graphql", "nas", "rmcp"]
-repository = "https://github.com/dinglebear-ai/unraid-mcp"
-homepage = "https://github.com/dinglebear-ai/unraid-mcp#readme"
+repository = "https://github.com/dinglebear-ai/unraid"
+homepage = "https://github.com/dinglebear-ai/unraid#readme"
 description = "Rust MCP server and CLI for Unraid GraphQL operations across NAS, Docker, VM, and storage workflows."
 autobins = false
 

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -88,7 +88,7 @@ existing deployment config.
 | Path | Command | Best for | Notes |
 |---|---|---|---|
 | npm / npx | `npx -y unraid-rmcp --help` | Local MCP clients and quick trials. | Downloads the matching `runraid` binary from GitHub Releases. |
-| Release installer | `curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/unraid-rs/scripts/install.sh \| bash` | Host installs without Node. | Installs `runraid` for linux/amd64. |
+| Release installer | `curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/unraid/main/unraid-rs/scripts/install.sh \| bash` | Host installs without Node. | Installs `runraid` for linux/amd64. |
 | Docker / Compose | `docker compose up -d` | Shared HTTP MCP deployments. | Reads `.env` and exposes container port `40010`. |
 | Build from source | `cargo build --release` | Development and audits. | Produces `target/release/runraid`. |
 | Plugin | `claude plugin install agents/unraid-rs` | Claude Code local plugin setup from this checkout. | Uses the packaged setup hook, skill, and local runtime metadata. |
@@ -116,7 +116,7 @@ behavior only when testing packaging:
 ### Build From Source
 
 ```bash
-git clone https://github.com/dinglebear-ai/unraid-mcp
+git clone https://github.com/dinglebear-ai/unraid
 cd unraid-mcp/unraid-rs
 cargo build --release
 ./target/release/runraid --help

--- a/unraid-rs/docs/QUICKSTART.md
+++ b/unraid-rs/docs/QUICKSTART.md
@@ -11,7 +11,7 @@ Get unraid-rmcp running and make your first MCP call in five minutes.
 ## 1. Clone and build
 
 ```bash
-git clone https://github.com/dinglebear-ai/unraid-mcp
+git clone https://github.com/dinglebear-ai/unraid
 cd unraid-mcp/unraid-rs
 cargo build --release
 # Binary at: target/release/runraid

--- a/unraid-rs/install.sh
+++ b/unraid-rs/install.sh
@@ -2,7 +2,7 @@
 # install.sh — One-line installer for unraid-rmcp
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/unraid-rs/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/unraid/main/unraid-rs/install.sh | bash
 #
 # What it does:
 #   1. Runs pre-flight checks (OS/arch, tools, disk space, PATH, port)
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-REPO="dinglebear-ai/unraid-mcp"
+REPO="dinglebear-ai/unraid"
 BIN_NAME="runraid"
 # The Rust server is one component of the unraid-mcp monorepo. Its releases are
 # tagged `unraid-rs-v<semver>` and its crate lives in the `unraid-rs/` subtree —

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -88,7 +88,7 @@ existing deployment config.
 | Path | Command | Best for | Notes |
 |---|---|---|---|
 | npm / npx | `npx -y unraid-rmcp --help` | Local MCP clients and quick trials. | Downloads the matching `runraid` binary from GitHub Releases. |
-| Release installer | `curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/unraid-mcp/main/unraid-rs/scripts/install.sh \| bash` | Host installs without Node. | Installs `runraid` for linux/amd64. |
+| Release installer | `curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/unraid/main/unraid-rs/scripts/install.sh \| bash` | Host installs without Node. | Installs `runraid` for linux/amd64. |
 | Docker / Compose | `docker compose up -d` | Shared HTTP MCP deployments. | Reads `.env` and exposes container port `40010`. |
 | Build from source | `cargo build --release` | Development and audits. | Produces `target/release/runraid`. |
 | Plugin | `claude plugin install agents/unraid-rs` | Claude Code local plugin setup from this checkout. | Uses the packaged setup hook, skill, and local runtime metadata. |
@@ -116,7 +116,7 @@ behavior only when testing packaging:
 ### Build From Source
 
 ```bash
-git clone https://github.com/dinglebear-ai/unraid-mcp
+git clone https://github.com/dinglebear-ai/unraid
 cd unraid-mcp/unraid-rs
 cargo build --release
 ./target/release/runraid --help

--- a/unraid-rs/packages/unraid-rmcp/lib/platform.js
+++ b/unraid-rs/packages/unraid-rmcp/lib/platform.js
@@ -31,7 +31,7 @@ function releaseVersion(env = process.env) {
 }
 
 function releaseBaseUrl(env = process.env) {
-  const repo = env.UNRAID_RMCP_REPO || "dinglebear-ai/unraid-mcp";
+  const repo = env.UNRAID_RMCP_REPO || "dinglebear-ai/unraid";
   return env.UNRAID_RMCP_RELEASE_BASE_URL || `https://github.com/${repo}/releases/download`;
 }
 

--- a/unraid-rs/packages/unraid-rmcp/package.json
+++ b/unraid-rs/packages/unraid-rmcp/package.json
@@ -3,14 +3,14 @@
   "version": "0.2.5",
   "description": "Node launcher for the Unraid Rust MCP server and runraid CLI for NAS, Docker, VM, and storage workflows.",
   "license": "MIT",
-  "homepage": "https://github.com/dinglebear-ai/unraid-mcp#readme",
+  "homepage": "https://github.com/dinglebear-ai/unraid#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dinglebear-ai/unraid-mcp.git",
+    "url": "git+https://github.com/dinglebear-ai/unraid.git",
     "directory": "packages/unraid-rmcp"
   },
   "bugs": {
-    "url": "https://github.com/dinglebear-ai/unraid-mcp/issues"
+    "url": "https://github.com/dinglebear-ai/unraid/issues"
   },
   "bin": {
     "unraid-rmcp": "bin/runraid.js",

--- a/unraid-rs/packages/unraid-rmcp/scripts/check-package.js
+++ b/unraid-rs/packages/unraid-rmcp/scripts/check-package.js
@@ -10,7 +10,7 @@ const { spawnSync } = require("node:child_process");
 const packageRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(packageRoot, "..", "..");
 // Canonical home of this package after the monorepo consolidation.
-const CANONICAL_REPO = "dinglebear-ai/unraid-mcp";
+const CANONICAL_REPO = "dinglebear-ai/unraid";
 const packageJsonPath = path.join(packageRoot, "package.json");
 const packageJson = readJson(packageJsonPath);
 const releaseMode = process.argv.includes("--release");

--- a/unraid-rs/packages/unraid-rmcp/test/platform.test.js
+++ b/unraid-rs/packages/unraid-rmcp/test/platform.test.js
@@ -15,7 +15,7 @@ test("uses pinned binary version as the binary tag by default", () => {
   assert.equal(releaseVersion({}), `unraid-rs-v${pinnedBinaryVersion}`);
 });
 test("defaults to the monorepo's release download base", () => {
-  assert.equal(releaseBaseUrl({}), "https://github.com/dinglebear-ai/unraid-mcp/releases/download");
+  assert.equal(releaseBaseUrl({}), "https://github.com/dinglebear-ai/unraid/releases/download");
 });
 test("normalises bare, v-prefixed, and already-prefixed release versions to the component tag", () => {
   assert.equal(releaseVersion({ UNRAID_RMCP_BINARY_VERSION: "9.9.9" }), "unraid-rs-v9.9.9");

--- a/unraid-rs/scripts/install.sh
+++ b/unraid-rs/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-REPO="${UNRAID_RMCP_REPO:-dinglebear-ai/unraid-mcp}"
+REPO="${UNRAID_RMCP_REPO:-dinglebear-ai/unraid}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 VERSION="${UNRAID_RMCP_VERSION:-latest}"
 RELEASE_BASE_URL="${UNRAID_RMCP_RELEASE_BASE_URL:-}"
@@ -16,7 +16,7 @@ Install runraid from GitHub Releases.
 Environment:
   INSTALL_DIR Destination directory (default: ~/.local/bin)
   UNRAID_RMCP_VERSION Release version such as 0.2.3, v0.2.3 or unraid-rs-v0.2.3 (default: latest unraid-rs release)
-  UNRAID_RMCP_REPO GitHub repo owner/name (default: dinglebear-ai/unraid-mcp)
+  UNRAID_RMCP_REPO GitHub repo owner/name (default: dinglebear-ai/unraid)
 USAGE
 }
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; exit 0; fi

--- a/unraid-rs/server.json
+++ b/unraid-rs/server.json
@@ -4,9 +4,9 @@
   "title": "Unraid RMCP",
   "description": "Rust MCP server and CLI for Unraid GraphQL, NAS, Docker, VM, and storage workflows.",
   "version": "0.2.5",
-  "websiteUrl": "https://github.com/dinglebear-ai/unraid-mcp",
+  "websiteUrl": "https://github.com/dinglebear-ai/unraid",
   "repository": {
-    "url": "https://github.com/dinglebear-ai/unraid-mcp",
+    "url": "https://github.com/dinglebear-ai/unraid",
     "source": "github",
     "id": "1238227303"
   },
@@ -102,7 +102,7 @@
       },
       "buildInfo": {
         "version": "0.2.5",
-        "repository": "https://github.com/dinglebear-ai/unraid-mcp"
+        "repository": "https://github.com/dinglebear-ai/unraid"
       }
     }
   }


### PR DESCRIPTION
The repo was renamed from unraid-mcp to unraid (and earlier moved from the
jmagar user to the dinglebear-ai org). Both old paths still resolve through
GitHub's transfer redirects, so nothing is broken today — but plugin
self-update URLs, install scripts, and package manifests were all depending on
those redirects staying alive.

Rewrites functional references only. Historical PR/issue/commit links in
CHANGELOGs and dated session docs are deliberately left alone: they are
records, they still resolve, and release-please regenerates the CHANGELOGs.

Does not touch the GHCR image path — that is a separate decision.
