### PR TITLE
fix(release): embed canonical PyPI ownership proof

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -54,6 +54,26 @@ jobs:
         run: |
           package_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -n1)"
           test "$package_version" = "${RELEASE_TAG#v}"
+      - name: Stamp canonical MCP package ownership proof
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          readme = Path("README.md")
+          lines = readme.read_text(encoding="utf-8").splitlines()
+          marker = "<!-- mcp-name: ai.dinglebear/unraid-mcp -->"
+          replaced = False
+          for index, line in enumerate(lines):
+              if line.startswith("<!-- mcp-name:"):
+                  lines[index] = marker
+                  replaced = True
+                  break
+          if not replaced:
+              lines.insert(1, "")
+              lines.insert(2, marker)
+          readme.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          assert marker in readme.read_text(encoding="utf-8")
+          PY
       - name: Build package once from clean sources
         run: uv build --no-sources
       - name: Validate metadata, wheel contents, and installed stdio server
@@ -62,6 +82,8 @@ jobs:
           unzip -l dist/*.whl | tee wheel-contents.txt
           grep -q 'unraid_mcp/server.py' wheel-contents.txt
           grep -q 'licenses/LICENSE' wheel-contents.txt
+          unzip -p dist/*.whl '*.dist-info/METADATA' |
+            grep -F 'mcp-name: ai.dinglebear/unraid-mcp'
           uv venv --python 3.12 .release-venv
           uv pip install --python .release-venv/bin/python dist/*.whl
           bash scripts/smoke-stdio.sh .release-venv/bin/unraid-mcp-server

--- a/unraid-py/README.md
+++ b/unraid-py/README.md
@@ -1,6 +1,6 @@
 # Unraid MCP
 
-<!-- mcp-name: tv.tootie/unraid-mcp -->
+<!-- mcp-name: ai.dinglebear/unraid-mcp -->
 
 [![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-dinglebear--ai%2Funraid--mcp-blue?logo=docker)](https://github.com/dinglebear-ai/unraid/pkgs/container/unraid-mcp)
 

--- a/unraid-py/scripts/check-version-sync.sh
+++ b/unraid-py/scripts/check-version-sync.sh
@@ -59,6 +59,11 @@ assert publisher.get("dnsDomain") == "dinglebear.ai", publisher
 PY
 fi
 
+if [ -f "README.md" ] && ! grep -Fq '<!-- mcp-name: ai.dinglebear/unraid-mcp -->' README.md; then
+  echo "[version-sync] FAIL — README.md must prove canonical MCP ownership" >&2
+  exit 1
+fi
+
 # Need at least one version source
 if [ ${#versions[@]} -eq 0 ]; then
   echo "[version-sync] No version-bearing files found — skipping"


### PR DESCRIPTION
## Summary
- replace the retired `tv.tootie/unraid-mcp` README ownership marker with `ai.dinglebear/unraid-mcp`
- stamp the canonical marker into historical tag recovery builds before packaging
- assert the marker is embedded in wheel METADATA
- guard the marker in the version contract

## Validation
- workflow YAML parses
- version/identity contract passes
- local 2.9.0 wheel and sdist build successfully
- Twine validation passes
- wheel METADATA contains `mcp-name: ai.dinglebear/unraid-mcp`
