### PR TITLE
fix(unraid-rs): bind MCP to trusted interfaces

### DIFF
--- a/unraid-rs/CHANGELOG.md
+++ b/unraid-rs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Bind the production MCP port only to DOOKIE's Tailscale and LAN addresses instead of every host interface.
+
 ## [0.3.0](https://github.com/dinglebear-ai/unraid/compare/unraid-rs-v0.2.5...unraid-rs-v0.3.0) (2026-08-02)
 
 

--- a/unraid-rs/docker-compose.prod.yml
+++ b/unraid-rs/docker-compose.prod.yml
@@ -28,7 +28,8 @@ services:
       - path: .env
         required: false
     ports:
-      - "${UNRAID_RMCP_HOST_PORT:-40010}:40010/tcp"
+      - "100.88.16.79:${UNRAID_RMCP_HOST_PORT:-40010}:40010/tcp"
+      - "10.1.0.6:${UNRAID_RMCP_HOST_PORT:-40010}:40010/tcp"
     volumes:
       - ${UNRAID_RMCP_DATA_VOLUME:-${HOME}/.unraid}:/data
     healthcheck:


### PR DESCRIPTION
## Summary

- bind the unraid-rmcp production port to DOOKIE's Tailscale and LAN addresses
- stop publishing port 40010 on every host interface
- document the deployment hardening in unraid-rs/CHANGELOG.md

## Validation

- both addresses are assigned on DOOKIE
- docker compose config --no-interpolate --quiet
- git diff --check
