### PR TITLE
ci: enforce repository contract

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,3 +8,4 @@ self-hosted-runner:
   labels:
     - tailscale
     - unraid
+    - ci-pool-ops

--- a/.github/allowed-actions.txt
+++ b/.github/allowed-actions.txt
@@ -37,6 +37,7 @@ anthropics/claude-code-action@*
 aquasecurity/trivy-action@*
 astral-sh/setup-uv@*
 docker/*@*
+dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@*
 dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@*
 dtolnay/rust-toolchain@*
 gitleaks/gitleaks-action@*

--- a/.github/workflows/repository-contract.yml
+++ b/.github/workflows/repository-contract.yml
@@ -16,7 +16,7 @@ jobs:
   contract:
     permissions:
       contents: read
-    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@d1a41a7af9c41189e0f1062234364f5814bda99d
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@d1a41a7af9c41189e0f1062234364f5814bda99d # fleet-2026-07-31
     with:
       profile: rust
       implementation-ref: d1a41a7af9c41189e0f1062234364f5814bda99d

--- a/.github/workflows/repository-contract.yml
+++ b/.github/workflows/repository-contract.yml
@@ -1,0 +1,40 @@
+name: Repository contract
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: repository-contract-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
+jobs:
+  contract:
+    permissions:
+      contents: read
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@d1a41a7af9c41189e0f1062234364f5814bda99d
+    with:
+      profile: rust
+      implementation-ref: d1a41a7af9c41189e0f1062234364f5814bda99d
+    secrets: inherit
+
+  repository-contract:
+    name: Repository Contract
+    if: always()
+    needs: [contract]
+    runs-on: ci-pool-ops
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Require repository contract
+        env:
+          RESULT: ${{ needs.contract.result }}
+        run: |
+          if [[ "$RESULT" != "success" ]]; then
+            echo "repository contract concluded $RESULT" >&2
+            exit 1
+          fi


### PR DESCRIPTION
Adds the immutable fleet repository contract at d1a41a7 behind a stable Repository Contract aggregate gate. Local verification: Actionlint, fleet contract, and git diff hygiene.