### PR TITLE
fix: normalize npm release archive binary

### DIFF
--- a/unraid-rs/packages/unraid-rmcp/lib/platform.js
+++ b/unraid-rs/packages/unraid-rmcp/lib/platform.js
@@ -12,7 +12,7 @@ function binaryVersion() {
 
 function targetFor(platform = process.platform, arch = process.arch) {
   if (platform === "linux" && arch === "x64") {
-    return { asset: "runraid-x86_64.tar.gz", binary: "runraid" };
+    return { asset: "runraid-x86_64.tar.gz", archiveBinary: "runraid-linux-x86_64", binary: "runraid" };
   }
   throw new Error(`Unsupported platform ${platform}/${arch}. Supported target: linux/x64.`);
 }

--- a/unraid-rs/packages/unraid-rmcp/scripts/install.js
+++ b/unraid-rs/packages/unraid-rmcp/scripts/install.js
@@ -71,6 +71,18 @@ function extract(archive, destination) {
   const result = spawnSync("tar", ["-xzf", archive, "-C", destination], { encoding: "utf8" });
   if (result.status !== 0) throw new Error((result.stderr || result.stdout || "tar extraction failed").trim());
 }
+
+function promoteExtractedBinary(target, destination, root = installRoot()) {
+  const extracted = path.join(root, target.archiveBinary || target.binary);
+  if (!fs.existsSync(extracted)) {
+    throw new Error(`archive did not contain expected binary ${path.basename(extracted)}`);
+  }
+  if (path.resolve(extracted) !== path.resolve(destination)) {
+    fs.rmSync(destination, { force: true });
+    fs.renameSync(extracted, destination);
+  }
+  fs.chmodSync(destination, 0o755);
+}
 async function main() {
   if (process.env.UNRAID_RMCP_SKIP_DOWNLOAD === "1") { log("skipping binary download because UNRAID_RMCP_SKIP_DOWNLOAD=1"); return; }
   const target = targetFor();
@@ -84,8 +96,12 @@ async function main() {
     await download(url, archive);
     await verifyChecksum(url, archive);
     extract(archive, installRoot());
-    fs.chmodSync(destination, 0o755);
+    promoteExtractedBinary(target, destination);
     log(`installed ${destination}`);
   } finally { fs.rmSync(tempDir, { recursive: true, force: true }); }
 }
-main().catch((error) => { log(error.message); process.exitCode = 1; });
+if (require.main === module) {
+  main().catch((error) => { log(error.message); process.exitCode = 1; });
+}
+
+module.exports = { checksumFromText, promoteExtractedBinary };

--- a/unraid-rs/packages/unraid-rmcp/test/platform.test.js
+++ b/unraid-rs/packages/unraid-rmcp/test/platform.test.js
@@ -1,10 +1,14 @@
 "use strict";
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 const { binaryVersion, downloadUrl, releaseBaseUrl, releaseVersion, targetFor } = require("../lib/platform");
 const { binaryVersion: pinnedBinaryVersion } = require("../package.json");
+const { promoteExtractedBinary } = require("../scripts/install");
 test("maps supported platforms to release assets", () => {
-  assert.deepEqual(targetFor("linux", "x64"), { asset: "runraid-x86_64.tar.gz", binary: "runraid" });
+  assert.deepEqual(targetFor("linux", "x64"), { asset: "runraid-x86_64.tar.gz", archiveBinary: "runraid-linux-x86_64", binary: "runraid" });
 });
 test("rejects unsupported platforms", () => {
   assert.throws(() => targetFor("win32", "x64"), /Unsupported platform/);
@@ -26,4 +30,20 @@ test("allows release tag and repo overrides", () => {
   const env = { UNRAID_RMCP_BINARY_VERSION: "v9.9.9", UNRAID_RMCP_REPO: "example/unraid-rmcp" };
   assert.equal(releaseBaseUrl(env), "https://github.com/example/unraid-rmcp/releases/download");
   assert.equal(downloadUrl(targetFor("linux", "x64"), env), "https://github.com/example/unraid-rmcp/releases/download/unraid-rs-v9.9.9/runraid-x86_64.tar.gz");
+});
+
+test("normalises the release archive binary name", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "unraid-rmcp-test-"));
+  try {
+    const target = targetFor("linux", "x64");
+    const extracted = path.join(root, target.archiveBinary);
+    const destination = path.join(root, target.binary);
+    fs.writeFileSync(extracted, "binary");
+    promoteExtractedBinary(target, destination, root);
+    assert.equal(fs.existsSync(extracted), false);
+    assert.equal(fs.readFileSync(destination, "utf8"), "binary");
+    assert.equal(fs.statSync(destination).mode & 0o777, 0o755);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

- declare the binary filename contained inside the published Linux archive
- rename the extracted binary to the npm launcher path before chmod
- add a regression test for the real `runraid-linux-x86_64` archive layout

## Verification

- `npm test`
- `npm run check`
- packed and installed the package in a clean temporary project
- downloaded and verified `unraid-rs-v0.2.5/runraid-x86_64.tar.gz`
- executed `runraid --version` successfully