### PR TITLE
ci: make runner workflows operational

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
   mcp-integration:
     name: MCP Integration Tests
-    runs-on: [self-hosted, linux, tailscale]
+    runs-on: ci-pool-system
     timeout-minutes: 15
     # Live smoke test against the REAL Unraid box (via repo secrets). The homelab
     # Unraid API lives on a private/Tailscale network that GitHub's cloud runners


### PR DESCRIPTION
Replaces legacy self-hosted runner selectors with stable ci-pool-* scale-set routing and keeps release work on the intended hosted runners. Built from an isolated worktree; primary checkout changes were not touched. YAML and Actionlint validation passed.