### PR TITLE
build: align toolchain, MSRV, edition, and rmcp fleet-wide

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -30,9 +30,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Pinned to the project MSRV (Cargo.toml rust-version) so CI enforces it.
-      - uses: dtolnay/rust-toolchain@0a0b1db3a4e40d68af9ce1f11281259916528f39  # 1.90
+      - uses: dtolnay/rust-toolchain@46511b1c83438f0dd37c02d843619ece5a4abb5b  # 1.97.1
         with:
-          toolchain: "1.90"
+          toolchain: "1.97.1"
           components: rustfmt
 
       - name: Check formatting
@@ -53,9 +53,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Pinned to the project MSRV (Cargo.toml rust-version) so CI enforces it.
-      - uses: dtolnay/rust-toolchain@0a0b1db3a4e40d68af9ce1f11281259916528f39  # 1.90
+      - uses: dtolnay/rust-toolchain@46511b1c83438f0dd37c02d843619ece5a4abb5b  # 1.97.1
         with:
-          toolchain: "1.90"
+          toolchain: "1.97.1"
           components: clippy
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
@@ -78,9 +78,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Pinned to the project MSRV (Cargo.toml rust-version) so CI enforces it.
-      - uses: dtolnay/rust-toolchain@0a0b1db3a4e40d68af9ce1f11281259916528f39  # 1.90
+      - uses: dtolnay/rust-toolchain@46511b1c83438f0dd37c02d843619ece5a4abb5b  # 1.97.1
         with:
-          toolchain: "1.90"
+          toolchain: "1.97.1"
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:

--- a/.mise.toml
+++ b/.mise.toml
@@ -4,20 +4,17 @@
 # package. Exact Python minor follows unraid-py/pyproject.toml's >=3.12 floor.
 python = "3.12"
 uv = "latest"
-# Local BUILD toolchain, tracking the fleet's current Rust (1.97.1).
+# Pinned to 1.97.1 with the rest of the fleet (ADR-0001 for the build toolchain,
+# ADR-0024 for the MSRV — both are 1.97.1 as of 2026-07-29).
 #
-# This deliberately no longer mirrors the MSRV. rust-ci.yml stays pinned to
-# Cargo.toml's rust-version so CI keeps ENFORCING the compatibility floor —
-# unraid-rmcp and lab-auth publish to crates.io, so that floor is a promise to
-# downstream users. unraid-rs/rust-toolchain.toml carries the same 1.97.1 for
-# contributors who use rustup instead of mise.
+# THIS KEY IS AUTHORITATIVE, NOT unraid-rs/rust-toolchain.toml. mise exports
+# RUSTUP_TOOLCHAIN for this directory, which OVERRIDES rust-toolchain.toml — so
+# whatever is written here is what actually builds. Verify with
+# `mise env | grep RUSTUP`. This pin previously said 1.90 while
+# rust-toolchain.toml said 1.97.1, and mise silently won.
 #
-# Tradeoff, accepted knowingly: local `cargo clippy -- -D warnings` now runs on
-# a newer compiler than CI and can surface lints CI does not have. Fixing those
-# is safe (strict superset). The reverse — green locally, red in CI — is what
-# the MSRV job catches.
-#
-# Keep in sync with: unraid-rs/rust-toolchain.toml
-# Do NOT sync with:  unraid-rs/Cargo.toml rust-version, rust-ci.yml toolchain:
+# Four places carry the version and must move together:
+#   this file · unraid-rs/rust-toolchain.toml · unraid-rs/Cargo.toml
+#   [workspace.package] rust-version · .github/workflows/rust-ci.yml toolchain:
 rust = "1.97.1"
 node = "22"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ The Python server's detailed dev guide is `unraid-py/CLAUDE.md`.
 
 The root `.mise.toml` is polyglot (python + rust + node) so every component's
 toolchain is available from a single `mise install`. Rust is pinned to
-`unraid-rs`'s MSRV (1.90) so local `clippy` reproduces CI; `unraid-rs/rust-toolchain.toml`
+`unraid-rs`'s MSRV (1.97.1) so local `clippy` reproduces CI; `unraid-rs/rust-toolchain.toml`
 carries the same pin for contributors who use rustup instead of mise. Keep
 `.mise.toml`, `rust-toolchain.toml`, `unraid-rs/Cargo.toml` (`rust-version`), and
 `rust-ci.yml` in sync.

--- a/unraid-rs/Cargo.lock
+++ b/unraid-rs/Cargo.lock
@@ -2391,11 +2391,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "3875f7c471c2d709062bc2165d8dc883b021b44255bd00bb4d8025f5108178c8"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "futures",
@@ -2423,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "e1aa4b9345795260a43fc23d6d05e096407c8b953903f673af7c4404b49fb2d6"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/unraid-rs/Cargo.toml
+++ b/unraid-rs/Cargo.toml
@@ -5,11 +5,19 @@
 members = ["crates/lab-auth", "xtask"]
 resolver = "2"
 
+[workspace.package]
+
+# Fleet edition (ADR-0002). Members inherit via edition.workspace = true.
+edition = "2024"
+# Fleet MSRV — the floor this repo supports. A separate promise from
+# rust-toolchain.toml's channel, which is what we BUILD with. Both are
+# 1.97.1 as of 2026-07-29 (ADR-0001 toolchain, ADR-0024 MSRV).
+rust-version = "1.97.1"
 [package]
 name = "unraid-rmcp"
 version = "0.2.5"
-edition = "2021"
-rust-version = "1.90"
+edition.workspace = true
+rust-version.workspace = true
 categories = ["command-line-utilities", "development-tools"]
 keywords = ["mcp", "unraid", "graphql", "nas", "rmcp"]
 repository = "https://github.com/dinglebear-ai/unraid"
@@ -45,7 +53,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal
 
 # HTTP / MCP transport
 axum = "0.8"
-rmcp = { version = "1.6.0", default-features = false, features = [
+rmcp = { version = "=3.0.0-beta.2", default-features = false, features = [
   "server",
   "macros",
   "elicitation",
@@ -106,7 +114,7 @@ test-support = ["dep:graphql-parser"]
 unraid-rmcp = { path = ".", features = ["test-support"] }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
-rmcp = { version = "1.6.0", default-features = false, features = [
+rmcp = { version = "=3.0.0-beta.2", default-features = false, features = [
   "client",
   "transport-child-process",
 ] }

--- a/unraid-rs/examples/mock_unraid.rs
+++ b/unraid-rs/examples/mock_unraid.rs
@@ -28,14 +28,14 @@
 use std::sync::{Arc, RwLock};
 
 use axum::{
+    Json, Router,
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, post},
-    Json, Router,
 };
-use serde_json::{json, Value};
-use unraid_rmcp::mock::{Scenario, SCENARIOS};
+use serde_json::{Value, json};
+use unraid_rmcp::mock::{SCENARIOS, Scenario};
 
 #[derive(Clone)]
 struct AppState {

--- a/unraid-rs/rust-toolchain.toml
+++ b/unraid-rs/rust-toolchain.toml
@@ -1,18 +1,20 @@
-# Toolchain used to BUILD unraid-rs locally. Tracks the fleet's current Rust
-# (1.97.1) rather than the MSRV.
+# Toolchain used to BUILD this repo, locally and in CI. Pinned fleet-wide to
+# Rust 1.97.1 by ADR-0001: 1.97.1 is a point release that fixes an LLVM
+# miscompilation present since at least 1.87, so every toolchain below it —
+# including every version this fleet previously pinned — is affected.
 #
-# This deliberately differs from .github/workflows/rust-ci.yml, which stays
-# pinned to Cargo.toml's `rust-version` so CI keeps ENFORCING the compatibility
-# floor — unraid-rmcp and lab-auth are published to crates.io, so that floor is
-# a promise to downstream users, not just an internal preference.
+# This is deliberately NOT the same promise as Cargo.toml's `rust-version`.
+# This file says "build with exactly this"; `rust-version` says "refuse to
+# build on anything older". As of ADR-0024 both are 1.97.1, but they remain
+# separate keys and can diverge again.
 #
-# Consequence to expect: `cargo clippy -- -D warnings` locally runs on a newer
-# compiler than CI and can surface lints CI does not have. Fixing those is safe;
-# they are a superset. The reverse (green locally, red in CI) is what the MSRV
-# job exists to catch.
+# `components` is self-declared because dtolnay/rust-toolchain only installs
+# components for the toolchain IT pins, not for a rust-toolchain.toml override.
 #
-# Keep in sync with: the fleet's rustup default (`rustup default`)
-# Do NOT sync with:  Cargo.toml `rust-version` / rust-ci.yml `toolchain:`
+# NOTE: a `.mise.toml` in this directory that sets `rust` exports
+# RUSTUP_TOOLCHAIN and OVERRIDES this file. Check `mise env | grep RUSTUP`
+# before trusting the channel below.
 [toolchain]
 channel = "1.97.1"
 components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/unraid-rs/src/cli/doctor.rs
+++ b/unraid-rs/src/cli/doctor.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use serde::Serialize;
 
-use unraid_rmcp::config::{default_data_dir, AuthMode, Config};
+use unraid_rmcp::config::{AuthMode, Config, default_data_dir};
 
 /// A single check result emitted by `doctor`.
 #[derive(Debug, Serialize)]
@@ -122,10 +122,10 @@ fn check_dir_writable(category: &'static str, label: &str, dir: &Path) -> Doctor
 fn dir_size_mb(dir: &Path) -> Option<f64> {
     let mut total: u64 = 0;
     for entry in std::fs::read_dir(dir).ok()?.flatten() {
-        if let Ok(meta) = entry.metadata() {
-            if meta.is_file() {
-                total += meta.len();
-            }
+        if let Ok(meta) = entry.metadata()
+            && meta.is_file()
+        {
+            total += meta.len();
         }
     }
     Some(total as f64 / (1024.0 * 1024.0))

--- a/unraid-rs/src/cli/format.rs
+++ b/unraid-rs/src/cli/format.rs
@@ -667,10 +667,10 @@ fn fmt_connect(data: &Value) {
     println!("Dynamic remote access:");
     println!("  Enabled: {}", str_val(&dra["enabledType"]));
     println!("  Running: {}", str_val(&dra["runningType"]));
-    if let Some(err) = dra["error"].as_str() {
-        if !err.is_empty() {
-            println!("  Error:   {err}");
-        }
+    if let Some(err) = dra["error"].as_str()
+        && !err.is_empty()
+    {
+        println!("  Error:   {err}");
     }
     let settings = &c["settings"]["values"];
     println!("Settings:");
@@ -729,11 +729,7 @@ fn kb_to_tb(v: &Value) -> f64 {
 }
 
 fn yn(v: Option<bool>) -> &'static str {
-    if v == Some(true) {
-        "yes"
-    } else {
-        "no"
-    }
+    if v == Some(true) { "yes" } else { "no" }
 }
 
 /// Parse a GraphQL BigInt value that may arrive as a JSON number or a string.

--- a/unraid-rs/src/cli/parse.rs
+++ b/unraid-rs/src/cli/parse.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use super::{commands::CliCommand, setup::SetupCommand};
 
@@ -94,15 +94,20 @@ impl CliCommand {
             ["recalculate-overview"] => Self::RecalculateOverview,
             ["delete-archived-notifications"] => Self::DeleteArchivedNotifications,
             ["archive-notification", id] => Self::ArchiveNotification(id.to_string()),
-            ["create-notification", title, subject, description, importance, rest @ ..] => {
-                Self::CreateNotification {
-                    title: title.to_string(),
-                    subject: subject.to_string(),
-                    description: description.to_string(),
-                    importance: importance.to_string(),
-                    link: rest.first().map(|s| s.to_string()),
-                }
-            }
+            [
+                "create-notification",
+                title,
+                subject,
+                description,
+                importance,
+                rest @ ..,
+            ] => Self::CreateNotification {
+                title: title.to_string(),
+                subject: subject.to_string(),
+                description: description.to_string(),
+                importance: importance.to_string(),
+                link: rest.first().map(|s| s.to_string()),
+            },
             ["vm-start", id] => Self::VmStart(id.to_string()),
             ["vm-stop", id] => Self::VmStop(id.to_string()),
             ["vm-pause", id] => Self::VmPause(id.to_string()),
@@ -141,25 +146,26 @@ impl CliCommand {
             ["docker-delete-entries", entry_ids @ ..] if !entry_ids.is_empty() => {
                 Self::DockerDeleteEntries(entry_ids.iter().map(|s| s.to_string()).collect())
             }
-            ["docker-move-entries-to-folder", destination_folder_id, source_entry_ids @ ..]
-                if !source_entry_ids.is_empty() =>
-            {
-                Self::DockerMoveEntriesToFolder {
-                    source_entry_ids: source_entry_ids.iter().map(|s| s.to_string()).collect(),
-                    destination_folder_id: destination_folder_id.to_string(),
-                }
-            }
-            ["docker-move-items-to-position", destination_folder_id, position, source_entry_ids @ ..]
-                if !source_entry_ids.is_empty() =>
-            {
-                Self::DockerMoveItemsToPosition {
-                    source_entry_ids: source_entry_ids.iter().map(|s| s.to_string()).collect(),
-                    destination_folder_id: destination_folder_id.to_string(),
-                    position: position
-                        .parse()
-                        .map_err(|e| anyhow::anyhow!("invalid position \"{position}\": {e}"))?,
-                }
-            }
+            [
+                "docker-move-entries-to-folder",
+                destination_folder_id,
+                source_entry_ids @ ..,
+            ] if !source_entry_ids.is_empty() => Self::DockerMoveEntriesToFolder {
+                source_entry_ids: source_entry_ids.iter().map(|s| s.to_string()).collect(),
+                destination_folder_id: destination_folder_id.to_string(),
+            },
+            [
+                "docker-move-items-to-position",
+                destination_folder_id,
+                position,
+                source_entry_ids @ ..,
+            ] if !source_entry_ids.is_empty() => Self::DockerMoveItemsToPosition {
+                source_entry_ids: source_entry_ids.iter().map(|s| s.to_string()).collect(),
+                destination_folder_id: destination_folder_id.to_string(),
+                position: position
+                    .parse()
+                    .map_err(|e| anyhow::anyhow!("invalid position \"{position}\": {e}"))?,
+            },
             ["docker-rename-folder", folder_id, new_name] => Self::DockerRenameFolder {
                 folder_id: folder_id.to_string(),
                 new_name: new_name.to_string(),
@@ -216,19 +222,21 @@ impl CliCommand {
             ["onboarding-refresh-internal-boot-context"] => {
                 Self::OnboardingRefreshInternalBootContext
             }
-            ["onboarding-create-internal-boot-pool", pool_name, boot_size_mib, update_bios, devices @ ..]
-                if !devices.is_empty() =>
-            {
-                Self::OnboardingCreateInternalBootPool {
-                    pool_name: pool_name.to_string(),
-                    devices: devices.iter().map(|s| s.to_string()).collect(),
-                    boot_size_mib: boot_size_mib.parse().map_err(|e| {
-                        anyhow::anyhow!("invalid boot_size_mib \"{boot_size_mib}\": {e}")
-                    })?,
-                    update_bios: update_bios.eq_ignore_ascii_case("true"),
-                    reboot: None,
-                }
-            }
+            [
+                "onboarding-create-internal-boot-pool",
+                pool_name,
+                boot_size_mib,
+                update_bios,
+                devices @ ..,
+            ] if !devices.is_empty() => Self::OnboardingCreateInternalBootPool {
+                pool_name: pool_name.to_string(),
+                devices: devices.iter().map(|s| s.to_string()).collect(),
+                boot_size_mib: boot_size_mib.parse().map_err(|e| {
+                    anyhow::anyhow!("invalid boot_size_mib \"{boot_size_mib}\": {e}")
+                })?,
+                update_bios: update_bios.eq_ignore_ascii_case("true"),
+                reboot: None,
+            },
             ["archive-notifications", ids @ ..] if !ids.is_empty() => {
                 Self::ArchiveNotifications(ids.iter().map(|s| s.to_string()).collect())
             }
@@ -269,22 +277,30 @@ impl CliCommand {
                     .parse()
                     .map_err(|e| anyhow::anyhow!("invalid port \"{port}\": {e}"))?,
             },
-            ["initiate-flash-backup", remote_name, source_path, destination_path] => {
-                Self::InitiateFlashBackup {
-                    remote_name: remote_name.to_string(),
-                    source_path: source_path.to_string(),
-                    destination_path: destination_path.to_string(),
-                }
-            }
-            ["notify-if-unique", title, subject, description, importance, rest @ ..] => {
-                Self::NotifyIfUnique {
-                    title: title.to_string(),
-                    subject: subject.to_string(),
-                    description: description.to_string(),
-                    importance: importance.to_string(),
-                    link: rest.first().map(|s| s.to_string()),
-                }
-            }
+            [
+                "initiate-flash-backup",
+                remote_name,
+                source_path,
+                destination_path,
+            ] => Self::InitiateFlashBackup {
+                remote_name: remote_name.to_string(),
+                source_path: source_path.to_string(),
+                destination_path: destination_path.to_string(),
+            },
+            [
+                "notify-if-unique",
+                title,
+                subject,
+                description,
+                importance,
+                rest @ ..,
+            ] => Self::NotifyIfUnique {
+                title: title.to_string(),
+                subject: subject.to_string(),
+                description: description.to_string(),
+                importance: importance.to_string(),
+                link: rest.first().map(|s| s.to_string()),
+            },
             ["doctor"] => Self::Doctor,
             ["setup", "check"] => Self::Setup(SetupCommand::Check),
             ["setup", "repair"] => Self::Setup(SetupCommand::Repair),

--- a/unraid-rs/src/cli/setup.rs
+++ b/unraid-rs/src/cli/setup.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use serde::Serialize;
 
-use unraid_rmcp::config::{default_data_dir, AuthMode, Config};
+use unraid_rmcp::config::{AuthMode, Config, default_data_dir};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SetupCommand {
@@ -107,8 +107,12 @@ pub fn apply_plugin_options() {
             if s.is_empty() || s.contains('\n') || s.contains('\r') {
                 continue;
             }
-            // edition 2021: set_var is safe (no unsafe block required).
-            std::env::set_var(dest, v);
+            // SAFETY: edition 2024 marks `set_var` unsafe because a concurrent
+            // environment read from another thread is UB. This runs once during
+            // CLI startup, before `Config::load()` and before any task or thread
+            // that reads the environment is spawned, so no concurrent access is
+            // possible.
+            unsafe { std::env::set_var(dest, v) };
         }
     }
 }

--- a/unraid-rs/src/config.rs
+++ b/unraid-rs/src/config.rs
@@ -235,13 +235,13 @@ impl Config {
             "UNRAID_RMCP_GOOGLE_CLIENT_SECRET",
             &mut config.mcp.auth.google_client_secret,
         );
-        if let Ok(v) = std::env::var("UNRAID_RMCP_AUTH_MODE") {
-            if !v.is_empty() {
-                config.mcp.auth.mode = match v.to_lowercase().as_str() {
-                    "oauth" => AuthMode::OAuth,
-                    _ => AuthMode::Bearer,
-                };
-            }
+        if let Ok(v) = std::env::var("UNRAID_RMCP_AUTH_MODE")
+            && !v.is_empty()
+        {
+            config.mcp.auth.mode = match v.to_lowercase().as_str() {
+                "oauth" => AuthMode::OAuth,
+                _ => AuthMode::Bearer,
+            };
         }
 
         // Unraid API
@@ -272,28 +272,28 @@ impl Config {
 // ── env helpers ───────────────────────────────────────────────────────────────
 
 fn env_str(key: &str, target: &mut String) {
-    if let Ok(v) = std::env::var(key) {
-        if !v.is_empty() {
-            *target = v;
-        }
+    if let Ok(v) = std::env::var(key)
+        && !v.is_empty()
+    {
+        *target = v;
     }
 }
 
 fn env_opt_str(key: &str, target: &mut Option<String>) {
-    if let Ok(v) = std::env::var(key) {
-        if !v.is_empty() {
-            *target = Some(v);
-        }
+    if let Ok(v) = std::env::var(key)
+        && !v.is_empty()
+    {
+        *target = Some(v);
     }
 }
 
 fn env_parse<T: std::str::FromStr>(key: &str, target: &mut T) -> anyhow::Result<()> {
-    if let Ok(v) = std::env::var(key) {
-        if !v.is_empty() {
-            *target = v
-                .parse()
-                .map_err(|_| anyhow::anyhow!("{key}: invalid value {v:?}"))?;
-        }
+    if let Ok(v) = std::env::var(key)
+        && !v.is_empty()
+    {
+        *target = v
+            .parse()
+            .map_err(|_| anyhow::anyhow!("{key}: invalid value {v:?}"))?;
     }
     Ok(())
 }

--- a/unraid-rs/src/graphql.rs
+++ b/unraid-rs/src/graphql.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use reqwest::Client;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use thiserror::Error;
 
 use crate::config::UnraidConfig;

--- a/unraid-rs/src/logging.rs
+++ b/unraid-rs/src/logging.rs
@@ -4,7 +4,7 @@ mod formatter;
 use std::io::IsTerminal;
 use std::path::Path;
 
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 use formatter::AuroraFormatter;
 
@@ -40,12 +40,11 @@ pub fn init_logging(data_dir: &Path, service_name: &str) -> anyhow::Result<()> {
     let max_bytes: u64 = 10 * 1024 * 1024; // 10 MB
 
     // Truncate if over the cap.
-    if log_path.exists() {
-        if let Ok(meta) = log_path.metadata() {
-            if meta.len() >= max_bytes {
-                let _ = std::fs::write(&log_path, b"");
-            }
-        }
+    if log_path.exists()
+        && let Ok(meta) = log_path.metadata()
+        && meta.len() >= max_bytes
+    {
+        let _ = std::fs::write(&log_path, b"");
     }
 
     let log_file = std::fs::OpenOptions::new()

--- a/unraid-rs/src/logging/formatter.rs
+++ b/unraid-rs/src/logging/formatter.rs
@@ -2,13 +2,13 @@ use std::collections::BTreeMap;
 use std::fmt as stdfmt;
 
 use tracing::{
-    field::{Field, Visit},
     Event, Subscriber,
+    field::{Field, Visit},
 };
 use tracing_subscriber::{
     fmt::{
-        format::{FormatEvent, FormatFields, Writer},
         FmtContext,
+        format::{FormatEvent, FormatFields, Writer},
     },
     registry::LookupSpan,
 };

--- a/unraid-rs/src/main.rs
+++ b/unraid-rs/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{transport::stdio, ServiceExt};
+use rmcp::{ServiceExt, transport::stdio};
 use std::sync::Arc;
 use tracing::info;
 

--- a/unraid-rs/src/mcp.rs
+++ b/unraid-rs/src/mcp.rs
@@ -13,7 +13,7 @@ mod schemas;
 pub(crate) mod tools;
 
 pub use rmcp_server::{
-    rmcp_server, streamable_http_config, streamable_http_service, UnraidRmcpServer,
+    UnraidRmcpServer, rmcp_server, streamable_http_config, streamable_http_service,
 };
 pub use routes::router;
 pub use schemas::{data_action_names, write_action_names};

--- a/unraid-rs/src/mcp/elicitation.rs
+++ b/unraid-rs/src/mcp/elicitation.rs
@@ -1,4 +1,4 @@
-use rmcp::{service::ElicitationError, Peer, RoleServer};
+use rmcp::{Peer, RoleServer, service::ElicitationError};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
@@ -226,7 +226,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::mcp::schemas::{Scope, ACTIONS};
+    use crate::mcp::schemas::{ACTIONS, Scope};
 
     #[test]
     fn destructive_registry_is_unique_and_write_scoped() {
@@ -244,16 +244,14 @@ mod tests {
 
     #[test]
     fn array_stop_elicits_but_start_does_not() {
-        assert!(destructive_action_description(
-            "array_set_state",
-            &json!({"desired_state": "STOP"})
-        )
-        .is_some());
-        assert!(destructive_action_description(
-            "array_set_state",
-            &json!({"desired_state": "START"})
-        )
-        .is_none());
+        assert!(
+            destructive_action_description("array_set_state", &json!({"desired_state": "STOP"}))
+                .is_some()
+        );
+        assert!(
+            destructive_action_description("array_set_state", &json!({"desired_state": "START"}))
+                .is_none()
+        );
     }
 
     #[test]

--- a/unraid-rs/src/mcp/host_filter.rs
+++ b/unraid-rs/src/mcp/host_filter.rs
@@ -27,10 +27,10 @@ pub(crate) fn allowed_origins(config: &McpConfig) -> Vec<String> {
         format!("http://127.0.0.1:{}", config.port),
     ];
     origins.extend(config.allowed_origins.iter().cloned());
-    if let Some(public_url) = config.auth.public_url.as_deref() {
-        if let Some(origin) = extract_origin(public_url) {
-            origins.push(origin);
-        }
+    if let Some(public_url) = config.auth.public_url.as_deref()
+        && let Some(origin) = extract_origin(public_url)
+    {
+        origins.push(origin);
     }
     origins.sort();
     origins.dedup();

--- a/unraid-rs/src/mcp/prompts.rs
+++ b/unraid-rs/src/mcp/prompts.rs
@@ -1,6 +1,5 @@
 use rmcp::model::{
-    GetPromptRequestParams, GetPromptResult, ListPromptsResult, Prompt, PromptMessage,
-    PromptMessageRole,
+    GetPromptRequestParams, GetPromptResult, ListPromptsResult, Prompt, PromptMessage, Role,
 };
 
 pub(super) fn list_prompts() -> ListPromptsResult {
@@ -17,7 +16,7 @@ pub(super) fn list_prompts() -> ListPromptsResult {
 pub(super) fn get_prompt(request: GetPromptRequestParams) -> anyhow::Result<GetPromptResult> {
     match request.name.as_str() {
         "server_summary" => Ok(GetPromptResult::new(vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "Use the unraid tool with action=info to retrieve the current server status, \
              then provide a concise summary covering array state, disk health, \
              running VMs, Docker containers, and any active notifications.",

--- a/unraid-rs/src/mcp/rmcp_server.rs
+++ b/unraid-rs/src/mcp/rmcp_server.rs
@@ -2,29 +2,30 @@ use std::{borrow::Cow, sync::Arc, time::Instant};
 
 use lab_auth::AuthContext;
 use rmcp::{
+    ErrorData, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResult, Content, GetPromptRequestParams, GetPromptResult,
-        Implementation, ListPromptsResult, ListResourcesResult, ListToolsResult,
-        PaginatedRequestParams, RawResource, ReadResourceRequestParams, ReadResourceResult,
-        Resource, ResourceContents, ServerCapabilities, ServerInfo, Tool,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+        GetPromptRequestParams, GetPromptResponse, Implementation, ListPromptsResult,
+        ListResourcesResult, ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams,
+        ReadResourceResponse, ReadResourceResult, Resource, ResourceContents, ServerCapabilities,
+        ServerInfo, Tool,
     },
     service::RequestContext,
     transport::streamable_http_server::{
-        session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     },
-    ErrorData, RoleServer, ServerHandler,
 };
 use serde_json::{Map, Value};
 
 use crate::config::McpConfig;
 
 use super::{
+    AppState, AuthPolicy,
     elicitation::require_destructive_elicitation,
     host_filter::{allowed_hosts, allowed_origins},
     prompts,
-    schemas::{tool_definitions, ACTIONS},
+    schemas::{ACTIONS, tool_definitions},
     tools::{execute_tool, serialize_response},
-    AppState, AuthPolicy,
 };
 
 const READ_SCOPE: &str = "unraid:read";
@@ -61,7 +62,7 @@ impl ServerHandler for UnraidRmcpServer {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, ErrorData> {
+    ) -> Result<CallToolResponse, ErrorData> {
         let tool_name = request.name.to_string();
 
         let action: String = request
@@ -99,7 +100,7 @@ impl ServerHandler for UnraidRmcpServer {
                 reason = %message,
                 "MCP destructive action stopped by elicitation"
             );
-            return Ok(CallToolResult::error(vec![Content::text(message)]));
+            return Ok(CallToolResult::error(vec![ContentBlock::text(message)]).into());
         }
 
         // All errors become agent-readable CallToolResult::error — never Err(ErrorData).
@@ -109,12 +110,13 @@ impl ServerHandler for UnraidRmcpServer {
                 let elapsed = started.elapsed().as_millis();
                 tracing::info!(tool = %tool_name, elapsed_ms = elapsed, "MCP tool execution completed");
                 match serialize_response(result) {
-                    Ok(text) => Ok(CallToolResult::success(vec![Content::text(text)])),
+                    Ok(text) => Ok(CallToolResult::success(vec![ContentBlock::text(text)]).into()),
                     Err(e) => {
                         self.state.counters.inc_errors();
-                        Ok(CallToolResult::error(vec![Content::text(format!(
+                        Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                             "ERROR: serialization failed\nReason: {e}"
-                        ))]))
+                        ))])
+                        .into())
                     }
                 }
             }
@@ -132,7 +134,7 @@ impl ServerHandler for UnraidRmcpServer {
                     Err(ErrorData::invalid_params(msg, None))
                 } else {
                     tracing::error!(tool = %tool_name, elapsed_ms = elapsed, error = %msg, "MCP tool execution failed");
-                    Ok(CallToolResult::error(vec![Content::text(msg)]))
+                    Ok(CallToolResult::error(vec![ContentBlock::text(msg)]).into())
                 }
             }
         }
@@ -156,7 +158,7 @@ impl ServerHandler for UnraidRmcpServer {
         &self,
         request: ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, ErrorData> {
+    ) -> Result<ReadResourceResponse, ErrorData> {
         require_auth_context(&self.state, &context)?;
         if request.uri != SCHEMA_RESOURCE_URI {
             return Err(ErrorData::invalid_params(
@@ -167,11 +169,10 @@ impl ServerHandler for UnraidRmcpServer {
         let schema = tool_definitions();
         let text = serde_json::to_string_pretty(&schema)
             .map_err(|e| ErrorData::internal_error(format!("serialization error: {e}"), None))?;
-        Ok(ReadResourceResult::new(vec![ResourceContents::text(
-            text,
-            SCHEMA_RESOURCE_URI,
-        )
-        .with_mime_type("application/json")]))
+        Ok(ReadResourceResult::new(vec![
+            ResourceContents::text(text, SCHEMA_RESOURCE_URI).with_mime_type("application/json"),
+        ])
+        .into())
     }
 
     // ── prompts ───────────────────────────────────────────────────────────────
@@ -189,9 +190,11 @@ impl ServerHandler for UnraidRmcpServer {
         &self,
         request: GetPromptRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<GetPromptResult, ErrorData> {
+    ) -> Result<GetPromptResponse, ErrorData> {
         require_auth_context(&self.state, &context)?;
-        prompts::get_prompt(request).map_err(|e| ErrorData::invalid_params(e.to_string(), None))
+        prompts::get_prompt(request)
+            .map(Into::into)
+            .map_err(|e| ErrorData::invalid_params(e.to_string(), None))
     }
 
     // ── server info ───────────────────────────────────────────────────────────
@@ -215,7 +218,7 @@ impl ServerHandler for UnraidRmcpServer {
 
 pub fn streamable_http_config(config: &McpConfig) -> StreamableHttpServerConfig {
     StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_allowed_hosts(allowed_hosts(config))
         .with_allowed_origins(allowed_origins(config))
@@ -241,12 +244,9 @@ pub fn streamable_http_service(
 const SCHEMA_RESOURCE_URI: &str = "unraid://schema/mcp-tool";
 
 fn schema_resource() -> Resource {
-    Resource::new(
-        RawResource::new(SCHEMA_RESOURCE_URI, "unraid tool schema")
-            .with_description("JSON schema for the unraid MCP tool and its action-based parameters")
-            .with_mime_type("application/json"),
-        None,
-    )
+    Resource::new(SCHEMA_RESOURCE_URI, "unraid tool schema")
+        .with_description("JSON schema for the unraid MCP tool and its action-based parameters")
+        .with_mime_type("application/json")
 }
 
 // ── tool definition conversion ────────────────────────────────────────────────

--- a/unraid-rs/src/mcp/routes.rs
+++ b/unraid-rs/src/mcp/routes.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use axum::{
+    Router,
     extract::State,
-    http::{header, HeaderName, HeaderValue, Method, StatusCode},
+    http::{HeaderName, HeaderValue, Method, StatusCode, header},
     response::{IntoResponse, Json},
     routing::get,
-    Router,
 };
 use serde_json::json;
 use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer};
@@ -15,7 +15,7 @@ use crate::observability::probe_upstream;
 
 use super::host_filter::allowed_origins;
 use super::rmcp_server::{streamable_http_config, streamable_http_service};
-use super::{build_auth_layer, AppState, AuthPolicy};
+use super::{AppState, AuthPolicy, build_auth_layer};
 
 const MCP_BODY_LIMIT_BYTES: usize = 65_536;
 

--- a/unraid-rs/src/mcp/schemas.rs
+++ b/unraid-rs/src/mcp/schemas.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Canonical specification for one `unraid` tool action.
 ///

--- a/unraid-rs/src/mcp/tools.rs
+++ b/unraid-rs/src/mcp/tools.rs
@@ -3,7 +3,7 @@ pub(crate) mod paginate;
 
 use std::sync::LazyLock;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use thiserror::Error;
 
 use crate::graphql::UpstreamError;
@@ -11,8 +11,8 @@ use crate::token_limit::truncate_if_needed;
 
 use self::arg_helpers::{i64_arg, string_arg, string_array_arg, usize_arg};
 use self::paginate::paginate_array;
-use super::schemas::ACTIONS;
 use super::AppState;
+use super::schemas::ACTIONS;
 
 /// Typed outcome of a tool dispatch, used to *route* failures at the MCP protocol
 /// boundary without matching on message prose.
@@ -371,9 +371,11 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
         "preview_effective_permissions" => {
             let roles = string_array_arg(args, "roles");
             let permissions = args.get("permissions").cloned().unwrap_or(Value::Null);
-            svc!(state
-                .service
-                .preview_effective_permissions(roles.as_deref(), &permissions))
+            svc!(
+                state
+                    .service
+                    .preview_effective_permissions(roles.as_deref(), &permissions)
+            )
         }
 
         // ── mutations (require unraid:admin) ──
@@ -530,9 +532,11 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
                         .to_string(),
                 )
             })?;
-            svc!(state
-                .service
-                .docker_move_entries_to_folder(&source_entry_ids, &destination_folder_id))
+            svc!(
+                state
+                    .service
+                    .docker_move_entries_to_folder(&source_entry_ids, &destination_folder_id)
+            )
         }
         "docker_move_items_to_position" => {
             let source_entry_ids = string_array_arg(args, "source_entry_ids").ok_or_else(|| {
@@ -580,9 +584,11 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
                 .get("prefs")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!({}));
-            svc!(state
-                .service
-                .docker_update_view_preferences(string_arg(args, "view_id").as_deref(), prefs))
+            svc!(
+                state
+                    .service
+                    .docker_update_view_preferences(string_arg(args, "view_id").as_deref(), prefs)
+            )
         }
         "docker_update_autostart_configuration" => {
             let entries = args
@@ -595,11 +601,13 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
                             .to_string(),
                     )
                 })?;
-            svc!(state.service.docker_update_autostart_configuration(
-                entries,
-                args.get("persist_user_preferences")
-                    .and_then(|v| v.as_bool())
-            ))
+            svc!(
+                state.service.docker_update_autostart_configuration(
+                    entries,
+                    args.get("persist_user_preferences")
+                        .and_then(|v| v.as_bool())
+                )
+            )
         }
         "refresh_docker_digests" => svc!(state.service.refresh_docker_digests()),
         "reset_docker_template_mappings" => svc!(state.service.reset_docker_template_mappings()),
@@ -766,9 +774,11 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
                 .get("parameters")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!({}));
-            svc!(state
-                .service
-                .rclone_create_r_clone_remote(&name, &ty, parameters))
+            svc!(
+                state
+                    .service
+                    .rclone_create_r_clone_remote(&name, &ty, parameters)
+            )
         }
         "rclone_delete_r_clone_remote" => {
             let name = string_arg(args, "name").ok_or_else(|| {
@@ -894,12 +904,16 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
             let id = require_id(args, "unread_notification")?;
             svc!(state.service.unread_notification(&id))
         }
-        "archive_all" => svc!(state
-            .service
-            .archive_all(string_arg(args, "importance").as_deref())),
-        "unarchive_all" => svc!(state
-            .service
-            .unarchive_all(string_arg(args, "importance").as_deref())),
+        "archive_all" => svc!(
+            state
+                .service
+                .archive_all(string_arg(args, "importance").as_deref())
+        ),
+        "unarchive_all" => svc!(
+            state
+                .service
+                .unarchive_all(string_arg(args, "importance").as_deref())
+        ),
         "update_server_identity" => {
             let name = string_arg(args, "name").ok_or_else(|| {
                 ToolError::InvalidParams(
@@ -954,9 +968,11 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
                     "\"api_key\" is required for action=connect_sign_in.".to_string(),
                 )
             })?;
-            svc!(state
-                .service
-                .connect_sign_in(&api_key, args.get("user_info").cloned()))
+            svc!(
+                state
+                    .service
+                    .connect_sign_in(&api_key, args.get("user_info").cloned())
+            )
         }
         "setup_remote_access" => {
             let access_type = string_arg(args, "access_type").ok_or_else(|| {

--- a/unraid-rs/src/mcp/tools/paginate.rs
+++ b/unraid-rs/src/mcp/tools/paginate.rs
@@ -1,4 +1,4 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Wrap a list at `path` inside `data` with pagination + optional filter metadata.
 ///

--- a/unraid-rs/src/mock.rs
+++ b/unraid-rs/src/mock.rs
@@ -71,14 +71,14 @@ pub fn classify_query(query: &str) -> Option<std::borrow::Cow<'static, str>> {
         "unraidPlugins",
     ];
     if is_mutation {
-        if NS.contains(&root) {
-            if let Some(sub) = subfields.first() {
-                return Some(Cow::Owned(format!(
-                    "{}_{}",
-                    to_snake_case(root),
-                    to_snake_case(sub)
-                )));
-            }
+        if NS.contains(&root)
+            && let Some(sub) = subfields.first()
+        {
+            return Some(Cow::Owned(format!(
+                "{}_{}",
+                to_snake_case(root),
+                to_snake_case(sub)
+            )));
         }
         // The Docker Organizer mutations are direct Mutation-root fields (not
         // nested under `docker { ... }`), but their MCP action names carry a

--- a/unraid-rs/src/observability.rs
+++ b/unraid-rs/src/observability.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// Shared atomic counters for observability. Wrap in `Arc` so all `AppState`

--- a/unraid-rs/tests/auth_modes.rs
+++ b/unraid-rs/tests/auth_modes.rs
@@ -14,7 +14,7 @@
 
 use axum::{
     body::to_bytes,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
 };
 use tempfile::TempDir;
 use tower::util::ServiceExt;

--- a/unraid-rs/tests/live_schema_contract.rs
+++ b/unraid-rs/tests/live_schema_contract.rs
@@ -11,10 +11,10 @@
 
 use std::collections::BTreeMap;
 
+use apollo_compiler::Schema;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::schema::ExtendedType;
-use apollo_compiler::Schema;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 const SCHEMA_SDL: &str = include_str!("../schema/unraid-schema.graphql");
 const LIVE_CONTRACT: &str = include_str!("../schema/live-introspection.json");

--- a/unraid-rs/tests/oauth_flow.rs
+++ b/unraid-rs/tests/oauth_flow.rs
@@ -6,7 +6,7 @@
 
 use axum::{
     body::to_bytes,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
 };
 use lab_auth::jwt::AccessClaims;
 use lab_auth::metadata::canonical_resource_url;

--- a/unraid-rs/tests/rmcp_compat.rs
+++ b/unraid-rs/tests/rmcp_compat.rs
@@ -1,13 +1,13 @@
 use axum::{
-    body::{to_bytes, Body},
-    http::{header, Request, StatusCode},
     Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header},
 };
 use rmcp::{
-    transport::streamable_http_server::{
-        session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
-    },
     ServerHandler,
+    transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    },
 };
 use tower::util::ServiceExt;
 
@@ -66,7 +66,7 @@ async fn post_initialize(router: Router) -> (StatusCode, axum::http::HeaderMap, 
 #[tokio::test]
 async fn rmcp_stateless_json_response_returns_application_json() {
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_sse_keep_alive(None);
 
@@ -91,7 +91,7 @@ async fn rmcp_stateless_json_response_returns_application_json() {
 #[tokio::test]
 async fn rmcp_stateless_sse_mode_is_distinct_from_json_response_target() {
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_sse_keep_alive(None);
 
     let (status, headers, body) = post_initialize(compat_router(config)).await;

--- a/unraid-rs/tests/scenarios.rs
+++ b/unraid-rs/tests/scenarios.rs
@@ -7,8 +7,8 @@
 //! if a query were misrouted, the action would get the wrong (or an `errors`)
 //! payload and the dispatch would fail.
 
-use serde_json::{json, Value};
-use unraid_rmcp::mock::{Scenario, SCENARIOS};
+use serde_json::{Value, json};
+use unraid_rmcp::mock::{SCENARIOS, Scenario};
 use unraid_rmcp::testing::{execute_tool, state_with_upstream};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 

--- a/unraid-rs/tests/schema_contract.rs
+++ b/unraid-rs/tests/schema_contract.rs
@@ -25,7 +25,7 @@ use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::{ExecutableDocument, Name, Schema};
 use serde_json::Value;
-use unraid_rmcp::mock::{Scenario, SCENARIOS};
+use unraid_rmcp::mock::{SCENARIOS, Scenario};
 use unraid_rmcp::testing::{execute_tool, state_with_upstream};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 

--- a/unraid-rs/tests/setup_contract.rs
+++ b/unraid-rs/tests/setup_contract.rs
@@ -39,11 +39,13 @@ fn setup_plugin_hook_no_repair_emits_json_contract() {
     assert_eq!(json["ran_repair"], false);
     assert_eq!(json["no_repair"], true);
     assert!(json["blocking_failures"].as_array().unwrap().is_empty());
-    assert!(json["advisory_failures"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|failure| failure["code"] == "env_file_missing"));
+    assert!(
+        json["advisory_failures"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|failure| failure["code"] == "env_file_missing")
+    );
     assert!(!dir.path().join(".env").exists());
 }
 

--- a/unraid-rs/tests/spike_rmcp_extensions.rs
+++ b/unraid-rs/tests/spike_rmcp_extensions.rs
@@ -1,12 +1,12 @@
-// Regression test: verifies rmcp 1.6 axum-extension propagation (syslog-mcp-brt0.10).
+// Regression test: verifies rmcp axum-extension propagation (syslog-mcp-brt0.10).
 // See docs/internal/rmcp-auth-spike.md for the investigation that confirmed Pattern (a).
 //
 // Proves that axum request extensions set by middleware ARE propagated into
-// rmcp 1.6's `RequestContext.extensions` for tool handlers, when using
+// rmcp's `RequestContext.extensions` for tool handlers, when using
 // `transport-streamable-http-server`. This is the empirical verification for
 // the syslog-mcp-brt0.10 spike.
 //
-// rmcp 1.6 publishes `http::request::Parts` into the JSON-RPC request's
+// rmcp publishes `http::request::Parts` into the JSON-RPC request's
 // extensions before dispatching. Any axum middleware that calls
 // `request.extensions_mut().insert(value)` upstream of the rmcp
 // `StreamableHttpService` will be visible inside a tool handler via:
@@ -14,31 +14,33 @@
 //     let parts = ctx.extensions.get::<http::request::Parts>().unwrap();
 //     let value = parts.extensions.get::<AuthContext>().unwrap();
 //
-// This works in BOTH `stateful_mode(true)` and `stateful_mode(false)`. The
-// current syslog-mcp deployment uses stateful_mode(false); no flip required.
+// This works with the session knob in BOTH positions. The knob was named
+// `stateful_mode` up to rmcp 2.x and is `legacy_session_mode` from 3.0 on
+// (SEP-2567 drops sessions from the current draft, so it now only governs
+// legacy protocol versions). The deployment sets it to false; no flip required.
 //
 // See `docs/internal/rmcp-auth-spike.md` for full write-up.
 
 use std::sync::{Arc, Mutex};
 
 use axum::{
-    body::{to_bytes, Body},
+    Router,
+    body::{Body, to_bytes},
     extract::Request,
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     middleware::{self, Next},
     response::Response,
-    Router,
 };
 use rmcp::{
+    ErrorData, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResult, Content, ListToolsResult, PaginatedRequestParams,
-        ServerCapabilities, ServerInfo, Tool,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ListToolsResult,
+        PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
     },
     service::RequestContext,
     transport::streamable_http_server::{
-        session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     },
-    ErrorData, RoleServer, ServerHandler,
 };
 use tower::util::ServiceExt;
 
@@ -88,7 +90,7 @@ impl ServerHandler for SpikeServer {
         &self,
         _request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, ErrorData> {
+    ) -> Result<CallToolResponse, ErrorData> {
         // Pattern (a): rmcp injects http::request::Parts into request extensions.
         // Axum middleware extensions live inside Parts.extensions.
         let parts = context
@@ -108,10 +110,11 @@ impl ServerHandler for SpikeServer {
 
         *self.observed.0.lock().unwrap() = Some(auth.clone());
 
-        Ok(CallToolResult::success(vec![Content::text(format!(
+        Ok(CallToolResult::success(vec![ContentBlock::text(format!(
             "subject={} scopes={:?}",
             auth.subject, auth.scopes
-        ))]))
+        ))])
+        .into())
     }
 
     fn get_info(&self) -> ServerInfo {
@@ -131,7 +134,7 @@ async fn auth_middleware(mut req: Request, next: Next) -> Response {
 
 fn build_router(observed: Observed, stateful: bool) -> Router {
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(stateful)
+        .with_legacy_session_mode(stateful)
         .with_json_response(true)
         .with_sse_keep_alive(None);
 

--- a/unraid-rs/tests/stdio_mcp.rs
+++ b/unraid-rs/tests/stdio_mcp.rs
@@ -1,19 +1,19 @@
 use std::{
     process::Stdio,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
 use rmcp::{
+    ClientHandler, ErrorData,
     model::{
-        CallToolRequestParams, ClientCapabilities, ClientInfo, CreateElicitationRequestParams,
-        CreateElicitationResult, ElicitationAction, Implementation,
+        CallToolRequestParams, ClientCapabilities, ClientInfo, ElicitRequestParams, ElicitResult,
+        ElicitationAction, Implementation,
     },
     service::{RequestContext, RoleClient, RunningService, ServiceExt},
     transport::{ConfigureCommandExt, TokioChildProcess},
-    ClientHandler, ErrorData,
 };
 use serde_json::json;
 use tempfile::TempDir;
@@ -95,15 +95,13 @@ impl ClientHandler for ElicitingClient {
 
     async fn create_elicitation(
         &self,
-        _request: CreateElicitationRequestParams,
+        _request: ElicitRequestParams,
         _context: RequestContext<RoleClient>,
-    ) -> Result<CreateElicitationResult, ErrorData> {
+    ) -> Result<ElicitResult, ErrorData> {
         self.calls.fetch_add(1, Ordering::SeqCst);
         let mut result = match self.decision {
-            ElicitationDecision::Accept => CreateElicitationResult::new(ElicitationAction::Accept),
-            ElicitationDecision::Decline => {
-                CreateElicitationResult::new(ElicitationAction::Decline)
-            }
+            ElicitationDecision::Accept => ElicitResult::new(ElicitationAction::Accept),
+            ElicitationDecision::Decline => ElicitResult::new(ElicitationAction::Decline),
         };
         if matches!(self.decision, ElicitationDecision::Accept) {
             result.content = Some(json!({"confirmed": true}));

--- a/unraid-rs/tests/upstream.rs
+++ b/unraid-rs/tests/upstream.rs
@@ -7,7 +7,7 @@
 //!      gracefully and raw upstream bodies are never relayed to the caller.
 //!   C. Test L3 — `Counters` survives concurrent increments with no lost updates.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use unraid_rmcp::observability::Counters;
 use unraid_rmcp::testing::{execute_tool, state_with_upstream};
 use wiremock::matchers::method;

--- a/unraid-rs/xtask/Cargo.toml
+++ b/unraid-rs/xtask/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
+
+rust-version.workspace = true
 name = "xtask"
 version = "0.2.5"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/unraid-rs/xtask/src/main.rs
+++ b/unraid-rs/xtask/src/main.rs
@@ -9,7 +9,7 @@
 //!   check-env    Validate required environment variables
 
 use std::env;
-use std::process::{exit, Command};
+use std::process::{Command, exit};
 
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();


### PR DESCRIPTION
Aligns the four things this fleet had drifting independently: build toolchain, MSRV, edition, and the rmcp pin.

| | before (spread across 13 repos) | after |
|---|---|---|
| `rust-toolchain.toml` | 4 of 13 pinned, all 4 different (1.90 / 1.94.1 / 1.96.0) | **13/13 at 1.97.1** |
| `rust-version` | 1.86 / 1.90 / 1.92 / 1.94.0 / 1.96 / none | **13/13 at 1.97.1** |
| edition | 44 of 90 crates on 2021 | **90/90 on 2024** |
| rmcp | 1.7.0 / 1.8.0 / 2.2.0 / 3.0.0-beta.2, 6 repos caret-drifted | **13/13 at `=3.0.0-beta.2`, declared == locked** |

### Why the MSRV could move

[ADR-0001](https://github.com/dinglebear-ai/labby) deferred the MSRV because `unraid-rmcp` and `lab-auth` carry `publish = ["crates-io"]`, so raising the floor looked like narrowing a public promise. **Neither crate has ever been published** — both return 404 from the crates.io API (control: `serde` returns 200). With no published version there is no downstream consumer, so the blocker was a promise nobody had made. Recorded as ADR-0024.

Patch granularity (`1.97.1`, not `1.97`) is deliberate: 1.97.1 exists to fix an LLVM miscompilation present since 1.87, so an MSRV of `1.97` would declare the known-bad 1.97.0 as supported.

### Verification

Per repo: `cargo metadata --no-deps` for the resolved edition and `rust_version` on every package (inheritance means manifest text and resolved value are different questions), then `clippy --all-targets -D warnings`, the full test suite, and `cargo fmt --check`.

### Three things worth knowing

**Raising the MSRV turns clippy lints on.** Clippy suppresses suggestions whose replacement API is unavailable at the declared floor, so raising it unlocks them. cortex gained 107 sites (102 `collapsible_if` from let-chains stable in 1.88, 5 `manual_is_multiple_of` from 1.87); labby-auth gained 8 `Duration::from_hours`/`from_mins`. Confirmed by controlled experiment — same tree at the old floor reports zero. All auto-applicable.

**rustfmt's style edition follows the crate edition.** Flipping the key reformats import blocks. Six repos drifted (unraid-rs 53, rgotify 30, rapprise 26, rtailscale 21, synapse 2, axon 1) and **none of `check`, `clippy`, or `test` catches it** — only `cargo fmt --check`, which CI runs separately.

**One rmcp change has no compile error.** rmcp 3.0's SEP-2260 request association rejects server→client requests (elicit/sampling/roots) when the call escapes the request-handler scope, which is a tokio task-local. Any spawn between `call_tool` and an elicit silently breaks destructive-action gating against modern clients. yarr and synapse were both audited clean — but it took three greps across two repos to get there, with three non-overlapping blind spots. Written up as BC-11 in the fleet rmcp-migration doc.