### PR TITLE
fix(mcp): centralize Registry publication

### DIFF
--- a/.github/scripts/release_contract.py
+++ b/.github/scripts/release_contract.py
@@ -98,6 +98,17 @@ def validate_release_please(repo_root: Path, errors: list[str]) -> list[ReleaseU
         "unraid-rs must produce unraid-rs-vX.Y.Z tags",
         errors,
     )
+    python_extra_files = {
+        (entry.get("path"), entry.get("jsonpath"))
+        for entry in python_cfg.get("extra-files", [])
+        if isinstance(entry, dict)
+    }
+    assert_true(
+        ("server.json", "$.version") in python_extra_files
+        and ("server.json", "$.packages[0].version") in python_extra_files,
+        "release-please must update both Unraid Python Registry manifest versions",
+        errors,
+    )
     rust_extra_files = {
         (entry.get("path"), entry.get("jsonpath"))
         for entry in rust_cfg.get("extra-files", [])
@@ -123,11 +134,18 @@ def validate_release_please(repo_root: Path, errors: list[str]) -> list[ReleaseU
     npm_package = json.loads(
         (repo_root / "unraid-rs/packages/unraid-rmcp/package.json").read_text()
     )
+    python_server = json.loads((repo_root / "unraid-py/server.json").read_text())
     versions = {
         "unraid-py": pyproject["project"]["version"],
         "unraid-rs": cargo["package"]["version"],
     }
     tag_prefixes = {"unraid-py": "v", "unraid-rs": "unraid-rs-v"}
+    assert_true(
+        python_server.get("version") == versions["unraid-py"]
+        and python_server.get("packages", [{}])[0].get("version") == versions["unraid-py"],
+        "Unraid Python Registry manifest versions must match pyproject.toml",
+        errors,
+    )
     assert_true(
         npm_package.get("version") == versions["unraid-rs"],
         f"npm package version {npm_package.get('version')} != Rust {versions['unraid-rs']}",

--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -5,8 +5,16 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      component:
+        description: Component whose canonical manifest should be reconciled
+        required: true
+        default: unraid-rs
+        type: choice
+        options:
+          - unraid-rs
+          - unraid-py
       ref:
-        description: Git ref containing the canonical Rust manifest
+        description: Git ref containing the canonical component manifest
         required: true
         default: main
         type: string
@@ -21,12 +29,23 @@ permissions:
 
 jobs:
   publish-unraid-rs:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'unraid-rs-v')
+    if: (github.event_name == 'workflow_dispatch' && inputs.component == 'unraid-rs') || startsWith(github.event.release.tag_name, 'unraid-rs-v')
     uses: dinglebear-ai/workflows/.github/workflows/mcp-registry-publish.yml@befa67c7b7f976235bf3fbced6ede93293a7f405 # fleet-2026-08-04
     with:
       checkout-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
       expected-version: ${{ github.event_name == 'workflow_dispatch' && inputs.expected-version || github.event.release.tag_name }}
       manifest-path: unraid-rs/server.json
       version-prefix: unraid-rs-v
+    secrets:
+      MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+
+  publish-unraid-py:
+    if: (github.event_name == 'workflow_dispatch' && inputs.component == 'unraid-py') || startsWith(github.event.release.tag_name, 'v')
+    uses: dinglebear-ai/workflows/.github/workflows/mcp-registry-publish.yml@befa67c7b7f976235bf3fbced6ede93293a7f405 # fleet-2026-08-04
+    with:
+      checkout-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
+      expected-version: ${{ github.event_name == 'workflow_dispatch' && inputs.expected-version || github.event.release.tag_name }}
+      manifest-path: unraid-py/server.json
+      version-prefix: v
     secrets:
       MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build & Attest Release Artifact
     # Only the primary (Python) release tag `v*`. Component tags start with
     # incus-/codex-/unraid-rs-, so startsWith(tag,'v') already excludes them.
-    # Gating build cascades to pypi/github-release/mcp-registry/reconcile via needs.
+    # Gating build cascades to pypi/github-release/reconcile via needs.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'v')
@@ -171,103 +171,9 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: gh release upload "$RELEASE_TAG" dist/* --clobber
 
-  mcp-registry:
-    name: Publish MCP Registry Channel
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: release
-    permissions:
-      contents: read
-    # server.json (the MCP registry manifest) lives in unraid-py/; the publisher
-    # binary is downloaded into and run from there too.
-    defaults:
-      run:
-        working-directory: unraid-py
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          ref: refs/tags/${{ env.RELEASE_TAG }}
-      - name: Reconcile existing MCP Registry state
-        id: state
-        run: |
-          version="${RELEASE_TAG#v}"
-          url="https://registry.modelcontextprotocol.io/v0/servers/ai.dinglebear%2Funraid-mcp/versions/${version}"
-          if curl -fsS "$url" > registry-existing.json; then
-            jq -e --arg version "$version" '.server.version == $version' registry-existing.json
-            echo "published=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "published=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Download checksum-pinned MCP publisher v1.8.0
-        if: steps.state.outputs.published != 'true'
-        run: |
-          archive=mcp-publisher_linux_amd64.tar.gz
-          curl --fail --silent --show-error --location \
-            "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.0/${archive}" \
-            --output "$archive"
-          printf '%s  %s\n' \
-            1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf \
-            "$archive" | sha256sum --check --strict
-          tar --extract --gzip --file "$archive" mcp-publisher
-          test "$(./mcp-publisher --version 2>&1 | grep -o '1\.8\.0' | head -n1)" = "1.8.0"
-      - name: Stamp immutable release version into registry manifest
-        if: steps.state.outputs.published != 'true'
-        run: |
-          version="${RELEASE_TAG#v}"
-          jq --arg version "$version" '
-            .name = "ai.dinglebear/unraid-mcp" |
-            .version = $version |
-            .packages = [.packages[] | if .registryType == "pypi" then .version = $version else . end] |
-            ._meta["io.modelcontextprotocol.registry/publisher-provided"] = {
-              "namespace": "ai.dinglebear",
-              "dnsDomain": "dinglebear.ai",
-              "distribution": {"pypi": "unraid-mcp"}
-            }
-          ' server.json > server.release.json
-          mv server.release.json server.json
-      - name: Wait for release version to be visible on PyPI
-        if: steps.state.outputs.published != 'true'
-        run: |
-          version="${RELEASE_TAG#v}"
-          for attempt in {1..20}; do
-            if curl -fsS "https://pypi.org/pypi/unraid-mcp/${version}/json" > /dev/null; then
-              echo "PyPI reports unraid-mcp ${version} (attempt ${attempt})."
-              exit 0
-            fi
-            echo "unraid-mcp ${version} not visible on PyPI yet (attempt ${attempt}/20); retrying in 15s."
-            sleep 15
-          done
-          echo "::error::unraid-mcp ${version} never became visible on PyPI; registry validation would fail"
-          exit 1
-      - name: Authenticate to MCP Registry
-        if: steps.state.outputs.published != 'true'
-        env:
-          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
-          MCP_REGISTRY_DOMAIN: ${{ vars.MCP_REGISTRY_DOMAIN }}
-        run: |
-          set -euo pipefail
-          test "$MCP_REGISTRY_DOMAIN" = dinglebear.ai
-          ./mcp-publisher login dns --domain "$MCP_REGISTRY_DOMAIN" --private-key "$MCP_PRIVATE_KEY"
-      - name: Publish MCP Registry channel
-        if: steps.state.outputs.published != 'true'
-        run: |
-          for attempt in {1..3}; do
-            if ./mcp-publisher publish; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "mcp-publisher publish failed (attempt ${attempt}/3); retrying in 30s."
-              sleep 30
-            fi
-          done
-          echo "::error::MCP Registry publish failed after 3 attempts"
-          exit 1
-
   reconcile:
     name: Release Reconciliation
-    needs: [build, pypi, github-release, mcp-registry]
+    needs: [build, pypi, github-release]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -296,12 +202,6 @@ jobs:
           gh release download "$RELEASE_TAG" --dir github-assets --pattern 'unraid_mcp-*' --pattern SHA256SUMS
           (cd github-assets && sha256sum --check SHA256SUMS)
           diff -rq dist github-assets
-      - name: Verify MCP Registry version
-        run: |
-          version="${RELEASE_TAG#v}"
-          curl -fsS \
-            "https://registry.modelcontextprotocol.io/v0/servers/ai.dinglebear%2Funraid-mcp/versions/${version}" |
-            jq -e --arg version "$version" '.server.version == $version and .server.packages[0].version == $version'
       - name: Wait for matching GHCR release and latest digests
         env:
           # Pinned, not derived from github.repository: the repo was renamed

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -45,6 +45,16 @@
           "type": "json",
           "path": "gemini-extension.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
         }
       ]
     },

--- a/unraid-py/scripts/check-version-sync.sh
+++ b/unraid-py/scripts/check-version-sync.sh
@@ -44,6 +44,10 @@ fi
 # reverse-domain server namespace and DNS proof aligned with every other
 # DingleBear MCP package.
 if [ -f "server.json" ]; then
+  v=$(python3 -c "import json; print(json.load(open('server.json'))['version'])")
+  [ -n "$v" ] && versions+=("server.json=$v") && files_checked+=("server.json")
+  v=$(python3 -c "import json; print(json.load(open('server.json'))['packages'][0]['version'])")
+  [ -n "$v" ] && versions+=("server.json package=$v") && files_checked+=("server.json package")
   python3 - <<'PY'
 import json
 

--- a/unraid-py/server.json
+++ b/unraid-py/server.json
@@ -2,18 +2,18 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.dinglebear/unraid-mcp",
   "title": "Unraid MCP",
-  "description": "MCP server for Unraid API — provides tools to interact with an Unraid server's GraphQL API.",
+  "description": "MCP server for Unraid API \u2014 provides tools to interact with an Unraid server's GraphQL API.",
   "repository": {
     "url": "https://github.com/dinglebear-ai/unraid",
     "source": "github"
   },
-  "version": "0.0.0",
+  "version": "2.10.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "unraid-mcp",
-      "version": "0.0.0",
+      "version": "2.10.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/unraid-py/tests/test_supply_chain_policy.py
+++ b/unraid-py/tests/test_supply_chain_policy.py
@@ -45,10 +45,7 @@ def test_release_executables_and_tools_are_pinned_and_verified() -> None:
     registry = _workflows()["mcp-registry.yml"]
     assert "mcp-publisher" not in release
     assert "registry.modelcontextprotocol.io" not in release
-    assert (
-        "mcp-registry-publish.yml@befa67c7b7f976235bf3fbced6ede93293a7f405"
-        in registry
-    )
+    assert "mcp-registry-publish.yml@befa67c7b7f976235bf3fbced6ede93293a7f405" in registry
     assert "publish-unraid-py:" in registry
     assert "manifest-path: unraid-py/server.json" in registry
     assert "MCP_PRIVATE_KEY" in registry

--- a/unraid-py/tests/test_supply_chain_policy.py
+++ b/unraid-py/tests/test_supply_chain_policy.py
@@ -42,10 +42,17 @@ def test_release_executables_and_tools_are_pinned_and_verified() -> None:
     assert "/releases/latest/download/" not in combined
     assert not re.search(r"curl[^\n|]*\|\s*(?:sh|bash|tar)\b", combined)
     release = _workflows()["publish-pypi.yml"]
-    assert "/releases/download/v1.8.0/" in release
-    assert "1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf" in release
-    assert "sha256sum --check --strict" in release
-    assert "./mcp-publisher --version 2>&1" in release
+    registry = _workflows()["mcp-registry.yml"]
+    assert "mcp-publisher" not in release
+    assert "registry.modelcontextprotocol.io" not in release
+    assert (
+        "mcp-registry-publish.yml@befa67c7b7f976235bf3fbced6ede93293a7f405"
+        in registry
+    )
+    assert "publish-unraid-py:" in registry
+    assert "manifest-path: unraid-py/server.json" in registry
+    assert "MCP_PRIVATE_KEY" in registry
+    assert "auth-method:" not in registry
 
 
 def test_release_sensitive_uv_is_pinned_and_cacheless() -> None:
@@ -65,8 +72,9 @@ def test_release_sensitive_uv_is_pinned_and_cacheless() -> None:
 
 def test_artifact_channels_are_independent_and_reconciled() -> None:
     workflow = _workflows()["publish-pypi.yml"]
-    for job in ("build", "pypi", "github-release", "mcp-registry", "reconcile"):
+    for job in ("build", "pypi", "github-release", "reconcile"):
         assert re.search(rf"^  {re.escape(job)}:\s*$", workflow, re.MULTILINE)
+    assert not re.search(r"^  mcp-registry:\s*$", workflow, re.MULTILINE)
     assert "SHA256SUMS" in workflow
     assert "actions/attest-build-provenance@" in workflow
     assert "skip-existing: true" in workflow
@@ -80,7 +88,7 @@ def test_manual_release_reconciliation_targets_requested_release_tag() -> None:
     assert 'default: ""' in workflow
     assert "RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}" in workflow
     assert "group: release-${{ github.event.release.tag_name || inputs.release_tag }}" in workflow
-    assert workflow.count("ref: refs/tags/${{ env.RELEASE_TAG }}") == 2
+    assert workflow.count("ref: refs/tags/${{ env.RELEASE_TAG }}") == 1
     assert "GITHUB_REF_NAME" not in workflow
 
 


### PR DESCRIPTION
## Summary
- remove the repository-local MCP Registry publisher
- delegate publication to the immutable DNS-only dinglebear-ai/workflows source of truth
- retain release recovery through workflow_dispatch
- enforce canonical manifest and package ownership contracts

## Validation
- repository-native workflow/package/version tests passed
- actionlint passed
- official mcp-publisher validation passed