### PR TITLE
fix(release): preserve component release identity

### DIFF
--- a/.github/scripts/release_contract.py
+++ b/.github/scripts/release_contract.py
@@ -79,13 +79,18 @@ def validate_release_please(repo_root: Path, errors: list[str]) -> list[ReleaseU
         f"release manifest packages must be exactly {sorted(RELEASE_PLEASE_PACKAGES)}",
         errors,
     )
+    assert_true(
+        config.get("separate-pull-requests") is True,
+        "release-please must create separate component release PRs",
+        errors,
+    )
 
     python_cfg = packages.get("unraid-py", {})
     rust_cfg = packages.get("unraid-rs", {})
     assert_true(
-        python_cfg.get("component") == ""
+        python_cfg.get("component") == "unraid-mcp"
         and python_cfg.get("include-component-in-tag") is False,
-        "unraid-py must explicitly produce unprefixed vX.Y.Z tags",
+        "unraid-py must preserve the unraid-mcp component identity while producing unprefixed vX.Y.Z tags",
         errors,
     )
     assert_true(

--- a/.github/workflows/meta-ci.yml
+++ b/.github/workflows/meta-ci.yml
@@ -76,6 +76,20 @@ jobs:
           # agents/*/plugin.json are release-please version-bump targets — a malformed one would fail at release time; catch it here
           python3 -c "import glob,json;[json.load(open(f)) for f in glob.glob('agents/*/.claude-plugin/plugin.json')+glob.glob('agents/*/.codex-plugin/plugin.json')]"
 
+      - name: Release Please must preserve component identity
+        run: |
+          python3 - <<'PY'
+          import json
+
+          config = json.load(open("release-please-config.json"))
+          assert config.get("separate-pull-requests") is True
+          packages = config["packages"]
+          assert packages["unraid-py"]["component"] == "unraid-mcp"
+          assert packages["unraid-py"]["include-component-in-tag"] is False
+          assert packages["unraid-rs"]["component"] == "unraid-rs"
+          print("release-please component identities are explicit and separate")
+          PY
+
       - name: Both marketplaces must expose the same plugin set
         run: |
           python3 - <<'PY'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "include-v-in-tag": true,
   "include-component-in-tag": true,
   "always-update": true,
+  "separate-pull-requests": true,
   "changelog-sections": [
     {
       "type": "feat",
@@ -26,7 +27,7 @@
     "unraid-py": {
       "release-type": "python",
       "package-name": "unraid-mcp",
-      "component": "",
+      "component": "unraid-mcp",
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "extra-files": [


### PR DESCRIPTION
## Summary
- create separate Release Please PRs for Python and Rust components
- make the unraid-mcp component identity explicit while retaining vX.Y.Z Python tags
- enforce the configuration in meta CI

## Why
The combined generic release PR title could not be parsed back into the configured component after merge, leaving a merged release PR untagged.

## Validation
- JSON and YAML parsing passed
- component identity assertion passed
- actionlint passed