### PR TITLE
fix: publish scoped npm launcher

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -11,3 +11,4 @@ self-hosted-runner:
     - tailscale
     - unraid
     - ci-pool-ops
+    - ci-pool-system

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,7 +1,7 @@
 name: rust-release
 
 # Triggered when release-please publishes an unraid-rs-v<version> release. Builds
-# the linux/amd64 runraid binary, publishes the @dinglebear/unraid-mcp npm launcher, and
+# the linux/amd64 runraid binary, publishes the @dinglebear/unraid npm launcher, and
 # builds+pushes the Rust server container image (folds in runraid's former
 # standalone docker-publish workflow). All run: steps execute in unraid-rs/.
 #
@@ -161,8 +161,8 @@ jobs:
         run: |
           set -euo pipefail
           version="${{ steps.npm-version.outputs.version }}"
-          if npm view "@dinglebear/unraid-mcp@${version}" version >/dev/null 2>&1; then
-            echo "@dinglebear/unraid-mcp@${version} already published; skipping."
+          if npm view "@dinglebear/unraid@${version}" version >/dev/null 2>&1; then
+            echo "@dinglebear/unraid@${version} already published; skipping."
           else
             npm publish --provenance --access public ./packages/unraid-rmcp
           fi

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,7 +1,7 @@
 name: rust-release
 
 # Triggered when release-please publishes an unraid-rs-v<version> release. Builds
-# the linux/amd64 runraid binary, publishes the unraid-rmcp npm launcher, and
+# the linux/amd64 runraid binary, publishes the @dinglebear/unraid-mcp npm launcher, and
 # builds+pushes the Rust server container image (folds in runraid's former
 # standalone docker-publish workflow). All run: steps execute in unraid-rs/.
 #
@@ -134,6 +134,11 @@ jobs:
       - name: Install npm with trusted-publishing support
         run: npm install --global npm@11.5.1
 
+      - name: Validate npm publication identity
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami >/dev/null
+
       - name: Verify npm package version matches release tag
         id: npm-version
         run: |
@@ -151,14 +156,15 @@ jobs:
         run: npm run check --prefix packages/unraid-rmcp
 
       - name: Publish npm package if not already present
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           version="${{ steps.npm-version.outputs.version }}"
-          if npm view "unraid-rmcp@${version}" version >/dev/null 2>&1; then
-            echo "unraid-rmcp@${version} already published; skipping."
+          if npm view "@dinglebear/unraid-mcp@${version}" version >/dev/null 2>&1; then
+            echo "@dinglebear/unraid-mcp@${version} already published; skipping."
           else
-            # OIDC trusted publishing generates provenance automatically.
-            npm publish --access public ./packages/unraid-rmcp
+            npm publish --provenance --access public ./packages/unraid-rmcp
           fi
 
   docker:

--- a/unraid-py/tests/test_review_regressions.py
+++ b/unraid-py/tests/test_review_regressions.py
@@ -74,7 +74,7 @@ def test_ci_runs_blocking_live_integration_on_tailnet_runner() -> None:
     workflow = (MONOREPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     assert "secrets.UNRAID_API_URL" in workflow
     assert "secrets.UNRAID_API_KEY" in workflow
-    assert "runs-on: [self-hosted, linux, tailscale]" in workflow
+    assert "runs-on: ci-pool-system" in workflow
     assert "github.event_name == 'schedule'" in workflow
     integration_job = workflow.split("  mcp-integration:", 1)[1].split("\n  audit:", 1)[0]
     assert "continue-on-error: true" not in integration_job

--- a/unraid-rs/packages/unraid-rmcp/package.json
+++ b/unraid-rs/packages/unraid-rmcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dinglebear/unraid-mcp",
+  "name": "@dinglebear/unraid",
   "version": "0.2.5",
   "description": "Rust MCP server and CLI for Unraid GraphQL operations across NAS, Docker, VM, and storage workflows.",
   "license": "MIT",

--- a/unraid-rs/packages/unraid-rmcp/package.json
+++ b/unraid-rs/packages/unraid-rmcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "unraid-rmcp",
+  "name": "@dinglebear/unraid-mcp",
   "version": "0.2.5",
   "description": "Rust MCP server and CLI for Unraid GraphQL operations across NAS, Docker, VM, and storage workflows.",
   "license": "MIT",
@@ -54,10 +54,13 @@
     "automation",
     "oauth"
   ],
-  "mcpName": "ai.dinglebear/unraid-rmcp",
+  "mcpName": "ai.dinglebear/unraid",
   "binaryVersion": "0.2.5",
   "author": {
     "name": "dinglebear.ai",
     "url": "https://dinglebear.ai"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/unraid-rs/packages/unraid-rmcp/scripts/check-package.js
+++ b/unraid-rs/packages/unraid-rmcp/scripts/check-package.js
@@ -14,7 +14,7 @@ const CANONICAL_REPO = "dinglebear-ai/unraid";
 const REPOSITORY_DIRECTORY = "unraid-rs/packages/unraid-rmcp";
 const packageJsonPath = path.join(packageRoot, "package.json");
 const packageJson = readJson(packageJsonPath);
-const expectedPackageName = "@dinglebear/unraid-mcp";
+const expectedPackageName = "@dinglebear/unraid";
 const releaseMode = process.argv.includes("--release");
 const skipReleaseAssets = process.argv.includes("--skip-release-assets");
 

--- a/unraid-rs/packages/unraid-rmcp/scripts/check-package.js
+++ b/unraid-rs/packages/unraid-rmcp/scripts/check-package.js
@@ -14,6 +14,7 @@ const CANONICAL_REPO = "dinglebear-ai/unraid";
 const REPOSITORY_DIRECTORY = "unraid-rs/packages/unraid-rmcp";
 const packageJsonPath = path.join(packageRoot, "package.json");
 const packageJson = readJson(packageJsonPath);
+const expectedPackageName = "@dinglebear/unraid-mcp";
 const releaseMode = process.argv.includes("--release");
 const skipReleaseAssets = process.argv.includes("--skip-release-assets");
 
@@ -116,6 +117,14 @@ function checkMetadata() {
   const serverWebsite = normalizeHomepage(serverJson.websiteUrl);
 
   assert(packageJson.name, "package.json must include name");
+  assert(
+    packageJson.name === expectedPackageName,
+    "package.json name must match the dinglebear organization package",
+  );
+  assert(
+    packageJson.publishConfig && packageJson.publishConfig.access === "public",
+    "scoped npm package must publish with public access",
+  );
   assert(packageJson.version, "package.json must include version");
   assert(packageJson.description, "package.json must include description");
   assert(packageJson.license, "package.json must include license");
@@ -452,7 +461,8 @@ async function main() {
   checkMetadata();
   assertRuntimeScriptsDoNotEscapePackage();
 
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `${packageJson.name}-package-check-`));
+  const packageTempLabel = packageJson.name.replace(/[^A-Za-z0-9._-]/g, "-");
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `${packageTempLabel}-package-check-`));
   try {
     const tarball = packTarball(tempDir);
     checkPacklist(tarball);

--- a/unraid-rs/server.json
+++ b/unraid-rs/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "ai.dinglebear/unraid-rmcp",
+  "name": "ai.dinglebear/unraid",
   "title": "Unraid RMCP",
   "description": "Rust MCP server and CLI for Unraid GraphQL operations across NAS, Docker, VM, and storage workflows.",
   "version": "0.2.5",
@@ -24,7 +24,7 @@
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "unraid-rmcp",
+      "identifier": "@dinglebear/unraid-mcp",
       "version": "0.2.5",
       "runtimeHint": "npx",
       "packageArguments": [
@@ -98,7 +98,8 @@
       "namespace": "ai.dinglebear",
       "dnsDomain": "dinglebear.ai",
       "distribution": {
-        "nodePackage": "unraid-rmcp"
+        "nodePackage": "@dinglebear/unraid-mcp",
+        "npm": "@dinglebear/unraid-mcp@0.2.5"
       },
       "buildInfo": {
         "version": "0.2.5",

--- a/unraid-rs/server.json
+++ b/unraid-rs/server.json
@@ -24,7 +24,7 @@
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "@dinglebear/unraid-mcp",
+      "identifier": "@dinglebear/unraid",
       "version": "0.2.5",
       "runtimeHint": "npx",
       "packageArguments": [
@@ -98,8 +98,8 @@
       "namespace": "ai.dinglebear",
       "dnsDomain": "dinglebear.ai",
       "distribution": {
-        "nodePackage": "@dinglebear/unraid-mcp",
-        "npm": "@dinglebear/unraid-mcp@0.2.5"
+        "nodePackage": "@dinglebear/unraid",
+        "npm": "@dinglebear/unraid@0.2.5"
       },
       "buildInfo": {
         "version": "0.2.5",


### PR DESCRIPTION
## Summary
- publish the Node launcher as `@dinglebear/unraid`
- align MCP Registry identity to `ai.dinglebear/unraid`
- enforce public scoped-package metadata and token-backed release authentication
- preserve existing binary, archive, and package-directory contracts

## Verification
- npm tests and package validation
- npm pack dry run and tarball install smoke
- actionlint and JSON/schema checks
- git diff --check