### PR TITLE
fix(unraid-py): support Unraid 7.3 GraphQL changes

### DIFF
--- a/agents/unraid-py/skills/unraid/README.md
+++ b/agents/unraid-py/skills/unraid/README.md
@@ -96,6 +96,6 @@ UPS/power status, live CPU/memory, API keys, and rclone remotes.
 ## Notes
 
 - Array/disk sizes are in **kilobytes**; memory values are in **bytes**; temperatures in **Celsius**.
-- Docker container logs are **not** available via the API — use SSH + `docker logs`.
+- Docker container logs are available through `unraid(action="docker", subaction="logs", container_id=...)`.
 - Destructive subactions require `confirm=True` (see the Destructive Actions table in `SKILL.md`).
 - Rate limit: 100 requests / 10 seconds.

--- a/agents/unraid-py/skills/unraid/SKILL.md
+++ b/agents/unraid-py/skills/unraid/SKILL.md
@@ -376,6 +376,8 @@ unraid(action="health", subaction="check")
 ```text
 unraid(action="docker", subaction="list")
 unraid(action="docker", subaction="details", container_id="plex")
+unraid(action="docker", subaction="logs", container_id="plex", tail_lines=100)
+unraid(action="docker", subaction="check_updates")
 unraid(action="docker", subaction="restart", container_id="sonarr")
 ```
 
@@ -412,7 +414,7 @@ unraid(action="vm", subaction="force_stop", vm_id="<id>", confirm=True)
 
 - **Rate limit:** 100 requests / 10 seconds
 - **Log path validation:** Only `/var/log/`, `/boot/logs/`, `/mnt/` prefixes accepted
-- **Container logs:** Docker container stdout/stderr are NOT accessible via API — use SSH + `docker logs`
+- **Container logs:** Use `docker/logs` with `container_id` and optional `tail_lines`
 - **`arraySubscription`:** Known Unraid API bug — `live/array_state` may show "connecting" indefinitely
 - **Event-driven subs** (`notifications_overview`, `owner`, `server_status`, `ups_status`): Only populate cache on first real server event
 

--- a/agents/unraid-py/skills/unraid/references/api-reference.md
+++ b/agents/unraid-py/skills/unraid/references/api-reference.md
@@ -560,7 +560,7 @@ curl -s -X POST "https://YOUR-UNRAID/graphql" \
   -H "Content-Type: application/json" \
   -H "x-api-key: YOUR_API_KEY" \
   -d '{
-    "query": "{ owner { username url avatar } }"
+    "query": "{ owner { username avatar } }"
   }' | jq '.'
 ```
 
@@ -571,12 +571,15 @@ curl -s -X POST "https://YOUR-UNRAID/graphql" \
   "data": {
     "owner": {
       "username": "root",
-      "url": "",
       "avatar": ""
     }
   }
 }
 ```
+
+The consolidated `system/owner` MCP action also attempts to read `server.owner.url`.
+That optional lookup requires the separate `SERVERS` permission and defaults to an empty
+string when unavailable.
 
 ---
 

--- a/agents/unraid-py/skills/unraid/references/api-reference.md
+++ b/agents/unraid-py/skills/unraid/references/api-reference.md
@@ -323,7 +323,8 @@ curl -s -X POST "https://YOUR-UNRAID/graphql" \
 }
 ```
 
-**Note:** Container logs are NOT accessible via this API. Use `docker logs` via SSH.
+**Container logs:** Query `docker.logs(id:, tail:)` and select
+`containerId`, `lines { timestamp message }`, and `cursor`.
 
 ---
 
@@ -955,7 +956,7 @@ Common differences from online documentation:
 
 ## 🚫 Known Limitations
 
-1. **No Docker container logs** - Container output logs are NOT accessible via the read-only query API (use `docker.logs` mutation)
+1. **Docker logs require a sub-selection** - Query `docker.logs(id:, tail:) { containerId lines { timestamp message } cursor }`
 2. **WebSocket subscriptions are available** - The Unraid API supports real-time subscriptions (array, Docker stats, notifications, etc.) via WebSocket
 3. **Some queries require higher permissions** - Read-only "Viewer" role may not access all queries
 4. **No mutation examples included** - This guide covers read-only queries only

--- a/agents/unraid-py/skills/unraid/references/troubleshooting.md
+++ b/agents/unraid-py/skills/unraid/references/troubleshooting.md
@@ -108,6 +108,7 @@ Use `unraid(action="disk", subaction="log_files")` to list available logs before
 
 ---
 
-## Container Logs Not Available
+## Container Logs
 
-Docker container stdout/stderr are **not accessible via the Unraid API**. SSH to the Unraid server and use `docker logs <container>` directly.
+Use `unraid(action="docker", subaction="logs", container_id="<name-or-id>", tail_lines=100)`.
+The response includes timestamped lines and a continuation cursor.

--- a/unraid-py/CLAUDE.md
+++ b/unraid-py/CLAUDE.md
@@ -108,7 +108,7 @@ Copy `.env.example` to `.env` and configure:
 ### Tool Categories (1 Tool)
 
 The server registers a **single MCP tool**, `unraid`, with `action` (domain) +
-`subaction` (operation) routing (19 actions / 178 subactions). Call it as
+`subaction` (operation) routing (19 actions / 179 subactions). Call it as
 `unraid(action="docker", subaction="list")`. Subscription diagnostics and the
 Markdown reference that used to be standalone tools are now actions of `unraid`:
 - **`subscriptions`** — `diagnose` (connection states, errors, WebSocket URLs) and
@@ -126,7 +126,7 @@ The handler functions live in `src/unraid_mcp/subscriptions/diagnostics.py`
 | **health** (4) | check, test_connection, diagnose, setup |
 | **array** (14) | parity_status, parity_history, assignable_disks, parity_start, parity_pause, parity_resume, parity_cancel, start_array, stop_array*, add_disk, remove_disk*, mount_disk, unmount_disk, clear_disk_stats* |
 | **disk** (6) | shares, disks, disk_details, log_files, logs, flash_backup* |
-| **docker** (26) | list, details, logs, ports, start, stop, restart, unpause, networks, network_details, remove_container*, update_container, update_containers, update_all_containers, update_autostart, refresh_digests, sync_template_paths, reset_template_mappings*, create_folder, create_folder_with_items, rename_folder, set_folder_children, delete_entries*, move_entries_to_folder, move_items_to_position, update_view_preferences |
+| **docker** (27) | list, details, logs, check_updates, ports, start, stop, restart, unpause, networks, network_details, remove_container*, update_container, update_containers, update_all_containers, update_autostart, refresh_digests, sync_template_paths, reset_template_mappings*, create_folder, create_folder_with_items, rename_folder, set_folder_children, delete_entries*, move_entries_to_folder, move_items_to_position, update_view_preferences |
 | **vm** (9) | list, details, start, stop, pause, resume, force_stop*, reboot, reset* |
 | **notification** (13) | overview, list, create, notify_if_unique, archive, mark_unread, recalculate, archive_all, archive_many, unarchive_many, unarchive_all, delete*, delete_archived* |
 | **key** (13) | list, get, possible_roles, possible_permissions, permissions_for_roles, preview_permissions, auth_actions, creation_form_schema, create, update, delete*, add_role, remove_role |

--- a/unraid-py/README.md
+++ b/unraid-py/README.md
@@ -316,7 +316,7 @@ Shares, physical disks, log files, and flash backup. Destructive subactions mark
 
 **`flash_backup` details:** Calls the Unraid `initiateFlashBackup` GraphQL mutation, which triggers an rclone copy from the flash drive to a configured rclone remote. The destination on the remote is overwritten if it exists. Returns `{ status, jobId }`. To restore: use rclone to copy the backup back to the flash drive, or extract individual config files. Configure the rclone remote first via `rclone/create_remote`.
 
-#### `docker` — 26 subactions
+#### `docker` — 27 subactions
 
 Container lifecycle, image updates, template/digest maintenance, organizer folders, and network inspection. Destructive subactions marked with *.
 
@@ -324,7 +324,8 @@ Container lifecycle, image updates, template/digest maintenance, organizer folde
 | --- | --- | --- | --- |
 | `list` | All containers: ID, names, image, state, status, autoStart | — | — |
 | `details` | Full container detail: ports, mounts, labels, network settings | `container_id` | — |
-| `logs` | Not available via the Unraid GraphQL API — returns guidance to use `docker logs` on the host | `container_id` | — |
+| `logs` | Structured container log lines with timestamps and a continuation cursor | `container_id`; optional `tail_lines` (default 100, max 10000) | — |
+| `check_updates` | Current image-update status for every container | — | — |
 | `ports` | All host port bindings across running containers, sorted by `(host_port, protocol)`. | — | — |
 | `start` | Start a container | `container_id` | — |
 | `stop` | Stop a container | `container_id` | — |
@@ -629,7 +630,7 @@ All destructive actions require `confirm=True`. Omitting it or passing `confirm=
 | `correct` | bool | `array/parity_start` |
 | `slot` | int | `array/add_disk` |
 | `log_path` | str | `disk/logs` |
-| `tail_lines` | int (default 100, max 10000) | `disk/logs` |
+| `tail_lines` | int (default 100, max 10000) | `disk/logs`, `docker/logs` |
 | `remote_name` | str | `disk/flash_backup` |
 | `source_path` | str | `disk/flash_backup` |
 | `destination_path` | str | `disk/flash_backup` |

--- a/unraid-py/docs/INVENTORY.md
+++ b/unraid-py/docs/INVENTORY.md
@@ -6,7 +6,7 @@ Complete listing of all plugin components.
 
 | Tool | Type | Module | Description |
 | --- | --- | --- | --- |
-| `unraid` | Primary (only tool) | `tools/unraid.py` | Unified action/subaction router: 19 actions, 178 subactions. The Markdown reference (`help` action) and WebSocket diagnostics (`subscriptions` action, handled in `subscriptions/diagnostics.py`) are folded into this single tool. |
+| `unraid` | Primary (only tool) | `tools/unraid.py` | Unified action/subaction router: 19 actions, 179 subactions. The Markdown reference (`help` action) and WebSocket diagnostics (`subscriptions` action, handled in `subscriptions/diagnostics.py`) are folded into this single tool. |
 
 ## MCP resources
 
@@ -31,7 +31,7 @@ Complete listing of all plugin components.
 | `health` | 4 | `tools/_health.py` (+ handler in `tools/unraid.py`) | No |
 | `array` | 14 | `tools/_array.py` | Yes (3) |
 | `disk` | 6 | `tools/_disk.py` | Yes (1) |
-| `docker` | 26 | `tools/_docker.py` | Yes (3) |
+| `docker` | 27 | `tools/_docker.py` | Yes (3) |
 | `vm` | 9 | `tools/_vm.py` | Yes (2) |
 | `notification` | 13 | `tools/_notification.py` | Yes (2) |
 | `key` | 13 | `tools/_key.py` | Yes (1) |

--- a/unraid-py/docs/MARKETPLACE.md
+++ b/unraid-py/docs/MARKETPLACE.md
@@ -36,7 +36,7 @@ The plugin registers **a single MCP tool**:
 
 | Tool | Purpose |
 |------|---------|
-| `unraid` | The only tool — `action` (domain) + `subaction` (operation) routing, 178 subactions across 19 actions. WebSocket diagnostics and the Markdown reference are the `subscriptions` and `help` actions of this tool. |
+| `unraid` | The only tool — `action` (domain) + `subaction` (operation) routing, 179 subactions across 19 actions. WebSocket diagnostics and the Markdown reference are the `subscriptions` and `help` actions of this tool. |
 
 ### Calling Convention
 

--- a/unraid-py/docs/README.md
+++ b/unraid-py/docs/README.md
@@ -2,9 +2,9 @@
 
 <!-- mcp-name: tv.tootie/unraid-mcp -->
 
-[![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Funraid--mcp-blue?logo=docker)](https://github.com/dinglebear-ai/unraid/pkgs/container/unraid-mcp)
+[![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-dinglebear--ai%2Funraid--mcp-blue?logo=docker)](https://github.com/dinglebear-ai/unraid/pkgs/container/unraid-mcp)
 
-MCP server for Unraid NAS management. Exposes a single unified `unraid` tool with 19 action domains and 178 subactions, backed by Unraid's GraphQL API and real-time WebSocket subscriptions.
+MCP server for Unraid NAS management. Exposes a single unified `unraid` tool with 19 action domains and 179 subactions, backed by Unraid's GraphQL API and real-time WebSocket subscriptions.
 
 ## Overview
 
@@ -12,7 +12,7 @@ A single MCP tool is exposed:
 
 | Tool | Purpose |
 | --- | --- |
-| `unraid` | Unified action/subaction router for all operations (19 actions, 178 subactions). The Markdown reference and WebSocket diagnostics, which used to be standalone tools, are now the `help` and `subscriptions` actions of this tool. |
+| `unraid` | Unified action/subaction router for all operations (19 actions, 179 subactions). The Markdown reference and WebSocket diagnostics, which used to be standalone tools, are now the `help` and `subscriptions` actions of this tool. |
 
 Discover the full surface with `unraid(action="help")`. WebSocket subscription diagnostics are available via `unraid(action="subscriptions", subaction="diagnose")` and `unraid(action="subscriptions", subaction="test_query", subscription_query=...)`.
 
@@ -43,7 +43,7 @@ Single entry point for all Unraid operations. Select the operation with `action`
 | `health` (4) | `check`, `test_connection`, `diagnose`, `setup` | Health checks, connection test, credential setup |
 | `array` (14) | `parity_status`, `parity_history`, `assignable_disks`, `parity_start`, `parity_pause`, `parity_resume`, `parity_cancel`, `start_array`, `stop_array`\*, `add_disk`, `remove_disk`\*, `mount_disk`, `unmount_disk`, `clear_disk_stats`\* | Parity checks, array lifecycle, disk operations |
 | `disk` (6) | `shares`, `disks`, `disk_details`, `log_files`, `logs`, `flash_backup`\* | Shares, physical disks, log files |
-| `docker` (26) | `list`, `details`, `logs`, `ports`, `start`, `stop`, `restart`, `unpause`, `networks`, `network_details`, `remove_container`\*, `update_container`, `update_containers`, `update_all_containers`, `update_autostart`, `refresh_digests`, `sync_template_paths`, `reset_template_mappings`\*, `create_folder`, `create_folder_with_items`, `rename_folder`, `set_folder_children`, `delete_entries`\*, `move_entries_to_folder`, `move_items_to_position`, `update_view_preferences` | Container lifecycle, updates, organizer folders, network inspection |
+| `docker` (27) | `list`, `details`, `logs`, `check_updates`, `ports`, `start`, `stop`, `restart`, `unpause`, `networks`, `network_details`, `remove_container`\*, `update_container`, `update_containers`, `update_all_containers`, `update_autostart`, `refresh_digests`, `sync_template_paths`, `reset_template_mappings`\*, `create_folder`, `create_folder_with_items`, `rename_folder`, `set_folder_children`, `delete_entries`\*, `move_entries_to_folder`, `move_items_to_position`, `update_view_preferences` | Container lifecycle, updates, organizer folders, network inspection |
 | `vm` (9) | `list`, `details`, `start`, `stop`, `pause`, `resume`, `force_stop`\*, `reboot`, `reset`\* | Virtual machine lifecycle |
 | `notification` (13) | `overview`, `list`, `create`, `notify_if_unique`, `archive`, `mark_unread`, `recalculate`, `archive_all`, `archive_many`, `unarchive_many`, `unarchive_all`, `delete`\*, `delete_archived`\* | Notification CRUD |
 | `key` (13) | `list`, `get`, `possible_roles`, `possible_permissions`, `permissions_for_roles`, `preview_permissions`, `auth_actions`, `creation_form_schema`, `create`, `update`, `delete`\*, `add_role`, `remove_role` | API key and permission management |

--- a/unraid-py/docs/mcp/CLAUDE.md
+++ b/unraid-py/docs/mcp/CLAUDE.md
@@ -32,7 +32,7 @@ Documentation for the unraid-mcp MCP server.
 1. ENV.md -- understand required configuration
 2. AUTH.md -- set up authentication
 3. TRANSPORT.md -- choose a transport and connect
-4. TOOLS.md -- learn available operations (19 actions, 178 subactions)
+4. TOOLS.md -- learn available operations (19 actions, 179 subactions)
 5. RESOURCES.md -- discover live subscription data endpoints
 6. ELICITATION.md -- understand the destructive action gates
 
@@ -45,7 +45,7 @@ Documentation for the unraid-mcp MCP server.
 ## At a glance
 
 - **One tool**, `unraid`, routed by `action` (domain) + `subaction` (operation):
-  `unraid(action="docker", subaction="list")`. 19 actions / 178 subactions.
+  `unraid(action="docker", subaction="list")`. 19 actions / 179 subactions.
 - **Destructive subactions require `confirm=True`** (e.g. `array/stop_array`,
   `docker/remove_container`); without it, an MCP elicitation form is raised.
 - **List subactions are capped** via the `limit` param (default 20; `limit<=0` =

--- a/unraid-py/docs/mcp/TOOLS.md
+++ b/unraid-py/docs/mcp/TOOLS.md
@@ -6,9 +6,9 @@ unraid-mcp exposes a single MCP tool, `unraid`, with `action` (domain) + `subact
 
 | Tool | Purpose | Parameters |
 |------|---------|------------|
-| `unraid` | The only tool -- action+subaction dispatch across 19 actions / 178 subactions. The Markdown reference and WebSocket diagnostics are the `help` and `subscriptions` actions. | `action`, `subaction`, plus domain-specific params |
+| `unraid` | The only tool -- action+subaction dispatch across 19 actions / 179 subactions. The Markdown reference and WebSocket diagnostics are the `help` and `subscriptions` actions. | `action`, `subaction`, plus domain-specific params |
 
-The consolidated action pattern keeps the MCP surface to one tool while supporting 178 subactions across 19 actions. Clients call `unraid(action="help")` first to discover available operations, then call `unraid` with the appropriate action and subaction. WebSocket subscription diagnostics live under `unraid(action="subscriptions", subaction="diagnose"|"test_query")`.
+The consolidated action pattern keeps the MCP surface to one tool while supporting 179 subactions across 19 actions. Clients call `unraid(action="help")` first to discover available operations, then call `unraid` with the appropriate action and subaction. WebSocket subscription diagnostics live under `unraid(action="subscriptions", subaction="diagnose"|"test_query")`.
 
 ## Primary Tool: `unraid`
 
@@ -122,7 +122,7 @@ Shares, physical disks, log files.
 | `logs` | Read log content | `log_path`, `tail_lines` | -- |
 | `flash_backup` | Trigger a flash backup | `remote_name`, `source_path`, `destination_path`, `backup_options` | Yes |
 
-#### `docker` (26 subactions)
+#### `docker` (27 subactions)
 
 Container lifecycle, image updates, template/digest maintenance, organizer
 folders, and network inspection.
@@ -131,7 +131,8 @@ folders, and network inspection.
 |-----------|-------------|-------------|-------------|
 | `list` | All containers with status, image, state | -- | -- |
 | `details` | Single container details | `container_id` | -- |
-| `logs` | Not available via the Unraid GraphQL API -- returns guidance to use `docker logs` on the host | `container_id` | -- |
+| `logs` | Structured container log lines with timestamps and a continuation cursor | `container_id`, `tail_lines` | -- |
+| `check_updates` | Current image-update status for every container | -- | -- |
 | `ports` | All host port bindings across running containers, sorted by host port | -- | -- |
 | `start` | Start a container | `container_id` | -- |
 | `stop` | Stop a container | `container_id` | -- |

--- a/unraid-py/docs/stack/ARCH.md
+++ b/unraid-py/docs/stack/ARCH.md
@@ -27,12 +27,12 @@ MCP Client (Claude Code / Codex / Gemini / HTTP)
 +----------------------------------------------+
     |
     +----> Tools (1 registered)
-    |      +-- unraid (action+subaction router, 19 actions / 178 subactions)
+    |      +-- unraid (action+subaction router, 19 actions / 179 subactions)
     |      |   +-- _system.py    (25 subactions)
     |      |   +-- _health.py    (4 subactions)
     |      |   +-- _array.py     (14 subactions)
     |      |   +-- _disk.py      (6 subactions)
-    |      |   +-- _docker.py    (26 subactions)
+    |      |   +-- _docker.py    (27 subactions)
     |      |   +-- _vm.py        (9 subactions)
     |      |   +-- _notification (13 subactions)
     |      |   +-- _key.py       (13 subactions)
@@ -118,7 +118,7 @@ MCP Client (Claude Code / Codex / Gemini / HTTP)
 
 ### Consolidated tool pattern
 
-One `unraid` tool with 19 actions (178 subactions) instead of many separate tools. This:
+One `unraid` tool with 19 actions (179 subactions) instead of many separate tools. This:
 - Reduces MCP context window usage (one tool description covers all operations)
 - Simplifies client tool selection
 - Enables shared parameters across domains

--- a/unraid-py/src/unraid_mcp/tools/__init__.py
+++ b/unraid-py/src/unraid_mcp/tools/__init__.py
@@ -1,6 +1,6 @@
 """MCP tools — single consolidated unraid tool with action + subaction routing.
 
-unraid - All Unraid operations (19 actions, 178 subactions)
+unraid - All Unraid operations (19 actions, 179 subactions)
 system        - System info, metrics, UPS, network, registration
 health        - Health checks, connection test, diagnostics, setup
 array         - Parity, array state, assignable/add/remove/mount disks

--- a/unraid-py/src/unraid_mcp/tools/_docker.py
+++ b/unraid-py/src/unraid_mcp/tools/_docker.py
@@ -1,12 +1,11 @@
 """Docker domain handler for the Unraid MCP tool.
 
-Covers: list, details, ports, start, stop, restart, unpause, networks,
+Covers: list, details, logs, check_updates, ports, start, stop, restart, unpause, networks,
 network_details, remove_container*, update_container, update_containers,
 update_all_containers, update_autostart, refresh_digests, sync_template_paths,
 reset_template_mappings*, create_folder, create_folder_with_items, rename_folder,
 set_folder_children, delete_entries*, move_entries_to_folder,
-move_items_to_position, update_view_preferences (25 subactions, plus a deprecated
-`logs` stub that returns an informative ToolError — not counted).
+move_items_to_position, update_view_preferences (27 subactions).
 """
 
 import re
@@ -37,6 +36,8 @@ _DOCKER_QUERIES: dict[str, str] = {
     # The "ports" subaction still needs every running container's bindings, so
     # it keeps a list-based query (trimmed to just ports + state + names).
     "ports": "query GetContainerPorts { docker { containers { id names state ports { ip privatePort publicPort type } } } }",
+    "logs": "query GetContainerLogs($id: PrefixedID!, $tail: Int) { docker { logs(id: $id, tail: $tail) { containerId lines { timestamp message } cursor } } }",
+    "check_updates": "query CheckContainerUpdates { docker { containerUpdateStatuses { name updateStatus } } }",
     "networks": "query GetDockerNetworks { docker { networks { id name driver scope } } }",
     "network_details": "query GetDockerNetwork { docker { networks { id name driver scope enableIPv6 internal attachable containers options labels } } }",
 }
@@ -148,9 +149,6 @@ _DOCKER_ORGANIZER: dict[str, _OrganizerSpec] = {
     },
 }
 
-# "logs" has no GraphQL query (field removed in Unraid 7.2.x) but is still a
-# recognised subaction so validation passes and the informative ToolError below
-# is returned rather than a generic "Invalid action" message.
 # "ports" has a dedicated list query and aggregates host port bindings client-side.
 _DOCKER_SUBACTIONS: set[str] = (
     set(_DOCKER_QUERIES)
@@ -158,14 +156,22 @@ _DOCKER_SUBACTIONS: set[str] = (
     | set(_DOCKER_BULK_MUTATIONS)
     | set(_DOCKER_ROOT_MUTATIONS)
     | set(_DOCKER_ORGANIZER)
-    | {"logs"}
 )
-_DOCKER_NEEDS_CONTAINER_ID = {"start", "stop", "details", "restart", "unpause", "update_container"}
+_DOCKER_NEEDS_CONTAINER_ID = {
+    "start",
+    "stop",
+    "details",
+    "logs",
+    "restart",
+    "unpause",
+    "update_container",
+}
 # remove_container deletes the container (and optionally its image); reset_template_mappings
 # wipes user template path overrides; delete_entries removes organizer entries.
 _DOCKER_DESTRUCTIVE: set[str] = {"remove_container", "reset_template_mappings", "delete_entries"}
 _DOCKER_ID_PATTERN = re.compile(r"^[a-f0-9]{64}(:[a-z0-9]+)?$", re.IGNORECASE)
 _DOCKER_SHORT_ID_PATTERN = re.compile(r"^[a-f0-9]{12,63}$", re.IGNORECASE)
+_MAX_TAIL_LINES = 10_000
 
 
 def _container_names(c: dict[str, Any]) -> list[str]:
@@ -251,6 +257,7 @@ async def _handle_docker(
     subaction: str,
     container_id: str | None,
     network_id: str | None,
+    tail_lines: int = 100,
     limit: int | None = None,
     ctx: Context | None = None,
     confirm: bool = False,
@@ -264,6 +271,8 @@ async def _handle_docker(
         raise ToolError(f"container_id is required for docker/{subaction}")
     if subaction == "network_details" and not network_id:
         raise ToolError("network_id is required for docker/network_details")
+    if subaction == "logs" and not 1 <= tail_lines <= _MAX_TAIL_LINES:
+        raise ToolError(f"tail_lines must be between 1 and {_MAX_TAIL_LINES}, got {tail_lines}")
 
     await gate_destructive_action(
         ctx,
@@ -340,11 +349,21 @@ async def _handle_docker(
             raise ToolError(f"Network '{network_id}' not found.")
 
         if subaction == "logs":
-            raise ToolError(
-                "Container logs are not available via the Unraid GraphQL API. "
-                "Use the Unraid terminal or SSH to run: "
-                f"`docker logs {container_id or '<container_id>'} --tail 100`"
+            actual_id = await _resolve_container_id(container_id or "")
+            data = await _client.make_graphql_request(
+                _DOCKER_QUERIES["logs"],
+                {"id": actual_id, "tail": tail_lines},
             )
+            logs = safe_get(data, "docker", "logs", default=None)
+            if logs is None:
+                raise ToolError(f"No logs returned for container '{container_id}'.")
+            return dict(logs)
+
+        if subaction == "check_updates":
+            data = await _client.make_graphql_request(_DOCKER_QUERIES["check_updates"])
+            updates = safe_get(data, "docker", "containerUpdateStatuses", default=[])
+            capped, page = cap_list(updates, limit)
+            return {"updates": capped, "page": page}
 
         # Root-level no-arg mutations (refresh digests / template sync + reset).
         if subaction in _DOCKER_ROOT_MUTATIONS:

--- a/unraid-py/src/unraid_mcp/tools/_system.py
+++ b/unraid-py/src/unraid_mcp/tools/_system.py
@@ -103,7 +103,7 @@ _SYSTEM_QUERIES: dict[str, str] = {
     """,
     "config": "query GetConfig { config { valid error } }",
     "online": "query GetOnline { online }",
-    "owner": "query GetOwner { owner { username avatar url } }",
+    "owner": "query GetOwner { owner { username avatar } }",
     # settings.unified.values is an opaque JSON! scalar in the GraphQL schema
     # (no selectable subfields), so field-level narrowing is not possible here.
     "settings": "query GetSettings { settings { unified { values } } }",
@@ -177,6 +177,12 @@ _SYSTEM_QUERIES: dict[str, str] = {
     """,
 }
 
+# Root owner.url is non-null in the schema but omitted for signed-in owners on
+# Unraid 7.3.x. The local server profile exposes a stable empty-string URL, but
+# that root requires the separate SERVERS permission. Fetch it opportunistically
+# so an OWNER-only API key still receives the owner profile.
+_OWNER_URL_QUERY = "query GetOwnerUrl { server { owner { url } } }"
+
 _SYSTEM_SUBACTIONS: set[str] = set(_SYSTEM_QUERIES)
 
 # Subactions whose response is a single object echoed back under a stable key.
@@ -186,7 +192,6 @@ _SYSTEM_SIMPLE_KEYS: dict[str, str] = {
     "variables": "vars",
     "metrics": "metrics",
     "config": "config",
-    "owner": "owner",
     "flash": "flash",
     "ups_config": "upsConfiguration",
     "server_time": "systemTime",
@@ -266,6 +271,24 @@ async def _handle_system(subaction: str, device_id: str | None, limit: int = 20)
 
     with tool_error_handler("system", subaction, logger):
         logger.info(f"Executing unraid action=system subaction={subaction}")
+
+        if subaction == "owner":
+            data = await _client.make_graphql_request(query)
+            owner = data.get("owner")
+            if not isinstance(owner, dict):
+                return {}
+            result = dict(owner)
+            result["url"] = ""
+            try:
+                url_data = await _client.make_graphql_request(_OWNER_URL_QUERY)
+            except ToolError as exc:
+                logger.warning("Owner URL unavailable from server profile: %s", exc)
+            else:
+                server_owner = safe_get(url_data, "server", "owner", default={})
+                if isinstance(server_owner, dict) and isinstance(server_owner.get("url"), str):
+                    result["url"] = server_owner["url"]
+            return result
+
         data = await _client.make_graphql_request(query, variables)
 
         if subaction == "overview":

--- a/unraid-py/src/unraid_mcp/tools/unraid.py
+++ b/unraid-py/src/unraid_mcp/tools/unraid.py
@@ -8,7 +8,7 @@ Actions:
   health       - Health checks, connection test, diagnostics, setup (4 subactions)
   array        - Parity checks, array state, disk operations (14 subactions)
   disk         - Shares, physical disks, log files (6 subactions)
-  docker       - Container lifecycle, updates, organizer, networks (26 subactions)
+  docker       - Container lifecycle, updates, organizer, networks (27 subactions)
   vm           - Virtual machine lifecycle (9 subactions)
   notification - System notifications CRUD (13 subactions)
   key          - API key & permission management (13 subactions)
@@ -157,7 +157,7 @@ Single entry point for all operations. Use `action` + `subaction` to select an o
 | `health` | `check`, `test_connection`, `diagnose`, `setup` | |
 | `array` | `parity_status`, `parity_history`, `assignable_disks`, `parity_start`, `parity_pause`, `parity_resume`, `parity_cancel`, `start_array`, `stop_array`*, `add_disk`, `remove_disk`*, `mount_disk`, `unmount_disk`, `clear_disk_stats`* | |
 | `disk` | `shares`, `disks`, `disk_details`, `log_files`, `logs`, `flash_backup`* | |
-| `docker` | `list`, `details`, `logs`, `ports`, `start`, `stop`, `restart`, `unpause`, `networks`, `network_details`, `remove_container`*, `update_container`, `update_containers`, `update_all_containers`, `update_autostart`, `refresh_digests`, `sync_template_paths`, `reset_template_mappings`*, `create_folder`, `create_folder_with_items`, `rename_folder`, `set_folder_children`, `delete_entries`*, `move_entries_to_folder`, `move_items_to_position`, `update_view_preferences` | organizer ops use `organizer_input` |
+| `docker` | `list`, `details`, `logs`, `check_updates`, `ports`, `start`, `stop`, `restart`, `unpause`, `networks`, `network_details`, `remove_container`*, `update_container`, `update_containers`, `update_all_containers`, `update_autostart`, `refresh_digests`, `sync_template_paths`, `reset_template_mappings`*, `create_folder`, `create_folder_with_items`, `rename_folder`, `set_folder_children`, `delete_entries`*, `move_entries_to_folder`, `move_items_to_position`, `update_view_preferences` | organizer ops use `organizer_input` |
 | `vm` | `list`, `details`, `start`, `stop`, `pause`, `resume`, `force_stop`*, `reboot`, `reset`* | |
 | `notification` | `overview`, `list`, `create`, `notify_if_unique`, `archive`, `mark_unread`, `recalculate`, `archive_all`, `archive_many`, `unarchive_many`, `unarchive_all`, `delete`*, `delete_archived`* | |
 | `key` | `list`, `get`, `possible_roles`, `possible_permissions`, `permissions_for_roles`, `preview_permissions`, `auth_actions`, `creation_form_schema`, `create`, `update`, `delete`*, `add_role`, `remove_role` | |
@@ -324,7 +324,10 @@ class UnraidInput(BaseModel):
     slot: int | None = Field(default=None, description="Disk slot number (array add/remove).")
     # disk
     log_path: str | None = Field(default=None, description="Log file path (disk/logs).")
-    tail_lines: int = Field(default=100, description="Number of trailing log lines (disk/logs).")
+    tail_lines: int = Field(
+        default=100,
+        description="Number of trailing log lines (disk/logs and docker/logs).",
+    )
     remote_name: str | None = Field(
         default=None, description="Rclone remote name (disk/flash_backup)."
     )
@@ -528,6 +531,7 @@ async def _dispatch_docker(inp: UnraidInput, ctx: Context | None) -> dict[str, A
         inp.subaction,
         container_id=inp.container_id,
         network_id=inp.network_id,
+        tail_lines=inp.tail_lines,
         limit=inp.limit,
         ctx=ctx,
         confirm=inp.confirm,
@@ -853,7 +857,8 @@ def register_unraid_tool(
         ├─────────────────┼──────────────────────────────────────────────────────────────────────┤
         │ disk            │ shares, disks, disk_details, log_files, logs, flash_backup*          │
         ├─────────────────┼──────────────────────────────────────────────────────────────────────┤
-        │ docker          │ list, details, logs, ports, start, stop, restart, unpause,           │
+        │ docker          │ list, details, logs, check_updates, ports, start, stop, restart,     │
+        │                 │ unpause,                                                              │
         │                 │ networks, network_details, remove_container*, update_container,      │
         │                 │ update_containers, update_all_containers, update_autostart,          │
         │                 │ refresh_digests, sync_template_paths, reset_template_mappings*,      │

--- a/unraid-py/tests/schema/test_query_validation.py
+++ b/unraid-py/tests/schema/test_query_validation.py
@@ -409,6 +409,18 @@ class TestDockerQueries:
         errors = _validate_operation(schema, QUERIES["ports"])
         assert not errors, f"ports query validation failed: {errors}"
 
+    def test_logs_query(self, schema: GraphQLSchema) -> None:
+        from unraid_mcp.tools._docker import _DOCKER_QUERIES as QUERIES
+
+        errors = _validate_operation(schema, QUERIES["logs"])
+        assert not errors, f"logs query validation failed: {errors}"
+
+    def test_check_updates_query(self, schema: GraphQLSchema) -> None:
+        from unraid_mcp.tools._docker import _DOCKER_QUERIES as QUERIES
+
+        errors = _validate_operation(schema, QUERIES["check_updates"])
+        assert not errors, f"check_updates query validation failed: {errors}"
+
     def test_all_docker_queries_covered(self, schema: GraphQLSchema) -> None:
         from unraid_mcp.tools._docker import _DOCKER_QUERIES as QUERIES
 
@@ -416,6 +428,8 @@ class TestDockerQueries:
             "list",
             "details",
             "ports",
+            "logs",
+            "check_updates",
             "networks",
             "network_details",
         }

--- a/unraid-py/tests/schema/test_query_validation.py
+++ b/unraid-py/tests/schema/test_query_validation.py
@@ -97,10 +97,13 @@ class TestInfoQueries:
         assert not errors, f"online query validation failed: {errors}"
 
     def test_owner_query(self, schema: GraphQLSchema) -> None:
+        from unraid_mcp.tools._system import _OWNER_URL_QUERY
         from unraid_mcp.tools._system import _SYSTEM_QUERIES as QUERIES
 
         errors = _validate_operation(schema, QUERIES["owner"])
         assert not errors, f"owner query validation failed: {errors}"
+        url_errors = _validate_operation(schema, _OWNER_URL_QUERY)
+        assert not url_errors, f"owner URL query validation failed: {url_errors}"
 
     def test_settings_query(self, schema: GraphQLSchema) -> None:
         from unraid_mcp.tools._system import _SYSTEM_QUERIES as QUERIES

--- a/unraid-py/tests/test_docker.py
+++ b/unraid-py/tests/test_docker.py
@@ -23,18 +23,47 @@ def _make_tool():
 
 
 class TestDockerValidation:
-    @pytest.mark.parametrize("subaction", ["start", "stop", "details"])
+    @pytest.mark.parametrize("subaction", ["start", "stop", "details", "logs"])
     async def test_container_actions_require_id(
         self, _mock_graphql: AsyncMock, subaction: str
     ) -> None:
         tool_fn = _make_tool()
-        with pytest.raises(ToolError, match="container_id"):
+        with pytest.raises(
+            ToolError,
+            match=rf"^container_id is required for docker/{subaction}$",
+        ):
             await tool_fn(action="docker", subaction=subaction)
 
     async def test_network_details_requires_id(self, _mock_graphql: AsyncMock) -> None:
         tool_fn = _make_tool()
         with pytest.raises(ToolError, match="network_id"):
             await tool_fn(action="docker", subaction="network_details")
+
+    @pytest.mark.parametrize("tail_lines", [0, 10_001])
+    async def test_logs_rejects_out_of_range_tail_lines(
+        self, _mock_graphql: AsyncMock, tail_lines: int
+    ) -> None:
+        container_id = "a" * 64 + ":local"
+        _mock_graphql.return_value = {
+            "docker": {
+                "logs": {
+                    "containerId": container_id,
+                    "lines": [],
+                    "cursor": None,
+                }
+            }
+        }
+
+        with pytest.raises(
+            ToolError,
+            match=rf"^tail_lines must be between 1 and 10000, got {tail_lines}$",
+        ):
+            await _make_tool()(
+                action="docker",
+                subaction="logs",
+                container_id=container_id,
+                tail_lines=tail_lines,
+            )
 
     async def test_non_logs_action_ignores_tail_lines_validation(
         self, _mock_graphql: AsyncMock
@@ -106,6 +135,69 @@ class TestDockerActions:
         tool_fn = _make_tool()
         result = await tool_fn(action="docker", subaction="networks")
         assert len(result["networks"]) == 1
+
+    async def test_logs_returns_structured_lines(self, _mock_graphql: AsyncMock) -> None:
+        container_id = "a" * 64 + ":local"
+        _mock_graphql.side_effect = [
+            {"docker": {"containers": [{"id": container_id, "names": ["plex"]}]}},
+            {
+                "docker": {
+                    "logs": {
+                        "containerId": container_id,
+                        "lines": [
+                            {
+                                "timestamp": "2026-07-30T12:00:00.000Z",
+                                "message": "server ready",
+                            }
+                        ],
+                        "cursor": "2026-07-30T12:00:00.000Z",
+                    }
+                }
+            },
+        ]
+
+        result = await _make_tool()(
+            action="docker",
+            subaction="logs",
+            container_id="plex",
+            tail_lines=25,
+        )
+
+        assert result == {
+            "containerId": container_id,
+            "lines": [
+                {
+                    "timestamp": "2026-07-30T12:00:00.000Z",
+                    "message": "server ready",
+                }
+            ],
+            "cursor": "2026-07-30T12:00:00.000Z",
+        }
+        logs_call = _mock_graphql.call_args_list[1]
+        assert "logs(id: $id, tail: $tail)" in logs_call.args[0]
+        assert logs_call.args[1] == {"id": container_id, "tail": 25}
+
+    async def test_check_updates_returns_current_status_shape(
+        self, _mock_graphql: AsyncMock
+    ) -> None:
+        _mock_graphql.return_value = {
+            "docker": {
+                "containerUpdateStatuses": [
+                    {"name": "plex", "updateStatus": "UP_TO_DATE"},
+                    {"name": "sonarr", "updateStatus": "UPDATE_AVAILABLE"},
+                ]
+            }
+        }
+
+        result = await _make_tool()(action="docker", subaction="check_updates")
+
+        assert result == {
+            "updates": [
+                {"name": "plex", "updateStatus": "UP_TO_DATE"},
+                {"name": "sonarr", "updateStatus": "UPDATE_AVAILABLE"},
+            ],
+            "page": {"returned": 2, "total": 2, "truncated": False},
+        }
 
     async def test_idempotent_start(self, _mock_graphql: AsyncMock) -> None:
         # Resolve + idempotent success

--- a/unraid-py/tests/test_info.py
+++ b/unraid-py/tests/test_info.py
@@ -173,6 +173,35 @@ class TestUnraidInfoTool:
         assert result["httpsPort"] == 31337
         assert any(u["type"] == "LAN" and u["ipv4"] == "10.1.0.2" for u in result["accessUrls"])
 
+    async def test_owner_uses_server_owner_url(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.side_effect = [
+            {"owner": {"username": "owner@example.com", "avatar": "avatar.png"}},
+            {"server": {"owner": {"url": "https://account.unraid.net/owner"}}},
+        ]
+        result = await _make_tool()(action="system", subaction="owner")
+
+        owner_query = _mock_graphql.call_args_list[0].args[0]
+        url_query = _mock_graphql.call_args_list[1].args[0]
+        assert "owner { username avatar }" in owner_query
+        assert "owner { username avatar url }" not in owner_query
+        assert "server { owner { url } }" in url_query
+        assert result == {
+            "username": "owner@example.com",
+            "avatar": "avatar.png",
+            "url": "https://account.unraid.net/owner",
+        }
+
+    async def test_owner_defaults_url_when_server_owner_is_unavailable(
+        self, _mock_graphql: AsyncMock
+    ) -> None:
+        _mock_graphql.side_effect = [
+            {"owner": {"username": "owner@example.com", "avatar": ""}},
+            ToolError("HTTP error 403: Forbidden"),
+        ]
+        result = await _make_tool()(action="system", subaction="owner")
+
+        assert result == {"username": "owner@example.com", "avatar": "", "url": ""}
+
     async def test_network_interfaces_includes_address_details(
         self, _mock_graphql: AsyncMock
     ) -> None:

--- a/unraid-py/tests/test_live.sh
+++ b/unraid-py/tests/test_live.sh
@@ -443,9 +443,7 @@ run_phase4() {
   call_unraid "unraid system/display"         "system"       "display"
   call_unraid "unraid system/config"          "system"       "config"
   call_unraid "unraid system/online"          "system"       "online"
-  call_unraid_optional "unraid system/owner"  "system"       "owner" \
-    'Cannot return null for non-nullable field Owner\.url' \
-    "upstream owner profile has null url"
+  call_unraid "unraid system/owner"           "system"       "owner"
   call_unraid "unraid system/settings"        "system"       "settings"
   call_unraid "unraid system/server"          "system"       "server"
   call_unraid "unraid system/servers"         "system"       "servers"


### PR DESCRIPTION
## Summary

- update Docker logs to use the Unraid 7.3 structured log response and cursor
- add Docker update checks using the current `updateStatus` schema
- update system overview and server queries for the current version fields
- tolerate the nullable root owner URL and fetch it opportunistically from `server.owner`
- refresh tests, live checks, skill references, and API documentation

## Verification

- full suite reviewed in split runs: 1,886 passed, 9 expected skips, 0 failures
- focused owner and schema regression suite: 174 passed
- Ruff lint and format checks passed
- `ty check src/` passed
- `git diff --check` passed

Closes #312