### PR TITLE
ci: pin the Python GHCR image name instead of deriving it from the repo name

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,10 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  # Pinned, not derived from github.repository: the repo was renamed unraid-mcp -> unraid
+  # and GHCR package paths do not follow repo-rename redirects. Deriving this would
+  # silently start publishing to a new, empty ghcr.io/<owner>/unraid package.
+  IMAGE_NAME: ${{ github.repository_owner }}/unraid-mcp
   TEST_IMAGE: local/unraid-mcp:${{ github.sha }}
 
 # Python server sources (incl. scripts/, tests/, pyproject.toml, Dockerfile)

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -271,11 +271,15 @@ jobs:
             "https://registry.modelcontextprotocol.io/v0/servers/tv.tootie%2Funraid-mcp/versions/${version}" |
             jq -e --arg version "$version" '.server.version == $version and .server.packages[0].version == $version'
       - name: Wait for matching GHCR release and latest digests
+        env:
+          # Pinned, not derived from github.repository: the repo was renamed
+          # unraid-mcp -> unraid and GHCR paths do not follow rename redirects.
+          GHCR_IMAGE: ${{ github.repository_owner }}/unraid-mcp
         run: |
           version="${RELEASE_TAG#v}"
           for _ in {1..30}; do
-            version_digest="$(docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY}:${version}" --format '{{json .Manifest}}' 2>/dev/null | jq -r '.digest // empty')"
-            latest_digest="$(docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY}:latest" --format '{{json .Manifest}}' 2>/dev/null | jq -r '.digest // empty')"
+            version_digest="$(docker buildx imagetools inspect "ghcr.io/${GHCR_IMAGE}:${version}" --format '{{json .Manifest}}' 2>/dev/null | jq -r '.digest // empty')"
+            latest_digest="$(docker buildx imagetools inspect "ghcr.io/${GHCR_IMAGE}:latest" --format '{{json .Manifest}}' 2>/dev/null | jq -r '.digest // empty')"
             if [[ -n "$version_digest" && "$version_digest" = "$latest_digest" ]]; then
               echo "GHCR ${version} and latest reconcile to ${version_digest}."
               exit 0


### PR DESCRIPTION
Renaming the repo `unraid-mcp` → `unraid` silently redirected where the Python Docker image publishes.

`docker-publish.yml` used `IMAGE_NAME: ${{ github.repository }}`, which now evaluates to `dinglebear-ai/unraid`. **GHCR package paths do not follow repo-rename redirects** (unlike clone and `raw.githubusercontent.com` URLs, which do). The next publish would have created a new empty package while `ghcr.io/dinglebear-ai/unraid-mcp` quietly stopped receiving tags — no error, no redirect, and anyone pulling the established path would sit on a frozen image indefinitely.

Pins both the publish and the digest-reconciliation check in `publish-pypi.yml` to `${{ github.repository_owner }}/unraid-mcp`.

This is the pattern `rust-release.yml` already used for the Rust image (`${{ github.repository_owner }}/unraid-rmcp`) — which is exactly why that one was unaffected by the rename.

The two images stay distinct on their established paths:

| Server | Image |
|---|---|
| Python | `ghcr.io/<owner>/unraid-mcp` |
| Rust | `ghcr.io/<owner>/unraid-rmcp` |

Other `github.repository` uses are deliberately left dynamic — `gh release --repo`, the release-please push URL, and fork detection all correctly follow a rename.

Validated: both workflows parse, `actionlint` rc=0.