### PR TITLE
fix(release): publish MCP metadata with dinglebear.ai

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -217,7 +217,11 @@ jobs:
         if: steps.state.outputs.published != 'true'
         env:
           MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
-        run: ./mcp-publisher login dns --domain tootie.tv --private-key "$MCP_PRIVATE_KEY"
+          MCP_REGISTRY_DOMAIN: ${{ vars.MCP_REGISTRY_DOMAIN }}
+        run: |
+          set -euo pipefail
+          test "$MCP_REGISTRY_DOMAIN" = dinglebear.ai
+          ./mcp-publisher login dns --domain "$MCP_REGISTRY_DOMAIN" --private-key "$MCP_PRIVATE_KEY"
       - name: Publish MCP Registry channel
         if: steps.state.outputs.published != 'true'
         run: |


### PR DESCRIPTION
## Summary
- read the MCP Registry DNS identity from the `MCP_REGISTRY_DOMAIN` repository variable
- require the value to be exactly `dinglebear.ai` before authentication
- remove the incorrect `tootie.tv` publisher identity

## Validation
- repository variable set and verified as `dinglebear.ai`
- workflow YAML parses
- no MCP publisher login references `tootie.tv`
- DNS TXT proof for `dinglebear.ai` matches the configured signing key
