### PR TITLE
feat(unraid-rs): add granular MCP tool and action controls

### DIFF
--- a/agents/unraid-rs/.claude-plugin/plugin.json
+++ b/agents/unraid-rs/.claude-plugin/plugin.json
@@ -36,6 +36,18 @@
       "required": true,
       "default": false
     },
+    "enabled_tools": {
+      "type": "string",
+      "title": "Enabled MCP tools/actions",
+      "description": "Optional comma-separated allowlist. Empty means all actions. Use action names such as array,docker,status,help or qualified selectors such as unraid.array.",
+      "default": ""
+    },
+    "disabled_tools": {
+      "type": "string",
+      "title": "Disabled MCP tools/actions",
+      "description": "Optional comma-separated denylist. Deny rules override enabled rules. Use * or unraid to disable the whole tool, or selectors such as vm_reset or unraid.docker_remove_container.",
+      "default": ""
+    },
     "auth_mode": {
       "type": "string",
       "title": "Auth mode",

--- a/agents/unraid-rs/.mcp.json
+++ b/agents/unraid-rs/.mcp.json
@@ -9,6 +9,8 @@
         "UNRAID_API_SKIP_TLS_VERIFY": "${user_config.unraid_skip_tls}",
         "UNRAID_RMCP_TOKEN": "${user_config.api_token}",
         "UNRAID_RMCP_NO_AUTH": "${user_config.no_auth}",
+        "UNRAID_RMCP_ENABLED_TOOLS": "${user_config.enabled_tools}",
+        "UNRAID_RMCP_DISABLED_TOOLS": "${user_config.disabled_tools}",
         "UNRAID_RMCP_AUTH_MODE": "${user_config.auth_mode}",
         "UNRAID_RMCP_PUBLIC_URL": "${user_config.public_url}",
         "UNRAID_RMCP_GOOGLE_CLIENT_ID": "${user_config.google_client_id}",

--- a/unraid-rs/.env.example
+++ b/unraid-rs/.env.example
@@ -10,6 +10,11 @@ UNRAID_API_KEY=
 UNRAID_RMCP_HOST=0.0.0.0
 UNRAID_RMCP_PORT=40010
 
+# Optional comma-separated MCP tool/action selectors. Empty enabled means all;
+# disabled always wins. Examples: docker_logs,unraid.vm_reset or * to disable all.
+# UNRAID_RMCP_ENABLED_TOOLS=array,docker,status,help
+# UNRAID_RMCP_DISABLED_TOOLS=unraid.vm_reset,docker_remove_container
+
 # MCP server bearer token (generate with: openssl rand -hex 32)
 # UNRAID_RMCP_TOKEN=
 

--- a/unraid-rs/.env.example
+++ b/unraid-rs/.env.example
@@ -12,6 +12,8 @@ UNRAID_RMCP_PORT=40010
 
 # Optional comma-separated MCP tool/action selectors. Empty enabled means all;
 # disabled always wins. Examples: docker_logs,unraid.vm_reset or * to disable all.
+# A set, non-empty value REPLACES the matching [mcp.tools] list in config.toml
+# (no merge); "" is treated as unset. MCP surface only — the CLI is unaffected.
 # UNRAID_RMCP_ENABLED_TOOLS=array,docker,status,help
 # UNRAID_RMCP_DISABLED_TOOLS=unraid.vm_reset,docker_remove_container
 

--- a/unraid-rs/CLAUDE.md
+++ b/unraid-rs/CLAUDE.md
@@ -77,9 +77,13 @@ via `dotenvy` before `Config::load` — see `load_dotenv()` in `config.rs`. A sy
 ## How to add a new action
 
 The set of valid actions lives in ONE place: the `ACTIONS: &[ActionSpec]` slice in
-`src/mcp/schemas.rs`. The schema enum (`UNRAID_ACTIONS`), the error-message action
-list (`VALID_ACTIONS` in `tools.rs`), and the MCP scope gating (`required_scope_for`
-in `rmcp_server.rs`) are all *derived* from it — do not hand-maintain those lists.
+`src/mcp/schemas.rs`. From there, `enabled_action_names()` in `tool_filter.rs`
+filters `ACTIONS` through the configured `[mcp.tools]` enable/disable policy
+(`UNRAID_RMCP_ENABLED_TOOLS` / `UNRAID_RMCP_DISABLED_TOOLS`), and that filtered
+list feeds both the JSON Schema enum — via `tool_definitions(action_names)` in
+`schemas.rs` — and the error-message action list in `tools.rs`. The MCP scope
+gating (`required_scope_for` in `rmcp_server.rs`) is still derived directly from
+`ACTIONS`. Do not hand-maintain any of these lists.
 
 1. **`src/graphql.rs`** — add `pub async fn your_action(&self) -> Result<Value>` that calls `self.query(...)`.
 

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -342,6 +342,8 @@ Host installs read `~/.unraid/.env` before loading config. Containers read
 | `UNRAID_API_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification for self-signed endpoints. |
 | `UNRAID_RMCP_HOST` | `0.0.0.0` | HTTP bind host. |
 | `UNRAID_RMCP_PORT` | `40010` | HTTP bind port. |
+| `UNRAID_RMCP_ENABLED_TOOLS` | unset | Comma-separated MCP tool/action allowlist; empty means all. |
+| `UNRAID_RMCP_DISABLED_TOOLS` | unset | Comma-separated MCP tool/action denylist; deny rules win. |
 | `UNRAID_RMCP_SERVER_NAME` | `unraid-rmcp` | Advertised MCP server name. |
 | `UNRAID_RMCP_TOKEN` | unset | Static bearer token for HTTP MCP. |
 | `UNRAID_RMCP_NO_AUTH` | `false` | Disable auth only for loopback development. |
@@ -354,6 +356,11 @@ Host installs read `~/.unraid/.env` before loading config. Containers read
 | `UNRAID_RMCP_GOOGLE_CLIENT_ID` | unset | Google OAuth client ID. |
 | `UNRAID_RMCP_GOOGLE_CLIENT_SECRET` | unset | Google OAuth client secret. |
 | `UNRAID_RMCP_AUTH_ADMIN_EMAIL` | unset | Admin email for OAuth bootstrap. |
+
+Tool selectors may target the entire tool (`*`, `unraid`, or `unraid.*`) or
+a single action (`docker_logs` or `unraid.vm_reset`). The advertised action
+schema is filtered, and disabled calls are rejected even when a client uses a
+stale cached schema. Invalid selectors fail configuration loading.
 
 ## Authentication
 

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -362,6 +362,14 @@ a single action (`docker_logs` or `unraid.vm_reset`). The advertised action
 schema is filtered, and disabled calls are rejected even when a client uses a
 stale cached schema. Invalid selectors fail configuration loading.
 
+A set, non-empty `UNRAID_RMCP_ENABLED_TOOLS` / `UNRAID_RMCP_DISABLED_TOOLS`
+**replaces** the corresponding `[mcp.tools]` list from `config.toml` — env and
+toml are never merged, so the env var is the complete policy for that list.
+An env var set to the empty string is treated as unset, while a non-empty
+value that parses to zero selectors (for example `","`) fails startup.
+This policy governs the MCP surface only; the `runraid` CLI is not filtered
+by `[mcp.tools]`.
+
 ## Authentication
 
 Stdio MCP runs as a local trusted child process and does not use HTTP auth.

--- a/unraid-rs/config.toml
+++ b/unraid-rs/config.toml
@@ -19,6 +19,9 @@ server_name = "unraid-rmcp"
 [mcp.tools]
 # Empty enabled means all actions. Disabled selectors always win.
 # Selectors: "*", "unraid", "unraid.*", "docker_logs", "unraid.vm_reset".
+# A set, non-empty UNRAID_RMCP_ENABLED_TOOLS / UNRAID_RMCP_DISABLED_TOOLS env
+# var REPLACES the matching list below (no merge). MCP surface only; the CLI
+# is not filtered by this policy.
 enabled = []
 disabled = []
 

--- a/unraid-rs/config.toml
+++ b/unraid-rs/config.toml
@@ -16,6 +16,12 @@ server_name = "unraid-rmcp"
 # allowed_hosts = ["unraid.example.com"]
 # allowed_origins = ["https://unraid.example.com"]
 
+[mcp.tools]
+# Empty enabled means all actions. Disabled selectors always win.
+# Selectors: "*", "unraid", "unraid.*", "docker_logs", "unraid.vm_reset".
+enabled = []
+disabled = []
+
 [mcp.auth]
 mode = "bearer"
 # public_url = "https://unraid.example.com"  # required when mode = "oauth"

--- a/unraid-rs/docs/QUICKSTART.md
+++ b/unraid-rs/docs/QUICKSTART.md
@@ -26,6 +26,9 @@ export UNRAID_API_URL="https://10-1-0-2.<hash>.myunraid.net:31337/graphql"
 export UNRAID_API_KEY="your-api-key-here"
 export UNRAID_RMCP_PORT=40010
 export UNRAID_RMCP_DISABLE_HTTP_AUTH=true
+# Optional: expose only selected actions, then subtract explicit denies.
+# export UNRAID_RMCP_ENABLED_TOOLS="array,docker,status,help"
+# export UNRAID_RMCP_DISABLED_TOOLS="unraid.vm_reset"
 ```
 
 If your Unraid API uses a self-signed certificate:

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -342,6 +342,8 @@ Host installs read `~/.unraid/.env` before loading config. Containers read
 | `UNRAID_API_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification for self-signed endpoints. |
 | `UNRAID_RMCP_HOST` | `0.0.0.0` | HTTP bind host. |
 | `UNRAID_RMCP_PORT` | `40010` | HTTP bind port. |
+| `UNRAID_RMCP_ENABLED_TOOLS` | unset | Comma-separated MCP tool/action allowlist; empty means all. |
+| `UNRAID_RMCP_DISABLED_TOOLS` | unset | Comma-separated MCP tool/action denylist; deny rules win. |
 | `UNRAID_RMCP_SERVER_NAME` | `unraid-rmcp` | Advertised MCP server name. |
 | `UNRAID_RMCP_TOKEN` | unset | Static bearer token for HTTP MCP. |
 | `UNRAID_RMCP_NO_AUTH` | `false` | Disable auth only for loopback development. |
@@ -354,6 +356,11 @@ Host installs read `~/.unraid/.env` before loading config. Containers read
 | `UNRAID_RMCP_GOOGLE_CLIENT_ID` | unset | Google OAuth client ID. |
 | `UNRAID_RMCP_GOOGLE_CLIENT_SECRET` | unset | Google OAuth client secret. |
 | `UNRAID_RMCP_AUTH_ADMIN_EMAIL` | unset | Admin email for OAuth bootstrap. |
+
+Tool selectors may target the entire tool (`*`, `unraid`, or `unraid.*`) or
+a single action (`docker_logs` or `unraid.vm_reset`). The advertised action
+schema is filtered, and disabled calls are rejected even when a client uses a
+stale cached schema. Invalid selectors fail configuration loading.
 
 ## Authentication
 

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -362,6 +362,14 @@ a single action (`docker_logs` or `unraid.vm_reset`). The advertised action
 schema is filtered, and disabled calls are rejected even when a client uses a
 stale cached schema. Invalid selectors fail configuration loading.
 
+A set, non-empty `UNRAID_RMCP_ENABLED_TOOLS` / `UNRAID_RMCP_DISABLED_TOOLS`
+**replaces** the corresponding `[mcp.tools]` list from `config.toml` — env and
+toml are never merged, so the env var is the complete policy for that list.
+An env var set to the empty string is treated as unset, while a non-empty
+value that parses to zero selectors (for example `","`) fails startup.
+This policy governs the MCP surface only; the `runraid` CLI is not filtered
+by `[mcp.tools]`.
+
 ## Authentication
 
 Stdio MCP runs as a local trusted child process and does not use HTTP auth.

--- a/unraid-rs/src/cli/setup.rs
+++ b/unraid-rs/src/cli/setup.rs
@@ -79,6 +79,14 @@ pub fn apply_plugin_options() {
     let map = [
         ("CLAUDE_PLUGIN_OPTION_API_TOKEN", "UNRAID_RMCP_TOKEN"),
         ("CLAUDE_PLUGIN_OPTION_MCP_PORT", "UNRAID_RMCP_PORT"),
+        (
+            "CLAUDE_PLUGIN_OPTION_ENABLED_TOOLS",
+            "UNRAID_RMCP_ENABLED_TOOLS",
+        ),
+        (
+            "CLAUDE_PLUGIN_OPTION_DISABLED_TOOLS",
+            "UNRAID_RMCP_DISABLED_TOOLS",
+        ),
         ("CLAUDE_PLUGIN_OPTION_UNRAID_API_URL", "UNRAID_API_URL"),
         ("CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY", "UNRAID_API_KEY"),
         (
@@ -323,6 +331,19 @@ fn write_env_file(data_dir: &Path, config: &Config) -> Result<()> {
         format!("UNRAID_RMCP_PORT={}", config.mcp.port),
         format!("UNRAID_RMCP_NO_AUTH={}", config.mcp.no_auth),
     ];
+
+    if !config.mcp.tools.enabled.is_empty() {
+        lines.push(format!(
+            "UNRAID_RMCP_ENABLED_TOOLS={}",
+            config.mcp.tools.enabled.join(",")
+        ));
+    }
+    if !config.mcp.tools.disabled.is_empty() {
+        lines.push(format!(
+            "UNRAID_RMCP_DISABLED_TOOLS={}",
+            config.mcp.tools.disabled.join(",")
+        ));
+    }
 
     if let Some(token) = config
         .mcp

--- a/unraid-rs/src/config.rs
+++ b/unraid-rs/src/config.rs
@@ -35,6 +35,8 @@ pub struct McpConfig {
     pub api_token: Option<String>,
     pub allowed_hosts: Vec<String>,
     pub allowed_origins: Vec<String>,
+    /// Granular MCP tool/action exposure policy.
+    pub tools: McpToolsConfig,
     pub auth: AuthConfig,
 }
 
@@ -42,6 +44,19 @@ impl McpConfig {
     pub fn bind_addr(&self) -> String {
         format!("{}:{}", self.host, self.port)
     }
+}
+
+/// Granular MCP tool/action filtering (nested under `[mcp.tools]`).
+///
+/// An empty `enabled` list means all tools/actions are eligible. Entries in
+/// `disabled` always win. Selectors may be `*`, `unraid`, `unraid.*`, a
+/// bare action such as `docker_logs`, or a qualified action such as
+/// `unraid.docker_logs`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(default)]
+pub struct McpToolsConfig {
+    pub enabled: Vec<String>,
+    pub disabled: Vec<String>,
 }
 
 /// OAuth / auth sub-config (nested under `[mcp.auth]` in config.toml)
@@ -170,6 +185,7 @@ impl Default for McpConfig {
             api_token: None,
             allowed_hosts: Vec::new(),
             allowed_origins: Vec::new(),
+            tools: McpToolsConfig::default(),
             auth: AuthConfig::default(),
         }
     }
@@ -222,6 +238,8 @@ impl Config {
             "UNRAID_RMCP_ALLOWED_ORIGINS",
             &mut config.mcp.allowed_origins,
         );
+        env_list("UNRAID_RMCP_ENABLED_TOOLS", &mut config.mcp.tools.enabled);
+        env_list("UNRAID_RMCP_DISABLED_TOOLS", &mut config.mcp.tools.disabled);
         env_opt_str("UNRAID_RMCP_PUBLIC_URL", &mut config.mcp.auth.public_url);
         env_str(
             "UNRAID_RMCP_AUTH_ADMIN_EMAIL",
@@ -264,6 +282,9 @@ impl Config {
         // that bypasses the non-loopback bind safety check in main.rs.
         // It does NOT set no_auth itself — it merely permits it.
         // (auth gating is handled in build_auth_policy; this flag is read in main.rs)
+
+        crate::mcp::validate_tool_config(&config.mcp.tools)
+            .map_err(|error| anyhow::anyhow!("Invalid MCP tool configuration: {error}"))?;
 
         Ok(config)
     }

--- a/unraid-rs/src/config.rs
+++ b/unraid-rs/src/config.rs
@@ -52,7 +52,7 @@ impl McpConfig {
 /// `disabled` always win. Selectors may be `*`, `unraid`, `unraid.*`, a
 /// bare action such as `docker_logs`, or a qualified action such as
 /// `unraid.docker_logs`.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct McpToolsConfig {
     pub enabled: Vec<String>,
@@ -238,8 +238,8 @@ impl Config {
             "UNRAID_RMCP_ALLOWED_ORIGINS",
             &mut config.mcp.allowed_origins,
         );
-        env_list("UNRAID_RMCP_ENABLED_TOOLS", &mut config.mcp.tools.enabled);
-        env_list("UNRAID_RMCP_DISABLED_TOOLS", &mut config.mcp.tools.disabled);
+        env_tool_selector_list("UNRAID_RMCP_ENABLED_TOOLS", &mut config.mcp.tools.enabled)?;
+        env_tool_selector_list("UNRAID_RMCP_DISABLED_TOOLS", &mut config.mcp.tools.disabled)?;
         env_opt_str("UNRAID_RMCP_PUBLIC_URL", &mut config.mcp.auth.public_url);
         env_str(
             "UNRAID_RMCP_AUTH_ADMIN_EMAIL",
@@ -327,6 +327,40 @@ fn env_bool(key: &str, target: &mut bool) -> anyhow::Result<()> {
             other => anyhow::bail!("{key}: expected bool, got {other:?}"),
         }
     }
+    Ok(())
+}
+
+/// Env override for the two `[mcp.tools]` selector lists ONLY — the generic
+/// `env_list` semantics are deliberately not reused here:
+///
+/// - Set to the empty string `""` → treated as unset (the toml value stays).
+///   The agent plugin's `.mcp.json` passes `""` for both vars by default, so
+///   empty MUST NOT be an error or default plugin installs would fail to start.
+/// - Set, non-empty, but parsing to ZERO selectors (whitespace/commas only,
+///   e.g. `","`) → fail config load. The operator visibly set a policy and it
+///   would otherwise silently do nothing.
+/// - Otherwise the parsed selectors REPLACE the `[mcp.tools]` toml list — env
+///   and toml are never merged. A set env var is the complete policy for that
+///   list (documented in README.md, .env.example, and config.toml).
+fn env_tool_selector_list(key: &str, target: &mut Vec<String>) -> anyhow::Result<()> {
+    let Ok(v) = std::env::var(key) else {
+        return Ok(());
+    };
+    if v.is_empty() {
+        return Ok(());
+    }
+    let items: Vec<String> = v
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if items.is_empty() {
+        anyhow::bail!(
+            "{key}: value {v:?} contains no selectors; \
+             unset the variable or provide comma-separated selectors"
+        );
+    }
+    *target = items;
     Ok(())
 }
 

--- a/unraid-rs/src/main.rs
+++ b/unraid-rs/src/main.rs
@@ -285,6 +285,8 @@ Environment:
   UNRAID_API_SKIP_TLS_VERIFY      Skip TLS cert check
   UNRAID_RMCP_HOST                 Bind host (default 0.0.0.0)
   UNRAID_RMCP_PORT                 Bind port (default 40010)
+  UNRAID_RMCP_ENABLED_TOOLS        Comma-separated MCP tool/action allowlist
+  UNRAID_RMCP_DISABLED_TOOLS       Comma-separated MCP tool/action denylist
   UNRAID_RMCP_DISABLE_HTTP_AUTH    Disable MCP auth
   RUST_LOG                        Log filter"
     );

--- a/unraid-rs/src/mcp.rs
+++ b/unraid-rs/src/mcp.rs
@@ -17,7 +17,7 @@ pub use rmcp_server::{
     UnraidRmcpServer, rmcp_server, streamable_http_config, streamable_http_service,
 };
 pub use routes::router;
-pub use schemas::{data_action_names, write_action_names};
+pub use schemas::{all_action_names, data_action_names, write_action_names};
 pub(crate) use tool_filter::validate_tool_config;
 
 /// Authentication policy attached to [`AppState`].

--- a/unraid-rs/src/mcp.rs
+++ b/unraid-rs/src/mcp.rs
@@ -10,6 +10,7 @@ mod prompts;
 mod rmcp_server;
 mod routes;
 mod schemas;
+mod tool_filter;
 pub(crate) mod tools;
 
 pub use rmcp_server::{
@@ -17,6 +18,7 @@ pub use rmcp_server::{
 };
 pub use routes::router;
 pub use schemas::{data_action_names, write_action_names};
+pub(crate) use tool_filter::validate_tool_config;
 
 /// Authentication policy attached to [`AppState`].
 ///

--- a/unraid-rs/src/mcp/rmcp_server.rs
+++ b/unraid-rs/src/mcp/rmcp_server.rs
@@ -25,6 +25,7 @@ use super::{
     host_filter::{allowed_hosts, allowed_origins},
     prompts,
     schemas::{ACTIONS, tool_definitions},
+    tool_filter::{enabled_action_names, ensure_tool_call_enabled, tool_is_enabled},
     tools::{execute_tool, serialize_response},
 };
 
@@ -50,7 +51,8 @@ impl ServerHandler for UnraidRmcpServer {
         context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
         require_auth_context(&self.state, &context)?;
-        let tools = rmcp_tool_definitions()?;
+        let action_names = enabled_action_names(&self.state.config.tools);
+        let tools = rmcp_tool_definitions(&action_names)?;
         tracing::info!(tool_count = tools.len(), "MCP tools listed");
         Ok(ListToolsResult {
             tools,
@@ -74,6 +76,12 @@ impl ServerHandler for UnraidRmcpServer {
             .to_owned();
 
         let auth = require_auth_context(&self.state, &context)?;
+        if let Err(message) =
+            ensure_tool_call_enabled(&self.state.config.tools, &tool_name, &action)
+        {
+            tracing::warn!(tool = %tool_name, action = %action, reason = %message, "MCP tool denied by server policy");
+            return Err(ErrorData::invalid_request(message, None));
+        }
         if let (Some(auth), Some(required_scope)) = (auth, required_scope_for(&action)) {
             check_scope(auth, required_scope, &action)?;
         }
@@ -148,8 +156,13 @@ impl ServerHandler for UnraidRmcpServer {
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
         require_auth_context(&self.state, &context)?;
+        let resources = if tool_is_enabled(&self.state.config.tools) {
+            vec![schema_resource()]
+        } else {
+            Vec::new()
+        };
         Ok(ListResourcesResult {
-            resources: vec![schema_resource()],
+            resources,
             ..Default::default()
         })
     }
@@ -166,7 +179,14 @@ impl ServerHandler for UnraidRmcpServer {
                 None,
             ));
         }
-        let schema = tool_definitions();
+        let action_names = enabled_action_names(&self.state.config.tools);
+        if action_names.is_empty() {
+            return Err(ErrorData::invalid_request(
+                "unraid MCP tool is disabled by server policy",
+                None,
+            ));
+        }
+        let schema = tool_definitions(&action_names);
         let text = serde_json::to_string_pretty(&schema)
             .map_err(|e| ErrorData::internal_error(format!("serialization error: {e}"), None))?;
         Ok(ReadResourceResult::new(vec![
@@ -251,8 +271,11 @@ fn schema_resource() -> Resource {
 
 // ── tool definition conversion ────────────────────────────────────────────────
 
-fn rmcp_tool_definitions() -> Result<Vec<Tool>, ErrorData> {
-    tool_definitions()
+fn rmcp_tool_definitions(action_names: &[&str]) -> Result<Vec<Tool>, ErrorData> {
+    if action_names.is_empty() {
+        return Ok(Vec::new());
+    }
+    tool_definitions(action_names)
         .into_iter()
         .map(rmcp_tool_from_json)
         .collect()
@@ -363,6 +386,11 @@ mod tests {
             };
             assert_eq!(got, want, "{} scope mapping", spec.name);
         }
+    }
+
+    #[test]
+    fn empty_action_set_hides_the_tool() {
+        assert!(rmcp_tool_definitions(&[]).unwrap().is_empty());
     }
 
     #[test]

--- a/unraid-rs/src/mcp/rmcp_server.rs
+++ b/unraid-rs/src/mcp/rmcp_server.rs
@@ -179,13 +179,13 @@ impl ServerHandler for UnraidRmcpServer {
                 None,
             ));
         }
-        let action_names = enabled_action_names(&self.state.config.tools);
-        if action_names.is_empty() {
+        if !tool_is_enabled(&self.state.config.tools) {
             return Err(ErrorData::invalid_request(
                 "unraid MCP tool is disabled by server policy",
                 None,
             ));
         }
+        let action_names = enabled_action_names(&self.state.config.tools);
         let schema = tool_definitions(&action_names);
         let text = serde_json::to_string_pretty(&schema)
             .map_err(|e| ErrorData::internal_error(format!("serialization error: {e}"), None))?;
@@ -203,6 +203,11 @@ impl ServerHandler for UnraidRmcpServer {
         context: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, ErrorData> {
         require_auth_context(&self.state, &context)?;
+        // Every prompt instructs the client to call the unraid tool, so a fully
+        // disabled tool must not advertise prompts that reference it.
+        if !tool_is_enabled(&self.state.config.tools) {
+            return Ok(ListPromptsResult::default());
+        }
         Ok(prompts::list_prompts())
     }
 
@@ -212,6 +217,12 @@ impl ServerHandler for UnraidRmcpServer {
         context: RequestContext<RoleServer>,
     ) -> Result<GetPromptResponse, ErrorData> {
         require_auth_context(&self.state, &context)?;
+        if !tool_is_enabled(&self.state.config.tools) {
+            return Err(ErrorData::invalid_request(
+                "unraid MCP tool is disabled by server policy",
+                None,
+            ));
+        }
         prompts::get_prompt(request)
             .map(Into::into)
             .map_err(|e| ErrorData::invalid_params(e.to_string(), None))

--- a/unraid-rs/src/mcp/schemas.rs
+++ b/unraid-rs/src/mcp/schemas.rs
@@ -619,6 +619,13 @@ pub fn data_action_names() -> Vec<&'static str> {
         .collect()
 }
 
+/// Every canonical action name, in declaration order — the full unfiltered
+/// action enum. Re-exported so integration tests can pin the default
+/// (no-policy) MCP surface against the canonical list.
+pub fn all_action_names() -> Vec<&'static str> {
+    ACTIONS.iter().map(|a| a.name).collect()
+}
+
 /// The mutating (write-scoped) actions. Re-exported for the same reason as
 /// [`data_action_names`] — so the contract/scenario tests cover mutations too.
 pub fn write_action_names() -> Vec<&'static str> {

--- a/unraid-rs/src/mcp/schemas.rs
+++ b/unraid-rs/src/mcp/schemas.rs
@@ -1,5 +1,3 @@
-use std::sync::LazyLock;
-
 use serde_json::{Value, json};
 
 /// Canonical specification for one `unraid` tool action.
@@ -609,10 +607,6 @@ pub(super) const ACTIONS: &[ActionSpec] = &[
     },
 ];
 
-/// All valid action names, derived from [`ACTIONS`]. Used for the JSON Schema enum.
-pub(super) static UNRAID_ACTIONS: LazyLock<Vec<&'static str>> =
-    LazyLock::new(|| ACTIONS.iter().map(|a| a.name).collect());
-
 /// The upstream-GraphQL-backed data actions (every read-only action except
 /// `status`, which is local observability with no query/fixture). Re-exported so
 /// the scenario + schema-contract integration tests cover every action
@@ -635,7 +629,7 @@ pub fn write_action_names() -> Vec<&'static str> {
         .collect()
 }
 
-pub(super) fn tool_definitions() -> Vec<Value> {
+pub(super) fn tool_definitions(action_names: &[&str]) -> Vec<Value> {
     vec![json!({
         "name": "unraid",
         "description": "Query and manage the Unraid server via its GraphQL API. Read actions need scope unraid:read; mutating actions need unraid:admin. Use action=help for documentation.",
@@ -645,7 +639,7 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 "action": {
                     "type": "string",
                     "description": "Operation to perform.",
-                    "enum": *UNRAID_ACTIONS
+                    "enum": action_names
                 },
                 "id": {
                     "type": "string",
@@ -772,12 +766,16 @@ mod tests {
         }
     }
 
-    /// The derived schema-enum name list must agree with the canonical specs,
-    /// in the same order — this is the list the JSON Schema `enum` is built from.
+    /// The generated schema enum must agree with the canonical specs in the
+    /// same order.
     #[test]
     fn schema_enum_matches_canonical() {
         let derived: Vec<&str> = ACTIONS.iter().map(|a| a.name).collect();
-        assert_eq!(*UNRAID_ACTIONS, derived);
+        let definitions = tool_definitions(&derived);
+        assert_eq!(
+            definitions[0]["inputSchema"]["properties"]["action"]["enum"],
+            json!(derived)
+        );
     }
 
     /// `help` must be present in the canonical list (it is reachable with no scope).

--- a/unraid-rs/src/mcp/tool_filter.rs
+++ b/unraid-rs/src/mcp/tool_filter.rs
@@ -8,22 +8,43 @@ const TOOL_NAME: &str = "unraid";
 ///
 /// Selectors may target the whole tool (`*`, `unraid`, or `unraid.*`) or
 /// one action (`array` or `unraid.array`). Validation is deliberately strict:
-/// a typo in a deny rule must not silently leave an action exposed.
+/// a typo in a deny rule must not silently leave an action exposed. All invalid
+/// selectors are collected and reported in one error so the operator can fix
+/// the whole config in one pass.
 pub(crate) fn validate_tool_config(config: &McpToolsConfig) -> Result<(), String> {
-    for (field, selectors) in [
-        ("enabled", config.enabled.as_slice()),
-        ("disabled", config.disabled.as_slice()),
+    let mut problems = Vec::new();
+    for (field, env_var, selectors) in [
+        (
+            "enabled",
+            "UNRAID_RMCP_ENABLED_TOOLS",
+            config.enabled.as_slice(),
+        ),
+        (
+            "disabled",
+            "UNRAID_RMCP_DISABLED_TOOLS",
+            config.disabled.as_slice(),
+        ),
     ] {
-        for selector in selectors {
-            if !selector_is_valid(selector) {
-                return Err(format!(
-                    "[mcp.tools].{field} contains unknown selector {selector:?}; \
-                     expected *, unraid, unraid.*, an action name, or unraid.<action>"
-                ));
-            }
+        let invalid: Vec<String> = selectors
+            .iter()
+            .filter(|selector| !selector_is_valid(selector))
+            .map(|selector| format!("{selector:?}"))
+            .collect();
+        if !invalid.is_empty() {
+            problems.push(format!(
+                "[mcp.tools].{field} / {env_var} contains unknown selector(s) {}",
+                invalid.join(", ")
+            ));
         }
     }
-    Ok(())
+    if problems.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{}; expected *, unraid, unraid.*, an action name, or unraid.<action>",
+            problems.join("; ")
+        ))
+    }
 }
 
 /// Return canonical action names that are visible under the configured policy.
@@ -80,20 +101,30 @@ pub(super) fn ensure_tool_call_enabled(
     Ok(())
 }
 
+/// Whether a (trimmed) selector targets the whole `unraid` tool rather than a
+/// single action. Shared by validation and matching so the alias list can
+/// never drift between the two.
+fn is_whole_tool_selector(selector: &str) -> bool {
+    matches!(selector, "*" | TOOL_NAME | "unraid.*")
+}
+
+/// The action name a (trimmed) selector refers to: the bare selector, or the
+/// remainder after an `unraid.` qualifier.
+fn selector_action(selector: &str) -> &str {
+    selector.strip_prefix("unraid.").unwrap_or(selector)
+}
+
 fn selector_is_valid(selector: &str) -> bool {
     let selector = selector.trim();
-    if matches!(selector, "*" | TOOL_NAME | "unraid.*") {
-        return true;
-    }
-    let action = selector.strip_prefix("unraid.").unwrap_or(selector);
-    !action.is_empty() && ACTIONS.iter().any(|spec| spec.name == action)
+    is_whole_tool_selector(selector)
+        || ACTIONS
+            .iter()
+            .any(|spec| spec.name == selector_action(selector))
 }
 
 fn selector_matches(selector: &str, action: &str) -> bool {
     let selector = selector.trim();
-    matches!(selector, "*" | TOOL_NAME | "unraid.*")
-        || selector == action
-        || selector.strip_prefix("unraid.") == Some(action)
+    is_whole_tool_selector(selector) || selector_action(selector) == action
 }
 
 #[cfg(test)]
@@ -141,6 +172,53 @@ mod tests {
         let config = config(&[], &["unraid.dockre"]);
         let error = validate_tool_config(&config).unwrap_err();
         assert!(error.contains("unraid.dockre"));
+        assert!(
+            error.contains("[mcp.tools].disabled / UNRAID_RMCP_DISABLED_TOOLS"),
+            "error must name both config sources; got: {error}"
+        );
+    }
+
+    #[test]
+    fn all_invalid_selectors_are_reported_in_one_error() {
+        let config = config(&["arrayy", "docker"], &["unraid.dockre", "vm_rest"]);
+        let error = validate_tool_config(&config).unwrap_err();
+        for needle in [
+            "\"arrayy\"",
+            "\"unraid.dockre\"",
+            "\"vm_rest\"",
+            "[mcp.tools].enabled / UNRAID_RMCP_ENABLED_TOOLS",
+            "[mcp.tools].disabled / UNRAID_RMCP_DISABLED_TOOLS",
+        ] {
+            assert!(
+                error.contains(needle),
+                "error should mention {needle}; got: {error}"
+            );
+        }
+        assert!(
+            !error.contains("\"docker\""),
+            "valid selector flagged: {error}"
+        );
+    }
+
+    /// Tripwire: `ensure_tool_call_enabled` passes through unknown tool names so
+    /// the dispatcher can emit its protocol-level error. That passthrough is safe
+    /// only while `unraid` is the server's entire tool surface — if a second MCP
+    /// tool ever appears, this file's selector policy must learn about it before
+    /// this assertion is relaxed.
+    #[test]
+    fn mcp_tool_surface_is_exactly_unraid() {
+        let config = McpToolsConfig::default();
+        let names: Vec<String> =
+            crate::mcp::schemas::tool_definitions(&enabled_action_names(&config))
+                .into_iter()
+                .map(|def| {
+                    def.get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .expect("tool definition must have a name")
+                        .to_string()
+                })
+                .collect();
+        assert_eq!(names, vec![TOOL_NAME.to_string()]);
     }
 
     #[test]

--- a/unraid-rs/src/mcp/tool_filter.rs
+++ b/unraid-rs/src/mcp/tool_filter.rs
@@ -1,0 +1,151 @@
+use crate::config::McpToolsConfig;
+
+use super::schemas::ACTIONS;
+
+const TOOL_NAME: &str = "unraid";
+
+/// Validate configured selectors before the server starts.
+///
+/// Selectors may target the whole tool (`*`, `unraid`, or `unraid.*`) or
+/// one action (`array` or `unraid.array`). Validation is deliberately strict:
+/// a typo in a deny rule must not silently leave an action exposed.
+pub(crate) fn validate_tool_config(config: &McpToolsConfig) -> Result<(), String> {
+    for (field, selectors) in [
+        ("enabled", config.enabled.as_slice()),
+        ("disabled", config.disabled.as_slice()),
+    ] {
+        for selector in selectors {
+            if !selector_is_valid(selector) {
+                return Err(format!(
+                    "[mcp.tools].{field} contains unknown selector {selector:?}; \
+                     expected *, unraid, unraid.*, an action name, or unraid.<action>"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Return canonical action names that are visible under the configured policy.
+pub(super) fn enabled_action_names(config: &McpToolsConfig) -> Vec<&'static str> {
+    ACTIONS
+        .iter()
+        .filter(|spec| action_is_enabled(config, spec.name))
+        .map(|spec| spec.name)
+        .collect()
+}
+
+/// Whether the top-level `unraid` MCP tool has at least one enabled action.
+pub(super) fn tool_is_enabled(config: &McpToolsConfig) -> bool {
+    ACTIONS
+        .iter()
+        .any(|spec| action_is_enabled(config, spec.name))
+}
+
+/// Whether one canonical action is enabled. Deny rules always win.
+pub(super) fn action_is_enabled(config: &McpToolsConfig, action: &str) -> bool {
+    let allowed = config.enabled.is_empty()
+        || config
+            .enabled
+            .iter()
+            .any(|selector| selector_matches(selector, action));
+    let denied = config
+        .disabled
+        .iter()
+        .any(|selector| selector_matches(selector, action));
+    allowed && !denied
+}
+
+/// Enforce policy before scope checks, elicitation, or dispatch. Unknown tools and
+/// unknown actions remain the dispatcher's responsibility so callers receive the
+/// existing protocol-level validation errors for those cases.
+pub(super) fn ensure_tool_call_enabled(
+    config: &McpToolsConfig,
+    tool_name: &str,
+    action: &str,
+) -> Result<(), String> {
+    if tool_name != TOOL_NAME {
+        return Ok(());
+    }
+    if !tool_is_enabled(config) {
+        return Err(format!(
+            "MCP tool {TOOL_NAME:?} is disabled by server policy"
+        ));
+    }
+    if ACTIONS.iter().any(|spec| spec.name == action) && !action_is_enabled(config, action) {
+        return Err(format!(
+            "MCP action {TOOL_NAME}.{action} is disabled by server policy"
+        ));
+    }
+    Ok(())
+}
+
+fn selector_is_valid(selector: &str) -> bool {
+    let selector = selector.trim();
+    if matches!(selector, "*" | TOOL_NAME | "unraid.*") {
+        return true;
+    }
+    let action = selector.strip_prefix("unraid.").unwrap_or(selector);
+    !action.is_empty() && ACTIONS.iter().any(|spec| spec.name == action)
+}
+
+fn selector_matches(selector: &str, action: &str) -> bool {
+    let selector = selector.trim();
+    matches!(selector, "*" | TOOL_NAME | "unraid.*")
+        || selector == action
+        || selector.strip_prefix("unraid.") == Some(action)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(enabled: &[&str], disabled: &[&str]) -> McpToolsConfig {
+        McpToolsConfig {
+            enabled: enabled.iter().map(|value| (*value).to_string()).collect(),
+            disabled: disabled.iter().map(|value| (*value).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn default_policy_enables_every_action() {
+        let config = McpToolsConfig::default();
+        assert_eq!(enabled_action_names(&config).len(), ACTIONS.len());
+        assert!(tool_is_enabled(&config));
+    }
+
+    #[test]
+    fn allowlist_accepts_bare_and_qualified_actions() {
+        let config = config(&["array", "unraid.docker"], &[]);
+        assert_eq!(enabled_action_names(&config), vec!["array", "docker"]);
+    }
+
+    #[test]
+    fn deny_rules_override_allow_rules() {
+        let config = config(&["unraid"], &["docker", "unraid.vm_reset"]);
+        assert!(action_is_enabled(&config, "array"));
+        assert!(!action_is_enabled(&config, "docker"));
+        assert!(!action_is_enabled(&config, "vm_reset"));
+    }
+
+    #[test]
+    fn wildcard_can_disable_the_entire_tool() {
+        let config = config(&[], &["*"]);
+        assert!(!tool_is_enabled(&config));
+        assert!(enabled_action_names(&config).is_empty());
+        assert!(ensure_tool_call_enabled(&config, "unraid", "array").is_err());
+    }
+
+    #[test]
+    fn invalid_selector_is_rejected() {
+        let config = config(&[], &["unraid.dockre"]);
+        let error = validate_tool_config(&config).unwrap_err();
+        assert!(error.contains("unraid.dockre"));
+    }
+
+    #[test]
+    fn unknown_actions_are_left_to_dispatch_validation() {
+        let config = config(&["array"], &[]);
+        assert!(ensure_tool_call_enabled(&config, "unraid", "not_real").is_ok());
+    }
+}

--- a/unraid-rs/src/mcp/tools.rs
+++ b/unraid-rs/src/mcp/tools.rs
@@ -89,6 +89,9 @@ pub(crate) async fn execute_tool(
     args: Value,
 ) -> Result<Value, ToolError> {
     let action = string_arg(&args, "action").unwrap_or_default();
+    // Deliberate double enforcement: rmcp_server's call_tool checks policy early
+    // (before elicitation); this check covers the test-support entry point
+    // (testing::execute_tool) that bypasses call_tool entirely.
     ensure_tool_call_enabled(&state.config.tools, name, &action)
         .map_err(ToolError::InvalidParams)?;
 

--- a/unraid-rs/src/mcp/tools.rs
+++ b/unraid-rs/src/mcp/tools.rs
@@ -1,8 +1,6 @@
 pub(crate) mod arg_helpers;
 pub(crate) mod paginate;
 
-use std::sync::LazyLock;
-
 use serde_json::{Value, json};
 use thiserror::Error;
 
@@ -12,7 +10,7 @@ use crate::token_limit::truncate_if_needed;
 use self::arg_helpers::{i64_arg, string_arg, string_array_arg, usize_arg};
 use self::paginate::paginate_array;
 use super::AppState;
-use super::schemas::ACTIONS;
+use super::tool_filter::{enabled_action_names, ensure_tool_call_enabled};
 
 /// Typed outcome of a tool dispatch, used to *route* failures at the MCP protocol
 /// boundary without matching on message prose.
@@ -77,16 +75,6 @@ fn classify_service_error(err: anyhow::Error, action: &str) -> ToolError {
     }
 }
 
-/// All valid action names — used in error messages. Derived from the canonical
-/// [`ACTIONS`] list so it can never drift from the schema enum or scope source.
-static VALID_ACTIONS: LazyLock<String> = LazyLock::new(|| {
-    ACTIONS
-        .iter()
-        .map(|a| a.name)
-        .collect::<Vec<_>>()
-        .join(", ")
-});
-
 // ── public entry point ────────────────────────────────────────────────────────
 
 /// Dispatch a named MCP tool. Returns `Ok(Value)` always; errors are encoded in
@@ -100,6 +88,10 @@ pub(crate) async fn execute_tool(
     name: &str,
     args: Value,
 ) -> Result<Value, ToolError> {
+    let action = string_arg(&args, "action").unwrap_or_default();
+    ensure_tool_call_enabled(&state.config.tools, name, &action)
+        .map_err(ToolError::InvalidParams)?;
+
     match name {
         "unraid" => dispatch(state, args).await,
         _ => Err(ToolError::InvalidParams(format!(
@@ -122,7 +114,7 @@ async fn dispatch(state: &AppState, args: Value) -> Result<Value, ToolError> {
     let action = match string_arg(&args, "action") {
         Some(a) => a,
         None => {
-            let valid = &*VALID_ACTIONS;
+            let valid = enabled_action_names(&state.config.tools).join(", ");
             return Err(ToolError::InvalidParams(format!(
                 "\"action\" is required.\n\
                  Valid actions: {valid}\n\
@@ -1092,10 +1084,13 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
             }))
         }
 
-        "help" => Ok(json!({ "help": HELP_TEXT })),
+        "help" => Ok(json!({
+            "help": HELP_TEXT,
+            "enabled_actions": enabled_action_names(&state.config.tools),
+        })),
 
         other => {
-            let valid = &*VALID_ACTIONS;
+            let valid = enabled_action_names(&state.config.tools).join(", ");
             Err(ToolError::InvalidParams(format!(
                 "unknown unraid action: \"{other}\"\n\
                  Valid actions: {valid}\n\
@@ -1111,6 +1106,7 @@ const HELP_TEXT: &str = r#"# unraid MCP Tool
 
 Read-only access to the Unraid server via its GraphQL API.
 Set the required `action` argument to select the operation.
+The response's `enabled_actions` list is authoritative when server policy filters actions.
 
 ## Core
 - `array`          — Array state, disk health, parity, capacity

--- a/unraid-rs/tests/auth_modes.rs
+++ b/unraid-rs/tests/auth_modes.rs
@@ -387,6 +387,40 @@ async fn static_bearer_token_reaches_ordinary_write_dispatch() {
     );
 }
 
+/// Server policy is checked before scope: a bearer-authenticated caller (the
+/// static token carries unraid:admin, so every scope check would pass) hitting
+/// a policy-disabled action must get the "disabled by server policy" error —
+/// never a scope error, and never a dispatch attempt.
+#[tokio::test]
+async fn policy_disabled_action_rejects_authenticated_caller_with_policy_error() {
+    let mut state = testing::bearer_state("admin-token");
+    state.config.tools.disabled = vec!["vm_stop".into()];
+    let (status, value) = post_mcp(
+        router(state),
+        tool_call_body(serde_json::json!({
+            "action": "vm_stop",
+            "id": "vm-1"
+        })),
+        Some("admin-token"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let body = value.to_string();
+    assert!(
+        body.contains("disabled by server policy"),
+        "policy-disabled action must surface the policy error; got: {body}"
+    );
+    assert!(
+        !body.contains("requires scope"),
+        "policy must win over scope errors; got: {body}"
+    );
+    assert!(
+        !body.contains("upstream unreachable"),
+        "policy-disabled action must not reach dispatch; got: {body}"
+    );
+}
+
 /// Destructive writes still require MCP elicitation after bearer authorization.
 /// A raw HTTP caller that did not advertise form elicitation must fail closed
 /// before the GraphQL mutation is attempted.

--- a/unraid-rs/tests/real_binary.rs
+++ b/unraid-rs/tests/real_binary.rs
@@ -76,6 +76,54 @@ async fn binary_renders_representative_actions() {
     }
 }
 
+/// Spawn `runraid mcp` with the given tool-policy env and expect a startup
+/// failure: non-zero exit and the config error on stderr.
+fn run_runraid_startup_failure(env: &[(&str, &str)]) -> String {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_runraid"));
+    cmd.arg("mcp")
+        .env("UNRAID_API_URL", "http://localhost:1/graphql")
+        .env("UNRAID_API_KEY", "test")
+        .env_remove("UNRAID_RMCP_ENABLED_TOOLS")
+        .env_remove("UNRAID_RMCP_DISABLED_TOOLS");
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+    let out = cmd.output().expect("spawn runraid");
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        !out.status.success(),
+        "runraid must refuse to start with env {env:?}; stderr:\n{stderr}"
+    );
+    stderr
+}
+
+/// A typo'd selector must fail startup loudly (fail closed) instead of
+/// silently leaving the action exposed.
+#[test]
+fn binary_refuses_to_start_on_unknown_tool_selector() {
+    let stderr = run_runraid_startup_failure(&[("UNRAID_RMCP_DISABLED_TOOLS", "unraid.dockre")]);
+    assert!(
+        stderr.contains("unknown selector") && stderr.contains("unraid.dockre"),
+        "stderr should name the invalid selector; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("[mcp.tools].disabled / UNRAID_RMCP_DISABLED_TOOLS"),
+        "stderr should name both config sources; got:\n{stderr}"
+    );
+}
+
+/// A set, non-empty value that parses to zero selectors (separators only) must
+/// also fail startup: the operator visibly set a policy that would otherwise
+/// silently do nothing. (The empty string stays valid — it means unset.)
+#[test]
+fn binary_refuses_to_start_on_separator_only_tool_selector_value() {
+    let stderr = run_runraid_startup_failure(&[("UNRAID_RMCP_DISABLED_TOOLS", ",")]);
+    assert!(
+        stderr.contains("UNRAID_RMCP_DISABLED_TOOLS") && stderr.contains("no selectors"),
+        "stderr should explain the zero-selector value; got:\n{stderr}"
+    );
+}
+
 #[tokio::test]
 async fn binary_passes_id_argument() {
     let server = mock_server("healthy").await;

--- a/unraid-rs/tests/setup_contract.rs
+++ b/unraid-rs/tests/setup_contract.rs
@@ -54,6 +54,8 @@ fn setup_repair_creates_env_file_without_upstream_contact() {
     let dir = tempdir().unwrap();
     let missing = dir.path().join("appdata");
     let mut cmd = base_command(&missing);
+    cmd.env("UNRAID_RMCP_ENABLED_TOOLS", "array,docker,status,help")
+        .env("UNRAID_RMCP_DISABLED_TOOLS", "docker_logs,unraid.vm_reset");
     let output = cmd.args(["setup", "repair"]).output().unwrap();
 
     assert!(
@@ -70,6 +72,8 @@ fn setup_repair_creates_env_file_without_upstream_contact() {
     assert!(env_file.contains("UNRAID_API_URL=https://tower.example/graphql"));
     assert!(env_file.contains("UNRAID_API_KEY=secret"));
     assert!(env_file.contains("UNRAID_RMCP_TOKEN=mcp-secret"));
+    assert!(env_file.contains("UNRAID_RMCP_ENABLED_TOOLS=array,docker,status,help"));
+    assert!(env_file.contains("UNRAID_RMCP_DISABLED_TOOLS=docker_logs,unraid.vm_reset"));
 }
 
 /// The setup wrapper script prefers an installed `runraid` binary, falls back to

--- a/unraid-rs/tests/stdio_mcp.rs
+++ b/unraid-rs/tests/stdio_mcp.rs
@@ -25,11 +25,33 @@ async fn stdio_client(
     RunningService<RoleClient, ()>,
     Option<tokio::process::ChildStderr>,
 )> {
-    stdio_client_with_handler(()).await
+    stdio_client_with_handler_and_env((), &[]).await
+}
+
+async fn stdio_client_with_env(
+    env: &[(&str, &str)],
+) -> anyhow::Result<(
+    RunningService<RoleClient, ()>,
+    Option<tokio::process::ChildStderr>,
+)> {
+    stdio_client_with_handler_and_env((), env).await
 }
 
 async fn stdio_client_with_handler<H>(
     handler: H,
+) -> anyhow::Result<(
+    RunningService<RoleClient, H>,
+    Option<tokio::process::ChildStderr>,
+)>
+where
+    H: ClientHandler,
+{
+    stdio_client_with_handler_and_env(handler, &[]).await
+}
+
+async fn stdio_client_with_handler_and_env<H>(
+    handler: H,
+    env: &[(&str, &str)],
 ) -> anyhow::Result<(
     RunningService<RoleClient, H>,
     Option<tokio::process::ChildStderr>,
@@ -45,6 +67,9 @@ where
             .env("UNRAID_RMCP_NO_AUTH", "true")
             .env("RUST_LOG", "warn")
             .env_remove("UNRAID_RMCP_TOKEN");
+        for (key, value) in env {
+            cmd.env(key, value);
+        }
     }))
     .stderr(Stdio::piped())
     .spawn()?;
@@ -164,6 +189,59 @@ async fn stdio_child_process_lists_tools_and_calls_queries() {
         .unwrap();
     let help = text_content_json(&help);
     assert!(help["help"].as_str().unwrap_or("").contains("unraid"));
+
+    cancel_and_drain(service, stderr).await;
+}
+
+#[tokio::test]
+async fn stdio_filters_advertised_actions_and_rejects_disabled_calls() {
+    let (service, stderr) = stdio_client_with_env(&[
+        ("UNRAID_RMCP_ENABLED_TOOLS", "array,status,help"),
+        ("UNRAID_RMCP_DISABLED_TOOLS", "array"),
+    ])
+    .await
+    .unwrap();
+
+    let tools = service.list_tools(Default::default()).await.unwrap();
+    assert_eq!(tools.tools.len(), 1);
+    let tool = serde_json::to_value(&tools.tools[0]).unwrap();
+    assert_eq!(
+        tool["inputSchema"]["properties"]["action"]["enum"],
+        json!(["status", "help"])
+    );
+
+    let status = service
+        .call_tool(
+            CallToolRequestParams::new("unraid")
+                .with_arguments(json!({"action": "status"}).as_object().unwrap().clone()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(text_content_json(&status)["status"], "ok");
+
+    let error = service
+        .call_tool(
+            CallToolRequestParams::new("unraid")
+                .with_arguments(json!({"action": "array"}).as_object().unwrap().clone()),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("disabled by server policy"),
+        "disabled action error was: {error}"
+    );
+
+    cancel_and_drain(service, stderr).await;
+}
+
+#[tokio::test]
+async fn stdio_can_disable_the_entire_mcp_tool() {
+    let (service, stderr) = stdio_client_with_env(&[("UNRAID_RMCP_DISABLED_TOOLS", "*")])
+        .await
+        .unwrap();
+
+    let tools = service.list_tools(Default::default()).await.unwrap();
+    assert!(tools.tools.is_empty());
 
     cancel_and_drain(service, stderr).await;
 }

--- a/unraid-rs/tests/stdio_mcp.rs
+++ b/unraid-rs/tests/stdio_mcp.rs
@@ -10,7 +10,7 @@ use rmcp::{
     ClientHandler, ErrorData,
     model::{
         CallToolRequestParams, ClientCapabilities, ClientInfo, ElicitRequestParams, ElicitResult,
-        ElicitationAction, Implementation,
+        ElicitationAction, Implementation, ReadResourceRequestParams,
     },
     service::{RequestContext, RoleClient, RunningService, ServiceExt},
     transport::{ConfigureCommandExt, TokioChildProcess},
@@ -66,7 +66,9 @@ where
             .env("UNRAID_API_KEY", "test")
             .env("UNRAID_RMCP_NO_AUTH", "true")
             .env("RUST_LOG", "warn")
-            .env_remove("UNRAID_RMCP_TOKEN");
+            .env_remove("UNRAID_RMCP_TOKEN")
+            .env_remove("UNRAID_RMCP_ENABLED_TOOLS")
+            .env_remove("UNRAID_RMCP_DISABLED_TOOLS");
         for (key, value) in env {
             cmd.env(key, value);
         }
@@ -231,6 +233,37 @@ async fn stdio_filters_advertised_actions_and_rejects_disabled_calls() {
         "disabled action error was: {error}"
     );
 
+    // The schema resource must advertise exactly the filtered action enum, not
+    // the full canonical list.
+    let resource = service
+        .read_resource(ReadResourceRequestParams::new("unraid://schema/mcp-tool"))
+        .await
+        .unwrap();
+    let resource = serde_json::to_value(&resource).unwrap();
+    let schema: serde_json::Value = serde_json::from_str(
+        resource["contents"][0]["text"]
+            .as_str()
+            .expect("schema resource should contain text"),
+    )
+    .expect("schema resource text should be JSON");
+    assert_eq!(
+        schema[0]["inputSchema"]["properties"]["action"]["enum"],
+        json!(["status", "help"])
+    );
+
+    // action=help reports the same filtered subset in enabled_actions.
+    let help = service
+        .call_tool(
+            CallToolRequestParams::new("unraid")
+                .with_arguments(json!({"action": "help"}).as_object().unwrap().clone()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        text_content_json(&help)["enabled_actions"],
+        json!(["status", "help"])
+    );
+
     cancel_and_drain(service, stderr).await;
 }
 
@@ -242,6 +275,50 @@ async fn stdio_can_disable_the_entire_mcp_tool() {
 
     let tools = service.list_tools(Default::default()).await.unwrap();
     assert!(tools.tools.is_empty());
+
+    let resources = service.list_resources(Default::default()).await.unwrap();
+    assert!(
+        resources.resources.is_empty(),
+        "a fully disabled tool must not advertise its schema resource"
+    );
+
+    let error = service
+        .read_resource(ReadResourceRequestParams::new("unraid://schema/mcp-tool"))
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("disabled by server policy"),
+        "read_resource error was: {error}"
+    );
+
+    let prompts = service.list_prompts(Default::default()).await.unwrap();
+    assert!(
+        prompts.prompts.is_empty(),
+        "a fully disabled tool must not advertise prompts that reference it"
+    );
+
+    cancel_and_drain(service, stderr).await;
+}
+
+/// The agent plugin's `.mcp.json` passes `""` for both policy env vars by
+/// default. Empty MUST behave as unset — the server starts and exposes the
+/// full canonical action enum. Breaking this bricks default plugin installs.
+#[tokio::test]
+async fn stdio_empty_policy_env_vars_expose_the_full_action_enum() {
+    let (service, stderr) = stdio_client_with_env(&[
+        ("UNRAID_RMCP_ENABLED_TOOLS", ""),
+        ("UNRAID_RMCP_DISABLED_TOOLS", ""),
+    ])
+    .await
+    .unwrap();
+
+    let tools = service.list_tools(Default::default()).await.unwrap();
+    assert_eq!(tools.tools.len(), 1);
+    let tool = serde_json::to_value(&tools.tools[0]).unwrap();
+    assert_eq!(
+        tool["inputSchema"]["properties"]["action"]["enum"],
+        serde_json::to_value(unraid_rmcp::mcp::all_action_names()).unwrap()
+    );
 
     cancel_and_drain(service, stderr).await;
 }


### PR DESCRIPTION
## Summary
- New `[mcp.tools]` config (`enabled` / `disabled` selector lists) filtering which actions the `unraid` MCP tool exposes, with env mapping `UNRAID_RMCP_ENABLED_TOOLS` / `UNRAID_RMCP_DISABLED_TOOLS`
- Selectors: `*`, `unraid`, `unraid.*`, bare action (`docker_logs`), or qualified (`unraid.docker_logs`); deny always wins; unknown selectors fail startup validation
- Policy enforced in `tools/list`, `tools/call`, and the schema resource; disabling everything hides the tool entirely
- Agent plugin (`agents/unraid-rs`) maps two new `userConfig` keys; docs/config examples updated

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --features test-support -- -D warnings`
- [x] `cargo test` (full suite incl. new tool_filter unit tests and stdio disable test)