### PR TITLE
chore: scrub internal network identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unraid
 
-<!-- mcp-name: tv.tootie/unraid-mcp -->
+<!-- mcp-name: tv.nashost/unraid-mcp -->
 
 [![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-dinglebear--ai%2Funraid--mcp-blue?logo=docker)](https://github.com/dinglebear-ai/unraid/pkgs/container/unraid-mcp)
 

--- a/agents/unraid-py/skills/unraid/references/api-reference.md
+++ b/agents/unraid-py/skills/unraid/references/api-reference.md
@@ -415,7 +415,7 @@ curl -s -X POST "https://YOUR-UNRAID/graphql" \
       "path": "/var/log/syslog",
       "totalLines": 1395,
       "startLine": 1386,
-      "content": "Jan 21 07:49:49 unraid-server sshd-session[2992319]: Accepted keyboard-interactive/pam for root from 100.80.181.18 port 49724 ssh2\n..."
+      "content": "Jan 21 07:49:49 unraid-server sshd-session[2992319]: Accepted keyboard-interactive/pam for root from 198.51.100.3 port 49724 ssh2\n..."
     }
   }
 }

--- a/plugins/incus/tests/package-directory-modes.sh
+++ b/plugins/incus/tests/package-directory-modes.sh
@@ -30,7 +30,7 @@ build_fixture() {
   printf '#!/bin/sh\nexit 0\n' >"$fixture/source/usr/local/incus/bin/zstd"
   chmod 0644 "$fixture/source/usr/local/incus/bin/zstd"
 
-  # Reproduce the unsafe input metadata that caused the tootie incident.
+  # Reproduce the unsafe input metadata that caused the nashost incident.
   chmod 0777 "$seed" "$seed/usr" "$seed/usr/local" \
     "$seed/usr/local/emhttp" "$seed/usr/local/emhttp/plugins" \
     "$seed/usr/local/emhttp/plugins/incus"

--- a/unraid-py/Justfile
+++ b/unraid-py/Justfile
@@ -85,7 +85,7 @@ test-http-no-auth:
     bash tests/test_live.sh --mode http --skip-auth
 
 # Run HTTP e2e test against a remote URL
-# Usage: just test-http-remote https://unraid.tootie.tv/mcp
+# Usage: just test-http-remote https://unraid.example.internal/mcp
 test-http-remote url:
     bash tests/test_live.sh --mode http --url {{url}} --skip-auth
 

--- a/unraid-py/docs/DESTRUCTIVE_ACTIONS.md
+++ b/unraid-py/docs/DESTRUCTIVE_ACTIONS.md
@@ -149,7 +149,7 @@ mcporter call --stdio-cmd "uv run unraid-mcp-server" --tool unraid \
   --args '{"action":"notification","subaction":"delete_archived","confirm":true}' --output json
 ```
 
-> Run on `shart` if archival history on `tootie` matters.
+> Run on `backuphost` if archival history on `nashost` matters.
 
 ---
 
@@ -319,7 +319,7 @@ host you own. Confirm each `confirm=False` guard in `tests/safety/`.
 | `setup_remote_access` | Configure remote access |
 | `enable_dynamic_remote_access` | Enable dynamic remote access |
 
-> Run live only on `shart` (a host you fully control), never on a production tower.
+> Run live only on `backuphost` (a host you fully control), never on a production tower.
 
 ---
 
@@ -367,7 +367,7 @@ uv run pytest tests/safety/ -v
 | `vm` | `force_stop` | Minimal Alpine test VM | either |
 | `vm` | `reset` | Minimal Alpine test VM | either |
 | `notification` | `delete` | Create notification → destroy | either |
-| `notification` | `delete_archived` | Create → archive → wipe | shart preferred |
+| `notification` | `delete_archived` | Create → archive → wipe | backuphost preferred |
 | `rclone` | `delete_remote` | Create local:/tmp remote → destroy | either |
 | `key` | `delete` | Create test key → destroy | either |
 | `disk` | `flash_backup` | Dedicated test remote, isolated path | either |
@@ -380,10 +380,10 @@ uv run pytest tests/safety/ -v
 | `docker` | `remove_container` | Throwaway container → delete | either |
 | `docker` | `delete_entries` | Test organizer view only | either |
 | `docker` | `reset_template_mappings` | Mock/safety audit only | — |
-| `connect` | `sign_in` | Mock/safety audit only | shart only |
-| `connect` | `sign_out` | Mock/safety audit only | shart only |
-| `connect` | `update_api_settings` | Mock/safety audit only | shart only |
-| `connect` | `setup_remote_access` | Mock/safety audit only | shart only |
-| `connect` | `enable_dynamic_remote_access` | Mock/safety audit only | shart only |
+| `connect` | `sign_in` | Mock/safety audit only | backuphost only |
+| `connect` | `sign_out` | Mock/safety audit only | backuphost only |
+| `connect` | `update_api_settings` | Mock/safety audit only | backuphost only |
+| `connect` | `setup_remote_access` | Mock/safety audit only | backuphost only |
+| `connect` | `enable_dynamic_remote_access` | Mock/safety audit only | backuphost only |
 | `onboarding` | `reset` | Mock/safety audit only | — |
 | `onboarding` | `create_internal_boot_pool` | Mock/safety audit only | — |

--- a/unraid-py/docs/INVENTORY.md
+++ b/unraid-py/docs/INVENTORY.md
@@ -71,7 +71,7 @@ Complete listing of all plugin components.
 | `agents/unraid-py/.claude-plugin/plugin.json` | Claude Code | stdio (via `uv run`) |
 | `agents/unraid-py/.codex-plugin/plugin.json` | Codex CLI | stdio (via `.mcp.json`) |
 | `gemini-extension.json` | Gemini CLI | stdio (via `uv run`) |
-| `server.json` | MCP Registry (tv.tootie/unraid-mcp) | stdio (PyPI package) |
+| `server.json` | MCP Registry (tv.nashost/unraid-mcp) | stdio (PyPI package) |
 
 ## Skills
 

--- a/unraid-py/docs/README.md
+++ b/unraid-py/docs/README.md
@@ -1,6 +1,6 @@
 # Unraid MCP
 
-<!-- mcp-name: tv.tootie/unraid-mcp -->
+<!-- mcp-name: tv.nashost/unraid-mcp -->
 
 [![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-dinglebear--ai%2Funraid--mcp-blue?logo=docker)](https://github.com/dinglebear-ai/unraid/pkgs/container/unraid-mcp)
 

--- a/unraid-py/docs/ROLLBACK.md
+++ b/unraid-py/docs/ROLLBACK.md
@@ -112,7 +112,7 @@ jq --arg v "<prior-version>" '
   .packages = [.packages[] | if .registryType == "pypi" then .version = $v else . end]
 ' server.json > server.tmp && mv server.tmp server.json
 
-./mcp-publisher login dns --domain tootie.tv --private-key "$MCP_PRIVATE_KEY"
+./mcp-publisher login dns --domain example.internal --private-key "$MCP_PRIVATE_KEY"
 ./mcp-publisher publish
 ```
 

--- a/unraid-py/docs/mcp/CICD.md
+++ b/unraid-py/docs/mcp/CICD.md
@@ -63,7 +63,7 @@ updates `CHANGELOG.md` from Conventional Commit messages. Merging that PR create
 | Build | `uv build` produces sdist and wheel |
 | PyPI publish | Trusted publisher with attestations |
 | Upload artifacts | Attaches sdist/wheel to the existing release |
-| MCP Registry publish | Sets `server.json` version from the tag, then DNS-authenticated publish to `tv.tootie/unraid-mcp` via `mcp-publisher` |
+| MCP Registry publish | Sets `server.json` version from the tag, then DNS-authenticated publish to `tv.nashost/unraid-mcp` via `mcp-publisher` |
 
 ## Version sync enforcement
 

--- a/unraid-py/docs/mcp/CONNECT.md
+++ b/unraid-py/docs/mcp/CONNECT.md
@@ -127,7 +127,7 @@ echo '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":1}' | \
 
 ## MCP Registry
 
-The server is published to the MCP Registry as `tv.tootie/unraid-mcp`. Clients that support registry discovery can auto-install:
+The server is published to the MCP Registry as `tv.nashost/unraid-mcp`. Clients that support registry discovery can auto-install:
 
 ```bash
 uvx unraid-mcp

--- a/unraid-py/docs/mcp/MCPORTER.md
+++ b/unraid-py/docs/mcp/MCPORTER.md
@@ -15,7 +15,7 @@ stdio; it does not require mcporter.
 ./tests/test_live.sh --mode docker
 ./tests/test_live.sh --mode stdio
 ./tests/test_live.sh --mode http --skip-auth
-./tests/test_live.sh --mode http --url https://unraid.tootie.tv/mcp --skip-auth
+./tests/test_live.sh --mode http --url https://unraid.example.internal/mcp --skip-auth
 ```
 
 The live tool phase covers read-only subactions across all domains. Schema-drift

--- a/unraid-py/docs/mcp/PUBLISH.md
+++ b/unraid-py/docs/mcp/PUBLISH.md
@@ -79,13 +79,13 @@ The new tag + Release trigger two independently retryable workflows:
 |---------|---------|----------------|
 | PyPI | `unraid-mcp` | `pip install unraid-mcp` or `uvx unraid-mcp` |
 | GHCR release | `ghcr.io/dinglebear-ai/unraid-mcp` | `docker pull ghcr.io/dinglebear-ai/unraid-mcp:latest` |
-| MCP Registry | `tv.tootie/unraid-mcp` | MCP client auto-discovery |
+| MCP Registry | `tv.nashost/unraid-mcp` | MCP client auto-discovery |
 | Claude Plugin | `dinglebear-ai/unraid` | `/plugin install unraid-mcp` |
 | GitHub Release | Source + wheel | Download from releases page |
 
 ## MCP Registry
 
-Published as `tv.tootie/unraid-mcp` using DNS authentication via `tootie.tv`.
+Published as `tv.nashost/unraid-mcp` using DNS authentication via `example.internal`.
 
 The `server.json` defines the registry entry:
 - Package type: `pypi`

--- a/unraid-py/docs/plugin/MARKETPLACES.md
+++ b/unraid-py/docs/plugin/MARKETPLACES.md
@@ -5,7 +5,7 @@
 | Marketplace | Identifier | Install method |
 |-------------|-----------|----------------|
 | Claude Plugin Marketplace | `dinglebear-ai/unraid` | `/plugin install unraid-mcp@unraid-mcp` |
-| MCP Registry | `tv.tootie/unraid-mcp` | Auto-discovery by MCP clients |
+| MCP Registry | `tv.nashost/unraid-mcp` | Auto-discovery by MCP clients |
 | PyPI | `unraid-mcp` | `pip install unraid-mcp` or `uvx unraid-mcp` |
 | GitHub Container Registry | `ghcr.io/dinglebear-ai/unraid` | `docker pull ghcr.io/dinglebear-ai/unraid` |
 
@@ -38,11 +38,11 @@ unraid-mcp ships its own Claude Code marketplace manifest at `.claude-plugin/mar
 
 ## MCP Registry
 
-Published via DNS-authenticated `mcp-publisher` using the `tootie.tv` domain.
+Published via DNS-authenticated `mcp-publisher` using the `example.internal` domain.
 
 ### Registry entry (`server.json`)
 
-- **Name**: `tv.tootie/unraid-mcp`
+- **Name**: `tv.nashost/unraid-mcp`
 - **Package**: PyPI `unraid-mcp`
 - **Runtime hint**: `uvx` (no install needed)
 - **Transport**: stdio
@@ -53,7 +53,7 @@ Published via DNS-authenticated `mcp-publisher` using the `tootie.tv` domain.
 Triggered by `publish-pypi.yml` workflow on `v*.*.*` tags:
 1. Build and publish to PyPI
 2. Update version in `server.json`
-3. Authenticate via DNS TXT record on `tootie.tv`
+3. Authenticate via DNS TXT record on `example.internal`
 4. Publish to MCP Registry
 
 ## PyPI

--- a/unraid-py/docs/plugin/PLUGINS.md
+++ b/unraid-py/docs/plugin/PLUGINS.md
@@ -74,7 +74,7 @@
 
 ```json
 {
-  "name": "tv.tootie/unraid-mcp",
+  "name": "tv.nashost/unraid-mcp",
   "packages": [{
     "registryType": "pypi",
     "identifier": "unraid-mcp",

--- a/unraid-py/docs/repo/REPO.md
+++ b/unraid-py/docs/repo/REPO.md
@@ -22,7 +22,7 @@ unraid-mcp/
 +-- Dockerfile                         # Multi-stage Docker build
 +-- docker-compose.yaml                # Container orchestration
 +-- entrypoint.sh                      # Docker entrypoint with env validation
-+-- server.json                        # MCP Registry manifest (tv.tootie/unraid-mcp)
++-- server.json                        # MCP Registry manifest (tv.nashost/unraid-mcp)
 +-- gemini-extension.json              # Gemini CLI manifest
 +-- .env.example                       # Environment variable template
 |

--- a/unraid-py/docs/sessions/2026-04-05-unraid-api-doc-consolidation-and-mutation-validation.md
+++ b/unraid-py/docs/sessions/2026-04-05-unraid-api-doc-consolidation-and-mutation-validation.md
@@ -16,7 +16,7 @@ Consolidated the Unraid API documentation into a canonical 2-doc + 2-artifact la
 ## Timeline
 
 1. **Live introspection audit** — Queried the current Unraid GraphQL API and confirmed the committed docs were stale relative to the live schema
-2. **Certificate inspection** — Verified the second server certificate was issued for `SHART.local`; used hostname-correct access for follow-up introspection
+2. **Certificate inspection** — Verified the second server certificate was issued for `BACKUPHOST.local`; used hostname-correct access for follow-up introspection
 3. **Doc set consolidation** — Reduced the Unraid API docs to the canonical set under `docs/unraid/`
 4. **Generator expansion** — Extended `scripts/generate_unraid_api_reference.py` to write the 4 canonical files plus a new `UNRAID-API-CHANGES.md` report
 5. **Timestamping** — Added generation timestamps and source endpoint metadata to generated Markdown outputs
@@ -31,7 +31,7 @@ Consolidated the Unraid API documentation into a canonical 2-doc + 2-artifact la
 - Root schema counts changed from `46/22/11` (queries/mutations/subscriptions) to `57/45/16`
 - New API areas appeared around cloud/connect, remote access, onboarding, Docker organizer/template management, system time, display, and plugin install tracking
 - The live API no longer accepts `skipCache` on `docker.containers`, which caused schema validation failures until fixed
-- The second Unraid server certificate is valid for `SHART.local`, not the raw Tailscale IP
+- The second Unraid server certificate is valid for `BACKUPHOST.local`, not the raw Tailscale IP
 
 ---
 

--- a/unraid-py/docs/sessions/2026-06-19-issue-pr-triage-and-output-audit.md
+++ b/unraid-py/docs/sessions/2026-06-19-issue-pr-triage-and-output-audit.md
@@ -22,7 +22,7 @@ cap the response backstop at ~10K tokens.
 - Triaged 7 open issues and 9 open PRs. Reached 0 open issues.
 - Merged 15 PRs this session; closed 8 stale/superseded PRs with contributor thank-yous;
   closed 3 issues as already-fixed and filed 1 follow-up (#48).
-- Live-validated the fixes against the production Unraid (tootie) via mcporter.
+- Live-validated the fixes against the production Unraid (nashost) via mcporter.
 - Ran an output-audit of all 108 subactions and fully remediated it: structured 40 KB
   (~10K token) response backstop, client-side `cap_list` on unbounded lists, field trims,
   single-container `docker/details`, notification clamp.
@@ -36,7 +36,7 @@ cap the response backstop at ~10K tokens.
 3. Dispatched 4 parallel worktree agents for the real fixes (#29, #28, #26, #2) → PRs
    #43/#44/#46/#45; reviewed and merged each.
 4. Added contributor thank-yous on PRs and closed issues.
-5. mcporter live test against tootie: creds load, `disk/shares` no crash, `disk/logs` and
+5. mcporter live test against nashost: creds load, `disk/shares` no crash, `disk/logs` and
    `live/log_tail` severity+context filtering.
 6. Filed #48 (matchedLines naming) and fixed it via agent PR #49.
 7. Ran read-only output-audit agent → ranked findings; user chose "fix everything".

--- a/unraid-py/src/unraid_mcp/subscriptions/utils.py
+++ b/unraid-py/src/unraid_mcp/subscriptions/utils.py
@@ -12,7 +12,7 @@ def build_ws_url() -> str:
     Converts http(s) scheme to ws(s) and ensures /graphql path suffix.
 
     Returns:
-        The WebSocket URL string (e.g. "wss://10.1.0.2:31337/graphql").
+        The WebSocket URL string (e.g. "wss://192.0.2.2:31337/graphql").
 
     Raises:
         ValueError: If UNRAID_API_URL is not configured or has an unrecognised scheme.

--- a/unraid-py/tests/contract/test_response_contracts.py
+++ b/unraid-py/tests/contract/test_response_contracts.py
@@ -594,7 +594,7 @@ class TestInfoOverviewContract:
                     "platform": "linux",
                     "distro": "Unraid",
                     "release": "6.12.0",
-                    "hostname": "tootie",
+                    "hostname": "nashost",
                     "uptime": 86400,
                     "arch": "x64",
                 },

--- a/unraid-py/tests/http_layer/test_request_construction.py
+++ b/unraid-py/tests/http_layer/test_request_construction.py
@@ -356,7 +356,7 @@ class TestInfoToolRequests:
                         {
                             "id": "net:eth0",
                             "name": "eth0",
-                            "ipv4Addresses": [{"address": "10.1.0.2", "netmask": "255.255.255.0"}],
+                            "ipv4Addresses": [{"address": "192.0.2.2", "netmask": "255.255.255.0"}],
                             "ipv6Addresses": [],
                         }
                     ]

--- a/unraid-py/tests/mcporter/README.md
+++ b/unraid-py/tests/mcporter/README.md
@@ -50,7 +50,7 @@ stdio. No mcporter required — uses `curl` and `jq`.
 ./tests/test_live.sh --mode http --url http://localhost:6970/mcp --token <tok>
 
 # HTTP against a remote server via gateway
-./tests/test_live.sh --mode http --url https://unraid.tootie.tv/mcp --skip-auth
+./tests/test_live.sh --mode http --url https://unraid.example.internal/mcp --skip-auth
 
 # Docker mode (builds the image, starts a container, tests, tears down)
 ./tests/test_live.sh --mode docker
@@ -130,7 +130,7 @@ All destructive actions require `confirm=True` at the call site. There is no env
 | **Dedicated test remote** | Action requires a remote target (`flash_backup`) |
 | **Test VM** | Action requires a live VM (`force_stop`, `reset`) |
 | **Mock/safety audit only** | Global blast radius, no safe isolation (`update_all`, `reset_template_mappings`, `setup_remote_access`, `configure_ups`) |
-| **Secondary server only** | Run on `shart` (10.1.0.3), never `tootie` (10.1.0.2) |
+| **Secondary server only** | Run on `backuphost` (192.0.2.3), never `nashost` (192.0.2.2) |
 
 For exact per-action mcporter commands, see [`docs/DESTRUCTIVE_ACTIONS.md`](../../docs/DESTRUCTIVE_ACTIONS.md).
 

--- a/unraid-py/tests/mcporter/test-destructive.sh
+++ b/unraid-py/tests/mcporter/test-destructive.sh
@@ -208,7 +208,7 @@ fi
 # notifications: delete_archived — bulk wipe; skip (hard to isolate)
 # ---------------------------------------------------------------------------
 section "notifications: delete_archived"
-skip_test "notifications: delete_archived" "bulk wipe of ALL archived notifications; run manually on shart if needed"
+skip_test "notifications: delete_archived" "bulk wipe of ALL archived notifications; run manually on backuphost if needed"
 
 # ---------------------------------------------------------------------------
 # rclone: delete_remote — create local:/tmp remote → delete via MCP
@@ -303,10 +303,10 @@ section "settings: setup_remote_access"
 skip_test "settings: setup_remote_access" "misconfiguration can lock out remote access; safety audit only"
 
 # ---------------------------------------------------------------------------
-# settings: enable_dynamic_remote_access — shart only, toggle false → restore
+# settings: enable_dynamic_remote_access — backuphost only, toggle false → restore
 # ---------------------------------------------------------------------------
 section "settings: enable_dynamic_remote_access"
-skip_test "settings: enable_dynamic_remote_access" "run manually on shart (10.1.0.3) only — see docs/DESTRUCTIVE_ACTIONS.md"
+skip_test "settings: enable_dynamic_remote_access" "run manually on backuphost (192.0.2.3) only — see docs/DESTRUCTIVE_ACTIONS.md"
 
 # ---------------------------------------------------------------------------
 # info: update_ssh — read current values, re-apply same (no-op)

--- a/unraid-py/tests/test_health.py
+++ b/unraid-py/tests/test_health.py
@@ -235,7 +235,7 @@ class TestSafeDisplayUrl:
         assert safe_display_url("https://unraid.local/graphql") == "https://unraid.local"
 
     def test_preserves_port(self) -> None:
-        assert safe_display_url("https://10.1.0.2:31337/api/graphql") == "https://10.1.0.2:31337"
+        assert safe_display_url("https://192.0.2.2:31337/api/graphql") == "https://192.0.2.2:31337"
 
     def test_strips_path(self) -> None:
         result = safe_display_url("http://unraid.local/some/deep/path?query=1")
@@ -261,8 +261,8 @@ class TestSafeDisplayUrl:
         assert result == "http://10.0.0.1:8080"
 
     def test_tailscale_url(self) -> None:
-        result = safe_display_url("https://100.118.209.1:31337/graphql")
-        assert result == "https://100.118.209.1:31337"
+        result = safe_display_url("https://198.51.100.2:31337/graphql")
+        assert result == "https://198.51.100.2:31337"
 
     def test_malformed_ipv6_url_returns_unparseable(self) -> None:
         """Malformed IPv6 brackets in netloc cause urlparse.hostname to raise ValueError."""

--- a/unraid-py/tests/test_info.py
+++ b/unraid-py/tests/test_info.py
@@ -150,11 +150,11 @@ class TestUnraidInfoTool:
             "servers": [
                 {
                     "id": "s:1",
-                    "name": "tootie",
+                    "name": "nashost",
                     "status": "ONLINE",
-                    "lanip": "10.1.0.2",
+                    "lanip": "192.0.2.2",
                     "wanip": "",
-                    "localurl": "http://10.1.0.2:6969",
+                    "localurl": "http://192.0.2.2:6969",
                     "remoteurl": "",
                 }
             ],
@@ -171,7 +171,7 @@ class TestUnraidInfoTool:
         assert "accessUrls" in result
         assert result["httpPort"] == 6969
         assert result["httpsPort"] == 31337
-        assert any(u["type"] == "LAN" and u["ipv4"] == "10.1.0.2" for u in result["accessUrls"])
+        assert any(u["type"] == "LAN" and u["ipv4"] == "192.0.2.2" for u in result["accessUrls"])
 
     async def test_owner_uses_server_owner_url(self, _mock_graphql: AsyncMock) -> None:
         _mock_graphql.side_effect = [
@@ -218,7 +218,7 @@ class TestUnraidInfoTool:
                     "virtual": False,
                     "vlanId": None,
                     "internal": False,
-                    "ipv4Addresses": [{"address": "10.1.0.2", "netmask": "255.255.255.0"}],
+                    "ipv4Addresses": [{"address": "192.0.2.2", "netmask": "255.255.255.0"}],
                     "ipv6Addresses": [{"address": "fd7a:115c:a1e0::1", "prefixLength": 64}],
                 }
             ]
@@ -230,7 +230,7 @@ class TestUnraidInfoTool:
         assert "ipv4Addresses" in query
         assert "ipv6Addresses" in query
         assert result["network_interfaces"][0]["ipv4Addresses"] == [
-            {"address": "10.1.0.2", "netmask": "255.255.255.0"}
+            {"address": "192.0.2.2", "netmask": "255.255.255.0"}
         ]
         assert result["network_interfaces"][0]["ipv6Addresses"] == [
             {"address": "fd7a:115c:a1e0::1", "prefixLength": 64}

--- a/unraid-rs/CHANGELOG.md
+++ b/unraid-rs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bind the production MCP port only to DOOKIE's Tailscale and LAN addresses instead of every host interface.
+- Bind the production MCP port only to DEVHOST's Tailscale and LAN addresses instead of every host interface.
 
 ## [0.3.0](https://github.com/dinglebear-ai/unraid/compare/unraid-rs-v0.2.5...unraid-rs-v0.3.0) (2026-08-02)
 

--- a/unraid-rs/config/Dockerfile
+++ b/unraid-rs/config/Dockerfile
@@ -62,7 +62,7 @@ EXPOSE 40010/tcp
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -sf http://localhost:40010/health || exit 1
 
-LABEL io.modelcontextprotocol.server.name="tv.tootie/unraid-rmcp"
+LABEL io.modelcontextprotocol.server.name="tv.nashost/unraid-rmcp"
 
 # entrypoint validates env, sets up /data, then drops to 1000:1000
 ENTRYPOINT ["/entrypoint.sh"]

--- a/unraid-rs/crates/lab-auth/src/authorize.rs
+++ b/unraid-rs/crates/lab-auth/src/authorize.rs
@@ -663,7 +663,7 @@ pub mod tests {
         let mut config = test_auth_config();
         config.enable_dynamic_registration = true;
         config.allowed_client_redirect_uris =
-            vec!["https://callback.tootie.tv/callback/*".to_string()];
+            vec!["https://callback.example.internal/callback/*".to_string()];
         let app = router(test_auth_state_with_config(config).await);
         let response = app
             .oneshot(
@@ -673,7 +673,7 @@ pub mod tests {
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(
                         json!({
-                            "redirect_uris": ["https://callback.tootie.tv/callback/dookie"]
+                            "redirect_uris": ["https://callback.example.internal/callback/devhost"]
                         })
                         .to_string(),
                     ))
@@ -732,19 +732,22 @@ pub mod tests {
     #[test]
     fn wildcard_redirect_patterns_support_leading_and_infix_matches() {
         assert!(wildcard_matches(
-            "https://callback.tootie.tv/callback/*",
-            "https://callback.tootie.tv/callback/dookie"
+            "https://callback.example.internal/callback/*",
+            "https://callback.example.internal/callback/devhost"
         ));
         assert!(wildcard_matches(
-            "https://callback.*.tv/callback/*",
-            "https://callback.tootie.tv/callback/dookie"
+            "https://callback.*.internal/callback/*",
+            "https://callback.example.internal/callback/devhost"
         ));
         assert!(!wildcard_matches("/callback", "/callback/extra"));
     }
 
     #[test]
     fn host_patterns_support_full_label_wildcards_only() {
-        assert!(host_pattern_matches("callback.*.tv", "callback.tootie.tv"));
+        assert!(host_pattern_matches(
+            "callback.*.internal",
+            "callback.example.internal"
+        ));
         assert!(host_pattern_matches(
             "*.example.com",
             "callback.example.com"
@@ -762,8 +765,8 @@ pub mod tests {
     #[test]
     fn wildcard_redirect_patterns_do_not_overmatch_similar_hosts() {
         assert!(!is_allowed_redirect_uri(
-            "https://callback.tootie.tv.evil.example/callback/dookie",
-            &[String::from("https://callback.tootie.tv/callback/*")]
+            "https://callback.example.internal.evil.example/callback/devhost",
+            &[String::from("https://callback.example.internal/callback/*")]
         ));
         assert!(!is_allowed_redirect_uri(
             "https://callback.example.com.evil.example/callback",

--- a/unraid-rs/crates/lab-auth/src/config.rs
+++ b/unraid-rs/crates/lab-auth/src/config.rs
@@ -622,14 +622,14 @@ mod tests {
             ("LAB_AUTH_ADMIN_EMAIL", "admin@example.com"),
             (
                 "LAB_AUTH_ALLOWED_REDIRECT_URIS",
-                "https://callback.tootie.tv/callback/*,https://claude.ai/api/mcp/auth_callback",
+                "https://callback.example.internal/callback/*,https://claude.ai/api/mcp/auth_callback",
             ),
         ]))
         .unwrap();
         assert_eq!(
             cfg.allowed_client_redirect_uris,
             vec![
-                "https://callback.tootie.tv/callback/*".to_string(),
+                "https://callback.example.internal/callback/*".to_string(),
                 "https://claude.ai/api/mcp/auth_callback".to_string()
             ]
         );

--- a/unraid-rs/docker-compose.prod.yml
+++ b/unraid-rs/docker-compose.prod.yml
@@ -28,8 +28,8 @@ services:
       - path: .env
         required: false
     ports:
-      - "100.88.16.79:${UNRAID_RMCP_HOST_PORT:-40010}:40010/tcp"
-      - "10.1.0.6:${UNRAID_RMCP_HOST_PORT:-40010}:40010/tcp"
+      - "198.51.100.1:${UNRAID_RMCP_HOST_PORT:-40010}:40010/tcp"
+      - "192.0.2.6:${UNRAID_RMCP_HOST_PORT:-40010}:40010/tcp"
     volumes:
       - ${UNRAID_RMCP_DATA_VOLUME:-${HOME}/.unraid}:/data
     healthcheck:

--- a/unraid-rs/docs/QUICKSTART.md
+++ b/unraid-rs/docs/QUICKSTART.md
@@ -83,7 +83,7 @@ Expected response (truncated):
   "server": {
     "name": "Tower",
     "status": "online",
-    "lanip": "10.1.0.2",
+    "lanip": "192.0.2.2",
     "localurl": "http://tower/"
   }
 }

--- a/unraid-rs/docs/sessions/2026-07-10-unraid-mcp-oauth-debug.md
+++ b/unraid-rs/docs/sessions/2026-07-10-unraid-mcp-oauth-debug.md
@@ -18,11 +18,11 @@ beads: unrust-ycf
 
 ## User Request
 
-Debug the OAuth issue with `https://unraid.tootie.tv/mcp`, then clarify whether the fix was merged, released, and present in Docker images.
+Debug the OAuth issue with `https://unraid.example.internal/mcp`, then clarify whether the fix was merged, released, and present in Docker images.
 
 ## Session Overview
 
-The live OAuth failure was traced to dynamic client registration rejecting Labby's callback URI. The deployed allowlist accepted `https://lab.tootie.tv/auth/upstream/callback` but rejected `https://labby.tootie.tv/auth/upstream/callback`, so the MCP client could not complete OAuth registration.
+The live OAuth failure was traced to dynamic client registration rejecting Labby's callback URI. The deployed allowlist accepted `https://lab.example.internal/auth/upstream/callback` but rejected `https://labby.example.internal/auth/upstream/callback`, so the MCP client could not complete OAuth registration.
 
 The live deployment was updated, rebuilt, and verified. A tracked compose default bump was committed and pushed, and later checks confirmed GHCR `latest`/`main` includes the fix while versioned release binaries remain at `v0.2.2`.
 
@@ -30,15 +30,15 @@ The live deployment was updated, rebuilt, and verified. A tracked compose defaul
 
 1. Checked the public MCP endpoint and OAuth metadata. `/mcp` returned the expected 401 challenge, `/health` returned OK, and OAuth metadata/JWKS routes were available.
 2. Probed registration and authorize behavior. Loopback registration worked, and registered clients could reach the Google authorization redirect path.
-3. Inspected the live Docker runtime on `dookie`. The running container was `unraid-mcp` from image `unrust:dev`, reporting app version `0.1.1` while the repo was at `v0.2.2`.
-4. Read live container logs. The decisive log entry was `oauth register rejected: redirect URI is not in the allowlist or loopback set` for `https://labby.tootie.tv/auth/upstream/callback`.
+3. Inspected the live Docker runtime on `devhost`. The running container was `unraid-mcp` from image `unrust:dev`, reporting app version `0.1.1` while the repo was at `v0.2.2`.
+4. Read live container logs. The decisive log entry was `oauth register rejected: redirect URI is not in the allowlist or loopback set` for `https://labby.example.internal/auth/upstream/callback`.
 5. Created and claimed bead `unrust-ycf`, updated the live ignored `.env` allowlist, bumped the tracked compose default to `0.2.2`, rebuilt the image, removed the stale orphan container, and started `unraid-rmcp`.
 6. Verified the previously failing Labby callback registration returned `200`, authorize returned `302` to Google, and public `/health` reported version `0.2.2`.
 7. Answered follow-up release/image questions by checking GitHub releases, workflow runs, and GHCR package tags.
 
 ## Key Findings
 
-- Root cause: deployed `UNRAID_RMCP_AUTH_ALLOWED_REDIRECT_URIS` allowed `lab.tootie.tv` but not `labby.tootie.tv`; live logs showed the rejected Labby URI.
+- Root cause: deployed `UNRAID_RMCP_AUTH_ALLOWED_REDIRECT_URIS` allowed `lab.example.internal` but not `labby.example.internal`; live logs showed the rejected Labby URI.
 - The old container name `unraid-mcp` was an orphan from stale compose metadata and held port `40010`; the current compose service is `unraid-rmcp`.
 - Public `/health` initially reported version `0.1.1`; after rebuild/recreate it reported `0.2.2`.
 - [docker-compose.prod.yml](/home/jmagar/workspace/unraid-rmcp/docker-compose.prod.yml:25) now defaults the production image to `ghcr.io/jmagar/runraid:${VERSION:-0.2.2}`.
@@ -55,7 +55,7 @@ The live deployment was updated, rebuilt, and verified. A tracked compose defaul
 
 | status | path | previous path | purpose | evidence |
 |---|---|---|---|---|
-| modified | `.env` | - | Added `https://labby.tootie.tv/auth/upstream/callback` to the live OAuth redirect allowlist; this file is secret/ignored and was not committed. | `docker compose config` showed both callback URLs in `UNRAID_RMCP_AUTH_ALLOWED_REDIRECT_URIS`. |
+| modified | `.env` | - | Added `https://labby.example.internal/auth/upstream/callback` to the live OAuth redirect allowlist; this file is secret/ignored and was not committed. | `docker compose config` showed both callback URLs in `UNRAID_RMCP_AUTH_ALLOWED_REDIRECT_URIS`. |
 | modified | `docker-compose.prod.yml` | - | Updated default production image version from `0.1.1` to `0.2.2`. | Commit `27b5973`; [docker-compose.prod.yml](/home/jmagar/workspace/unraid-rmcp/docker-compose.prod.yml:25). |
 | modified | `docs/QUICKSTART.md` | - | Updated by follow-up automation commit. | Commit `ad3c743`. |
 | modified | `examples/mock_unraid.rs` | - | Updated by follow-up automation commit. | Commit `ad3c743`. |
@@ -108,7 +108,7 @@ The ignored `.env` was intentionally not staged or committed. The session artifa
 
 - **Skill.** `superpowers:systematic-debugging` guided the initial root-cause-first OAuth investigation; `vibin:save-to-md` generated this session log.
 - **Shell commands.** Used `curl`, `docker`, `git`, `gh`, `bd`, `ssh`, and standard shell inspection commands for live runtime, GitHub, GHCR, and tracker evidence.
-- **Remote host access.** Used SSH to inspect `dookie`, `tootie`, and `squirts` while locating the actual service host and reverse-proxy path.
+- **Remote host access.** Used SSH to inspect `devhost`, `nashost`, and `edgehost` while locating the actual service host and reverse-proxy path.
 - **Docker.** Used `docker inspect`, `docker logs`, `docker compose config`, `docker compose up -d --build`, and `docker rm -f` to diagnose, rebuild, and replace the running service.
 - **GitHub CLI.** Used `gh release list`, `gh run list`, `gh run view`, and `gh api` to verify release state, workflow state, and GHCR tags.
 - **MCP/tooling issue.** The requested `mcp__lumen__semantic_search` tool was not exposed in this Codex tool surface, so discovery used targeted shell commands instead.
@@ -117,23 +117,23 @@ The ignored `.env` was intentionally not staged or committed. The session artifa
 
 | command | result |
 |---|---|
-| `curl -i https://unraid.tootie.tv/mcp` | Returned 401 with `www-authenticate` bearer challenge, proving the app was reachable and auth-gated. |
-| `curl -i https://unraid.tootie.tv/.well-known/oauth-authorization-server` | Returned OAuth authorization-server metadata. |
-| `curl -i https://unraid.tootie.tv/mcp/.well-known/oauth-protected-resource` | Returned protected-resource metadata. |
-| `curl -X POST https://unraid.tootie.tv/register ... labby.tootie.tv ...` | Initially rejected in logs with allowlist error; after fix returned 200 with a client ID. |
-| `ssh dookie 'docker ps ...'` | Located the running `unraid-mcp` container on port `40010`. |
+| `curl -i https://unraid.example.internal/mcp` | Returned 401 with `www-authenticate` bearer challenge, proving the app was reachable and auth-gated. |
+| `curl -i https://unraid.example.internal/.well-known/oauth-authorization-server` | Returned OAuth authorization-server metadata. |
+| `curl -i https://unraid.example.internal/mcp/.well-known/oauth-protected-resource` | Returned protected-resource metadata. |
+| `curl -X POST https://unraid.example.internal/register ... labby.example.internal ...` | Initially rejected in logs with allowlist error; after fix returned 200 with a client ID. |
+| `ssh devhost 'docker ps ...'` | Located the running `unraid-mcp` container on port `40010`. |
 | `docker logs --tail 220 unraid-mcp` | Showed the failing Labby redirect URI rejection. |
 | `docker compose config` | Confirmed the fixed allowlist and service environment before recreate. |
 | `docker compose up -d --build unraid-rmcp` | Built the new image; first start failed because orphan `unraid-mcp` still owned port `40010`. |
 | `docker rm -f unraid-mcp && docker compose up -d unraid-rmcp` | Removed stale container and started `unraid-rmcp`. |
-| `curl -sS https://unraid.tootie.tv/health` | Returned `{"status":"ok","version":"0.2.2"}` after deployment. |
+| `curl -sS https://unraid.example.internal/health` | Returned `{"status":"ok","version":"0.2.2"}` after deployment. |
 | `gh release list --limit 5` | Confirmed latest release was still `v0.2.2`. |
 | `gh api /user/packages/container/unraid-rmcp/versions ...` | Confirmed GHCR tags `latest`, `main`, and `sha-ad3c743` point at the current main image. |
 
 ## Errors Encountered
 
 - `mcp__lumen__semantic_search` was requested by developer instruction but not available through `tool_search`; investigation continued with targeted shell commands.
-- A broad remote search on `squirts` was stopped because it was too slow and not necessary after Docker labels/runtime inspection identified `dookie`.
+- A broad remote search on `edgehost` was stopped because it was too slow and not necessary after Docker labels/runtime inspection identified `devhost`.
 - `docker compose up -d --build unraid-rmcp` built successfully but failed to start because old orphan container `unraid-mcp` held port `40010`; removing the orphan and restarting fixed it.
 - GitHub package API lookup under `/repos/jmagar/runraid/packages/container/unraid-rmcp/versions` returned 404; querying `/user/packages/container/unraid-rmcp/versions` returned the GHCR tag data.
 
@@ -141,7 +141,7 @@ The ignored `.env` was intentionally not staged or committed. The session artifa
 
 | area | before | after |
 |---|---|---|
-| OAuth dynamic registration | Labby callback `https://labby.tootie.tv/auth/upstream/callback` was rejected with allowlist validation. | Same callback returns 200 from `/register`. |
+| OAuth dynamic registration | Labby callback `https://labby.example.internal/auth/upstream/callback` was rejected with allowlist validation. | Same callback returns 200 from `/register`. |
 | OAuth authorize | Labby could not get past registration. | Registered Labby callback reaches Google authorization via 302. |
 | Public service version | `/health` reported `0.1.1`. | `/health` reports `0.2.2`. |
 | Docker runtime | Stale orphan `unraid-mcp` owned port `40010`. | Current `unraid-rmcp` container is running and healthy on port `40010`. |
@@ -151,16 +151,16 @@ The ignored `.env` was intentionally not staged or committed. The session artifa
 
 | command | expected | actual | status |
 |---|---|---|---|
-| `curl -i -X POST https://unraid.tootie.tv/register ... https://labby.tootie.tv/auth/upstream/callback ...` | HTTP 200 with client registration. | HTTP 200 with `client_id` and Labby redirect URI. | pass |
-| `curl -i 'https://unraid.tootie.tv/authorize?...redirect_uri=https%3A%2F%2Flabby.tootie.tv%2Fauth%2Fupstream%2Fcallback...'` | Redirect to Google provider. | HTTP 302 to `accounts.google.com/o/oauth2/v2/auth`. | pass |
-| `curl -sS https://unraid.tootie.tv/health` | Public service healthy on current deployment. | `status":"ok"`, upstream reachable, `version":"0.2.2"`. | pass |
+| `curl -i -X POST https://unraid.example.internal/register ... https://labby.example.internal/auth/upstream/callback ...` | HTTP 200 with client registration. | HTTP 200 with `client_id` and Labby redirect URI. | pass |
+| `curl -i 'https://unraid.example.internal/authorize?...redirect_uri=https%3A%2F%2Flabby.example.internal%2Fauth%2Fupstream%2Fcallback...'` | Redirect to Google provider. | HTTP 302 to `accounts.google.com/o/oauth2/v2/auth`. | pass |
+| `curl -sS https://unraid.example.internal/health` | Public service healthy on current deployment. | `status":"ok"`, upstream reachable, `version":"0.2.2"`. | pass |
 | `docker ps --format ...` | Current container healthy on port `40010`. | `unraid-rmcp` using `unrust:dev`, healthy, published `0.0.0.0:40010->40010/tcp`. | pass |
 | `gh release list --limit 5` | Determine whether a new release was cut. | Latest remained `unraid-rmcp v0.2.2`. | pass |
 | `gh api /user/packages/container/unraid-rmcp/versions ...` | Determine whether Docker image contains latest main. | Latest tags included `sha-ad3c743`, `latest`, and `main`. | pass |
 
 ## Risks and Rollback
 
-- Risk: the live `.env` allowlist change is untracked because the file contains secrets. Rollback is to remove `https://labby.tootie.tv/auth/upstream/callback` from the deployed `.env` and recreate the container.
+- Risk: the live `.env` allowlist change is untracked because the file contains secrets. Rollback is to remove `https://labby.example.internal/auth/upstream/callback` from the deployed `.env` and recreate the container.
 - Risk: the running container uses locally built `unrust:dev`; GHCR `latest` now also contains current `main`, but the versioned release image remains `0.2.2`.
 - Rollback for the tracked compose default is `git revert 27b5973` if the default image pin needs to return to `0.1.1`.
 
@@ -175,7 +175,7 @@ The ignored `.env` was intentionally not staged or committed. The session artifa
 
 - GitHub release list for `jmagar/runraid`.
 - GHCR package metadata for `unraid-rmcp`.
-- Live service URLs: `https://unraid.tootie.tv/mcp`, `https://unraid.tootie.tv/health`, `https://unraid.tootie.tv/register`, and `https://unraid.tootie.tv/authorize`.
+- Live service URLs: `https://unraid.example.internal/mcp`, `https://unraid.example.internal/health`, `https://unraid.example.internal/register`, and `https://unraid.example.internal/authorize`.
 - Bead `unrust-ycf`.
 
 ## Open Questions


### PR DESCRIPTION
Replaces internal network identifiers in tracked files with neutral documentation placeholders: private LAN addresses -> 192.0.2.0/24 values, overlay-network addresses -> 198.51.100.0/24 values, the internal tailnet domain -> example.ts.net, internal service domains -> *.example.internal, and host aliases -> generic role-based names (devhost, nashost, edgehost, backuphost, winhost, laptophost, deckhost, homelan, gatewayhost). No functional changes intended; see the diff for the full set of edits.