### PR TITLE
fix(docker): repair the Rust image build (broken since #262)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -167,3 +167,24 @@ jobs:
           grep -qx 'src/main.rs' <<<"$files"
           grep -qx 'schema/unraid-schema.graphql' <<<"$files"
           test "$(wc -l <<<"$files")" -lt 90
+
+  docker-image:
+    name: Container Image
+    # The release image build is only exercised by rust-release.yml on a
+    # published release, so a broken Dockerfile stayed invisible for three
+    # consecutive releases (v0.3.0 through v0.4.0 all failed the docker job).
+    # Building it here fails the PR instead of the release.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # Plain `docker build` on the runner's preinstalled Docker: no new
+      # third-party action, so nothing to add to .github/allowed-actions.txt.
+      - name: Build the Rust server image
+        working-directory: ${{ github.workspace }}
+        run: docker build -f unraid-rs/config/Dockerfile -t unraid-rmcp:ci ./unraid-rs
+      - name: The built binary must run
+        working-directory: ${{ github.workspace }}
+        run: docker run --rm --entrypoint /usr/local/bin/runraid unraid-rmcp:ci --version

--- a/unraid-rs/config/Dockerfile
+++ b/unraid-rs/config/Dockerfile
@@ -10,8 +10,13 @@ FROM rust:1.97-slim-bookworm AS builder
 WORKDIR /app
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 
-# Cache deps layer — build a stub binary first so dependency compilation
-# is cached independently from source changes.
+# There is deliberately NO stub-binary "cache deps" layer here. Building a stub
+# first ran build.rs — which is what registers the cynic schema — and cargo then
+# considered build.rs fresh for the real build, so the schema module generated
+# against the stub was reused. Enum-typed fields (VmDomain.state,
+# UnraidArray.state, Registration.state) came out inaccessible and the lib failed
+# to compile. The cargo cache mounts below already cache dependency compilation
+# across builds, so the stub layer bought nothing. Do not reintroduce it.
 COPY Cargo.toml Cargo.lock ./
 # build.rs + the vendored SDL must be present before any `cargo build`: build.rs
 # calls cynic_codegen::register_schema(...).from_sdl_file("schema/unraid-schema.graphql"),
@@ -21,17 +26,17 @@ COPY build.rs ./
 COPY schema/ schema/
 # Strip xtask workspace member — not needed in Docker build context
 RUN sed -i 's/, \"xtask\"//g; s/\"xtask\", //g; s/\"xtask\"//g' Cargo.toml
-RUN --mount=type=cache,id=unraid-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,id=unraid-cargo-git,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,id=unraid-cargo-target,target=/app/target,sharing=locked \
-    mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release --locked -p unraid-rmcp && rm -rf src
 
-# Build real binary
+# crates/ must be copied: crates/lab-auth is a workspace member and a path
+# dependency of unraid-rmcp, so cargo refuses to load the workspace without it.
+# It was missing entirely, which is why the image build failed with
+# "failed to load manifest for workspace member /app/crates/lab-auth".
+COPY crates/ crates/
 COPY src/ src/
 RUN --mount=type=cache,id=unraid-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=unraid-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=unraid-cargo-target,target=/app/target,sharing=locked \
-    touch src/main.rs && cargo build --release --locked -p unraid-rmcp && cp target/release/runraid /usr/local/bin/runraid
+    cargo build --release --locked -p unraid-rmcp && cp target/release/runraid /usr/local/bin/runraid
 
 # Runtime image — minimal Debian with TLS certs and curl for healthcheck
 # TODO: digest-pin (debian:bookworm-slim@sha256:...) for fully reproducible builds.


### PR DESCRIPTION
## Summary

The `ghcr.io/dinglebear-ai/unraid-rmcp` image has failed to build for **three consecutive releases** — `unraid-rs-v0.3.0`, `v0.3.1`, and `v0.4.0` each cut their tag, published every other asset, then failed the `docker` job. Two independent bugs:

1. **`crates/lab-auth` was never copied.** It became a workspace member and a path dependency of `unraid-rmcp` in #262, but the Dockerfile still copied only the root manifest and `src/`. cargo could not load the workspace at all: `failed to load manifest for workspace member /app/crates/lab-auth`. The Dockerfile hasn't been meaningfully touched since the monorepo consolidation, so it simply predates that change.

2. **The stub "cache deps" layer poisoned the cynic schema.** With (1) fixed, the build failed differently: the stub build ran `build.rs` — which is what calls `cynic_codegen::register_schema` — and cargo then treated `build.rs` as fresh for the real build, reusing the schema module generated against the stub. Enum-typed fields came out inaccessible:
   ```
   `crate::gql_typed::schema::__fields::VmDomain::state`: not accessible
   `crate::gql_typed::schema::__fields::UnraidArray::state`: not accessible
   `crate::gql_typed::schema::__fields::Registration::state`: not accessible
   ```
   The `--mount=type=cache` mounts already cache dependency compilation across builds, so the stub layer bought nothing and is removed rather than worked around. A comment records why, so it isn't reintroduced.

Also adds a `Container Image` job to `rust-ci.yml`. The image was only ever built at release time, which is precisely why this stayed invisible while three releases shipped — the failure lands *after* the tag exists. It uses the runner's preinstalled Docker, so no new `.github/allowed-actions.txt` entry is required.

## Test plan
- [x] `docker build --no-cache` on **fresh cache-mount IDs** (mirroring a cold CI runner) — succeeds
- [x] Isolated the second bug empirically: identical build minus the stub layer succeeds, with the stub layer fails
- [x] `docker run --entrypoint /usr/local/bin/runraid ... --version` → `unraid-rmcp 0.3.1`; image 45 MB
- [x] Verified the vendored SDL is byte-identical inside the build context (ruled out `.dockerignore` / content drift)
- [x] Action pin-comment + allowlist mirror checks pass