### PR TITLE
ci: move release jobs to hosted runners

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -55,7 +55,8 @@ defaults:
 jobs:
   build:
     if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'unraid-rs-v')
-    runs-on: [self-hosted, unraid]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       id-token: write
@@ -113,6 +114,7 @@ jobs:
       )
     # npm trusted publishing supports GitHub-hosted runners only.
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       id-token: write
@@ -170,6 +172,7 @@ jobs:
           startsWith(inputs.tag, 'unraid-rs-v'))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Moves heavy release jobs from legacy Unraid runners to GitHub-hosted Linux and routes Release Please orchestration through ci-pool-ops where applicable. Product-specific tag, artifact, checksum, draft-release, npm, and container publication logic is unchanged. Local verification: Actionlint, fleet repository contract, hosted-release policy, timeout policy, selector scan, and diff hygiene.