### PR TITLE
fix(unraid-py): upgrade cryptography to 50.0.0 for CVE-2026-69247

### DIFF
--- a/unraid-py/uv.lock
+++ b/unraid-py/uv.lock
@@ -1525,8 +1525,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- `uv lock --upgrade-package cryptography`: 49.0.0 → 50.0.0, closing CVE-2026-69247
- This is the failure behind the red **Security Audit** check on the open dependabot PRs (#330–#334); once merged, rerunning those checks should turn them green

## Test plan
- [x] `uv sync --locked` resolves
- [ ] CI Test + Security Audit (lockfile-only change; local pytest run was network-bound and CI is authoritative)