### PR TITLE
fix(mcp): use DNS-only Registry publisher

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -22,11 +22,10 @@ permissions:
 jobs:
   publish-unraid-rs:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'unraid-rs-v')
-    uses: dinglebear-ai/workflows/.github/workflows/mcp-registry-publish.yml@3302f853574ba0c669a647f66cfcacb81f529fff # fleet-2026-08-04
+    uses: dinglebear-ai/workflows/.github/workflows/mcp-registry-publish.yml@befa67c7b7f976235bf3fbced6ede93293a7f405 # fleet-2026-08-04
     with:
       checkout-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
       expected-version: ${{ github.event_name == 'workflow_dispatch' && inputs.expected-version || github.event.release.tag_name }}
-      auth-method: dns
       manifest-path: unraid-rs/server.json
       version-prefix: unraid-rs-v
     secrets:


### PR DESCRIPTION
## Summary
- pin MCP Registry publication to the corrected DNS-only workflow source of truth
- remove the retired auth-method input
- retain dinglebear.ai DNS ownership through MCP_PRIVATE_KEY

## Validation
- actionlint passed
- caller references immutable workflow SHA befa67c7b7f976235bf3fbced6ede93293a7f405
