### PR TITLE
chore: pin rmcp 3.1.0

### DIFF
--- a/unraid-rs/Cargo.lock
+++ b/unraid-rs/Cargo.lock
@@ -2400,12 +2400,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0-beta.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3875f7c471c2d709062bc2165d8dc883b021b44255bd00bb4d8025f5108178c8"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -2433,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1aa4b9345795260a43fc23d6d05e096407c8b953903f673af7c4404b49fb2d6"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/unraid-rs/Cargo.toml
+++ b/unraid-rs/Cargo.toml
@@ -74,7 +74,7 @@ tokio = { version = "1", features = [
 
 # HTTP / MCP transport
 axum = "0.8"
-rmcp = { version = "=3.0.0-beta.2", default-features = false, features = [
+rmcp = { version = "=3.1.0", default-features = false, features = [
   "server",
   "macros",
   "elicitation",
@@ -142,7 +142,7 @@ test-support = ["dep:graphql-parser"]
 unraid-rmcp = { path = ".", features = ["test-support"] }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
-rmcp = { version = "=3.0.0-beta.2", default-features = false, features = [
+rmcp = { version = "=3.1.0", default-features = false, features = [
   "client",
   "transport-child-process",
 ] }


### PR DESCRIPTION
Pins rmcp exactly to 3.1.0, refreshes the lockfile, and updates code for the rmcp 3.1 metadata API where required.

Validated locally with cargo check --workspace --all-targets --locked, cargo fmt, and the fleet repository contract.