### PR TITLE
test(unraid-py): validate operations against live schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
         run: |
           test -n "$UNRAID_API_URL"
           test -n "$UNRAID_API_KEY"
+      - name: Validate every runtime operation against the live GraphQL schema
+        run: uv run python -m unraid_mcp.devtools.live_schema_validation
       - name: Run blocking live transport and packaged-container smoke
         run: bash tests/test_live.sh
 

--- a/unraid-py/src/unraid_mcp/devtools/live_schema_validation.py
+++ b/unraid-py/src/unraid_mcp/devtools/live_schema_validation.py
@@ -1,0 +1,130 @@
+"""Validate every runtime GraphQL operation against an introspected live schema."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from graphql import (
+    GraphQLSchema,
+    build_client_schema,
+    get_introspection_query,
+    parse,
+    validate,
+)
+
+from unraid_mcp.devtools.graphql_inventory import all_operation_cases
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+@dataclass(frozen=True)
+class OperationValidationFailure:
+    """One runtime operation that is incompatible with the live schema."""
+
+    source: str
+    name: str
+    errors: tuple[str, ...]
+
+
+def fetch_live_schema(
+    api_url: str,
+    api_key: str,
+    *,
+    verify_ssl: bool | str = True,
+    timeout_seconds: float = 30.0,
+) -> GraphQLSchema:
+    """Fetch an authenticated GraphQL introspection result and build its schema."""
+    with httpx.Client(timeout=timeout_seconds, verify=verify_ssl) as client:
+        response = client.post(
+            api_url,
+            headers={"X-API-Key": api_key},
+            json={"query": get_introspection_query(descriptions=False)},
+        )
+        response.raise_for_status()
+
+    payload: dict[str, Any] = response.json()
+    errors = payload.get("errors")
+    if errors:
+        messages = "; ".join(str(error.get("message", error)) for error in errors)
+        raise RuntimeError(f"GraphQL introspection failed: {messages}")
+    data = payload.get("data")
+    if not isinstance(data, dict) or "__schema" not in data:
+        raise RuntimeError("GraphQL introspection returned no data.__schema payload")
+    return build_client_schema(data)
+
+
+def validate_operation_inventory(
+    schema: GraphQLSchema,
+    cases: Iterable[tuple[str, str, str]] | None = None,
+) -> list[OperationValidationFailure]:
+    """Return every runtime operation that fails validation against ``schema``."""
+    failures: list[OperationValidationFailure] = []
+    operation_cases = all_operation_cases() if cases is None else cases
+    for source, name, operation in operation_cases:
+        errors = validate(schema, parse(operation))
+        if errors:
+            failures.append(
+                OperationValidationFailure(
+                    source=source,
+                    name=name,
+                    errors=tuple(str(error) for error in errors),
+                )
+            )
+    return failures
+
+
+def require_live_credentials() -> tuple[str, str]:
+    """Read the live API credentials or fail instead of silently skipping the gate."""
+    api_url = os.environ.get("UNRAID_API_URL", "").strip()
+    api_key = os.environ.get("UNRAID_API_KEY", "").strip()
+    missing = [
+        name
+        for name, value in (("UNRAID_API_URL", api_url), ("UNRAID_API_KEY", api_key))
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(f"Missing required live credential(s): {', '.join(missing)}")
+    return api_url, api_key
+
+
+def resolve_tls_verification() -> bool | str:
+    """Apply the server's guarded TLS verification environment contract."""
+    raw_verify = os.environ.get("UNRAID_VERIFY_SSL", "true").strip()
+    normalized = raw_verify.lower()
+    if normalized in {"", "true", "1", "yes"}:
+        return True
+    if normalized in {"false", "0", "no"}:
+        allow_insecure = os.environ.get("UNRAID_ALLOW_INSECURE_TLS", "").strip().lower()
+        if allow_insecure not in {"true", "1", "yes"}:
+            raise RuntimeError(
+                "UNRAID_VERIFY_SSL is disabled without UNRAID_ALLOW_INSECURE_TLS=true"
+            )
+        return False
+    return raw_verify
+
+
+def main() -> int:
+    """Run the blocking live-schema compatibility gate."""
+    api_url, api_key = require_live_credentials()
+    schema = fetch_live_schema(api_url, api_key, verify_ssl=resolve_tls_verification())
+    cases = all_operation_cases()
+    failures = validate_operation_inventory(schema, cases)
+    if failures:
+        details = "\n".join(
+            f"- {failure.source}/{failure.name}: {failure.errors[0]}" for failure in failures
+        )
+        raise SystemExit(
+            f"{len(failures)} of {len(cases)} runtime GraphQL operations are incompatible "
+            f"with the live schema:\n{details}"
+        )
+    print(f"Validated {len(cases)} runtime GraphQL operations against the live schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unraid-py/tests/TEST_COVERAGE.md
+++ b/unraid-py/tests/TEST_COVERAGE.md
@@ -26,6 +26,10 @@ A QA engineer should be able to verify correctness of the script without executi
   business data.
 - It does not test write operations (container start/stop, VM actions beyond force_stop guard
   check, array operations, etc.) to avoid causing data loss or service disruption.
+- Before this smoke test runs in scheduled/manual CI, the live-schema gate introspects the
+  authenticated Unraid API and statically validates every emitted query, mutation, and
+  subscription document. This covers write-operation schema compatibility without executing
+  destructive actions.
 - It intentionally covers new read-only schema-drift surfaces in the live phase, including
   `system/network_interfaces`, `system/network_metrics`, `onboarding/internal_boot_context`,
   `live/network_metrics`, and `subscriptions/test_query` for `systemMetricsNetwork`.

--- a/unraid-py/tests/test_live_schema_validation.py
+++ b/unraid-py/tests/test_live_schema_validation.py
@@ -1,0 +1,44 @@
+"""Tests for the live GraphQL operation compatibility gate."""
+
+import pytest
+from graphql import build_schema
+
+from unraid_mcp.devtools.live_schema_validation import (
+    require_live_credentials,
+    resolve_tls_verification,
+    validate_operation_inventory,
+)
+
+
+def test_validate_operation_inventory_reports_incompatible_operations() -> None:
+    schema = build_schema("type Query { server: String! }")
+    cases = [
+        ("system", "server", "query Server { server }"),
+        ("docker", "containers", "query Containers { docker { containers { id } } }"),
+    ]
+
+    failures = validate_operation_inventory(schema, cases)
+
+    assert [(failure.source, failure.name) for failure in failures] == [("docker", "containers")]
+    assert "Cannot query field 'docker' on type 'Query'" in failures[0].errors[0]
+
+
+def test_require_live_credentials_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UNRAID_API_URL", raising=False)
+    monkeypatch.delenv("UNRAID_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="UNRAID_API_URL, UNRAID_API_KEY"):
+        require_live_credentials()
+
+
+def test_tls_verification_requires_explicit_second_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("UNRAID_VERIFY_SSL", "false")
+    monkeypatch.delenv("UNRAID_ALLOW_INSECURE_TLS", raising=False)
+
+    with pytest.raises(RuntimeError, match="UNRAID_ALLOW_INSECURE_TLS=true"):
+        resolve_tls_verification()
+
+    monkeypatch.setenv("UNRAID_ALLOW_INSECURE_TLS", "true")
+    assert resolve_tls_verification() is False

--- a/unraid-py/tests/test_schema_drift_workflow.py
+++ b/unraid-py/tests/test_schema_drift_workflow.py
@@ -54,3 +54,12 @@ def test_sensitive_workflows_pin_privileged_actions() -> None:
         "actions/upload-artifact",
     ):
         assert_uses_pinned_action(combined, action)
+
+
+def test_scheduled_live_ci_validates_complete_operation_inventory() -> None:
+    ci = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+
+    assert "Validate every runtime operation against the live GraphQL schema" in ci
+    assert "python -m unraid_mcp.devtools.live_schema_validation" in ci
+    assert "UNRAID_API_URL: ${{ secrets.UNRAID_API_URL }}" in ci
+    assert "UNRAID_API_KEY: ${{ secrets.UNRAID_API_KEY }}" in ci


### PR DESCRIPTION
## Summary
- introspect the authenticated live Unraid GraphQL schema without executing operations
- validate all emitted queries, mutations, and subscriptions against that schema
- run the blocking gate before the existing scheduled/manual live smoke
- preserve the existing guarded TLS verification contract

## Verification
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run ty check src/`
- `uv run pytest -m "not slow and not integration" --tb=short -q`
- live appliance: `Validated 174 runtime GraphQL operations against the live schema.`

Closes the follow-up gap identified while resolving #312.