### PR TITLE
fix(release): canonicalize Unraid MCP Registry identity

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -171,7 +171,7 @@ jobs:
         id: state
         run: |
           version="${RELEASE_TAG#v}"
-          url="https://registry.modelcontextprotocol.io/v0/servers/tv.tootie%2Funraid-mcp/versions/${version}"
+          url="https://registry.modelcontextprotocol.io/v0/servers/ai.dinglebear%2Funraid-mcp/versions/${version}"
           if curl -fsS "$url" > registry-existing.json; then
             jq -e --arg version "$version" '.server.version == $version' registry-existing.json
             echo "published=true" >> "$GITHUB_OUTPUT"
@@ -195,8 +195,14 @@ jobs:
         run: |
           version="${RELEASE_TAG#v}"
           jq --arg version "$version" '
+            .name = "ai.dinglebear/unraid-mcp" |
             .version = $version |
-            .packages = [.packages[] | if .registryType == "pypi" then .version = $version else . end]
+            .packages = [.packages[] | if .registryType == "pypi" then .version = $version else . end] |
+            ._meta["io.modelcontextprotocol.registry/publisher-provided"] = {
+              "namespace": "ai.dinglebear",
+              "dnsDomain": "dinglebear.ai",
+              "distribution": {"pypi": "unraid-mcp"}
+            }
           ' server.json > server.release.json
           mv server.release.json server.json
       - name: Wait for release version to be visible on PyPI
@@ -272,7 +278,7 @@ jobs:
         run: |
           version="${RELEASE_TAG#v}"
           curl -fsS \
-            "https://registry.modelcontextprotocol.io/v0/servers/tv.tootie%2Funraid-mcp/versions/${version}" |
+            "https://registry.modelcontextprotocol.io/v0/servers/ai.dinglebear%2Funraid-mcp/versions/${version}" |
             jq -e --arg version "$version" '.server.version == $version and .server.packages[0].version == $version'
       - name: Wait for matching GHCR release and latest digests
         env:

--- a/unraid-py/scripts/check-version-sync.sh
+++ b/unraid-py/scripts/check-version-sync.sh
@@ -40,6 +40,25 @@ if [ -f "gemini-extension.json" ]; then
   [ -n "$v" ] && versions+=("gemini-extension.json=$v") && files_checked+=("gemini-extension.json")
 fi
 
+# The official MCP Registry identity belongs to dinglebear.ai. Keep the
+# reverse-domain server namespace and DNS proof aligned with every other
+# DingleBear MCP package.
+if [ -f "server.json" ]; then
+  python3 - <<'PY'
+import json
+
+with open("server.json", encoding="utf-8") as handle:
+    manifest = json.load(handle)
+
+assert manifest.get("name") == "ai.dinglebear/unraid-mcp", manifest.get("name")
+publisher = manifest.get("_meta", {}).get(
+    "io.modelcontextprotocol.registry/publisher-provided", {}
+)
+assert publisher.get("namespace") == "ai.dinglebear", publisher
+assert publisher.get("dnsDomain") == "dinglebear.ai", publisher
+PY
+fi
+
 # Need at least one version source
 if [ ${#versions[@]} -eq 0 ]; then
   echo "[version-sync] No version-bearing files found — skipping"

--- a/unraid-py/server.json
+++ b/unraid-py/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "tv.tootie/unraid-mcp",
+  "name": "ai.dinglebear/unraid-mcp",
   "title": "Unraid MCP",
   "description": "MCP server for Unraid API — provides tools to interact with an Unraid server's GraphQL API.",
   "repository": {
@@ -33,5 +33,14 @@
         }
       ]
     }
-  ]
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "namespace": "ai.dinglebear",
+      "dnsDomain": "dinglebear.ai",
+      "distribution": {
+        "pypi": "unraid-mcp"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- rename the Python MCP Registry server from `tv.tootie/unraid-mcp` to `ai.dinglebear/unraid-mcp`
- add the canonical `dinglebear.ai` DNS publisher proof to `unraid-py/server.json`
- restamp historical release tags into the canonical identity during reconciliation
- update registry state and verification URLs
- guard the identity in the existing version-contract script

## Validation
- JSON parses
- release workflow YAML parses
- version/identity contract passes
- `git diff --check` passes
