### PR TITLE
Revert "deps(deps): bump rmcp from 1.8.0 to 2.2.0" — main does not compile

### DIFF
--- a/unraid-rs/Cargo.lock
+++ b/unraid-rs/Cargo.lock
@@ -2426,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/unraid-rs/Cargo.toml
+++ b/unraid-rs/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal
 
 # HTTP / MCP transport
 axum = "0.8"
-rmcp = { version = "2.2.0", default-features = false, features = [
+rmcp = { version = "1.6.0", default-features = false, features = [
   "server",
   "macros",
   "elicitation",
@@ -88,7 +88,7 @@ test-support = ["dep:graphql-parser"]
 unraid-rmcp = { path = ".", features = ["test-support"] }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
-rmcp = { version = "2.2.0", default-features = false, features = [
+rmcp = { version = "1.6.0", default-features = false, features = [
   "client",
   "transport-child-process",
 ] }


### PR DESCRIPTION
**main is currently broken.** `cargo check --all-targets --features test-support` fails on `origin/main` with three errors introduced by #237:

```
error[E0432]: unresolved import `rmcp::model::PromptMessageRole`
error[E0432]: unresolved imports `rmcp::model::Content`, `rmcp::model::RawResource`
error[E0277]: the trait bound `String: From<Option<_>>` is not satisfied
error: could not compile `unraid-rmcp` (lib) due to 3 previous errors
```

rmcp 2.x moved and renamed several model types. That is a port, not a version bump.

### Why it got in

#237's own **Clippy and Tests jobs were already red** when it merged. Nothing stopped it, because `rust-ci` is **not in main's required status checks** — the required list is the nine Python/container checks (`Lint & Format`, `Type Check`, `Version Sync Check`, `Test (py3.12)`, `Test (py3.13)`, `Integration & Mock Roundtrip`, `Security Audit`, `Package Artifact Smoke`, `Container Artifact Smoke & Scan`). A Rust-breaking change therefore merges cleanly.

That gap is worth closing separately — `Formatting`, `Clippy`, `Tests`, `TOML Format` and the new `Crates.io Package` job should be required for anything touching `unraid-rs/`.

### Verified
`cargo check --all-targets --features test-support` → **exit 0** with this revert applied, with the toml 1.1 bump (#250) still in place. #250 is unaffected and stays.