### PR TITLE
fix(mcp): harden Rust plugin runtime

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -6,17 +6,13 @@ on:
     branches: ["main"]
     paths:
       - "plugins/mcp/**"
-      - "unraid-rs/Cargo.toml"
-      - "unraid-rs/Cargo.lock"
-      - "unraid-rs/src/**"
+      - "unraid-rs/**"
       - ".github/workflows/mcp-ci.yml"
       - ".github/workflows/rust-release.yml"
   pull_request:
     paths:
       - "plugins/mcp/**"
-      - "unraid-rs/Cargo.toml"
-      - "unraid-rs/Cargo.lock"
-      - "unraid-rs/src/**"
+      - "unraid-rs/**"
       - ".github/workflows/mcp-ci.yml"
       - ".github/workflows/rust-release.yml"
   workflow_dispatch:
@@ -42,19 +38,19 @@ jobs:
           node-version: "22"
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
           targets: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: unraid-rs
       - name: Install package validators
-        run: sudo apt-get update && sudo apt-get install -y file libxml2-utils shellcheck xz-utils
+        run: sudo apt-get update && sudo apt-get install -y binutils file libxml2-utils php-cli shellcheck xz-utils
 
       - name: Shellcheck packaging and on-box scripts
         run: |
           set -euo pipefail
           mapfile -t scripts < <(
-            find scripts source tests -type f \( -name '*.sh' -o -name 'rc.*' -o -path '*/event/*' \) | sort
+            find scripts source tests -type f \( -name '*.sh' -o -name 'rc.*' -o -path '*/event/*' -o -path '*/nchan/*' \) | sort
           )
           printf 'checking %d scripts\n' "${#scripts[@]}"
           printf '%s\n' "${scripts[@]}"
@@ -67,7 +63,7 @@ jobs:
           while IFS= read -r f; do
             [ -x "$f" ] || { echo "not executable: $f"; status=1; }
             if grep -qU $'\r' "$f"; then echo "CRLF line endings: $f"; status=1; fi
-          done < <(find scripts source tests -type f \( -name '*.sh' -o -name 'rc.*' -o -path '*/event/*' \))
+          done < <(find scripts source tests -type f \( -name '*.sh' -o -name 'rc.*' -o -path '*/event/*' -o -path '*/nchan/*' \))
           exit "$status"
 
       - name: Validate .plg XML and required entities
@@ -83,13 +79,25 @@ jobs:
               || { echo "::error::unraid-mcp.plg lost its ${placeholder}"; exit 1; }
           done
 
+      - name: Lint PHP endpoint and Unraid pages
+        run: |
+          php -l source/usr/local/emhttp/plugins/unraid-mcp/include/config.php
+          php -l source/usr/local/emhttp/plugins/unraid-mcp/UnraidMCP.page
+          php -l source/usr/local/emhttp/plugins/unraid-mcp/UnraidMCPDashboard.page
+          php -l tests/config-endpoint.php
+
       - name: Validate Community Applications metadata
         run: ./tests/ca-metadata.sh
+
+      - name: Validate runtime and settings contracts
+        run: ./tests/runtime-contract.sh
 
       - name: Build and audit the web bundle
         run: |
           npm ci --no-audit --no-fund --prefix web
-          npm audit --omit=dev --audit-level=high --prefix web
+          npm audit --audit-level=moderate --prefix web
+          npm run typecheck --prefix web
+          npm test --prefix web
           npm run build --prefix web
 
       - name: Build, verify, and reproduce the Rust plugin package

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
           targets: x86_64-unknown-linux-gnu
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -85,7 +85,7 @@ jobs:
           node-version: "22"
 
       - name: Install plugin package validators
-        run: sudo apt-get update && sudo apt-get install -y file libxml2-utils xz-utils
+        run: sudo apt-get update && sudo apt-get install -y binutils file libxml2-utils xz-utils
 
       - name: Build linux/amd64 binary
         run: cargo build --release --locked --target x86_64-unknown-linux-gnu --bin runraid
@@ -109,12 +109,19 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
-          subject-path: unraid-rs/runraid-linux-x86_64
+          subject-path: |
+            unraid-rs/runraid-linux-x86_64
+            unraid-rs/runraid-linux-x86_64.sha256
+            unraid-rs/runraid-x86_64.tar.gz
+            unraid-rs/runraid-x86_64.tar.gz.sha256
+            plugins/mcp/packages/*.txz
+            plugins/mcp/packages/unraid-mcp.plg
 
       - name: Attach binary + checksums to the release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           # The .txz is named by the fixed-width epoch-3 plugin version, not the
           # rust semver (see plugins/mcp/scripts/plugin-version.sh).
           plugin_version="$(bash ../plugins/mcp/scripts/plugin-version.sh "${TAG#unraid-rs-v}")"

--- a/plugins/mcp/README.md
+++ b/plugins/mcp/README.md
@@ -20,18 +20,34 @@ automatic credential bootstrap, service controls, and log rotation.
 ## Runtime model
 
 Persistent state lives under `/boot/config/plugins/unraid-mcp/` for the `.env`
-and service-enable flag. OAuth state and self-updated binaries live under
-`/mnt/user/appdata/unraid-mcp/`. The RAM-rootfs runtime is restored by Unraid on
-every boot.
+and service-enable flag. OAuth state and self-updated binaries live directly under
+`/mnt/user/appdata/unraid-mcp/` through the `UNRAID_HOME` override. The service
+refuses to create or modify that tree unless `/mnt/user` is actually mounted,
+and ignores overlay binaries that are symlinks or are not root-owned regular
+executables. The RAM-rootfs runtime is restored by Unraid on every boot.
 
-`rc.unraid-mcp` starts `runraid serve`, preferring the persistent overlay binary
-when one has been installed through the settings page. The updater downloads the
-`runraid-linux-x86_64` asset and its SHA-256 file from a Rust component release,
-verifies both the digest and reported version, then atomically replaces the
-overlay. Reset removes the overlay and returns to the plugin-bundled binary.
+`rc.unraid-mcp` starts `runraid serve`, preferring a safe persistent overlay
+binary when one has been installed through the settings page. Startup is not
+reported successful until the public `/health` endpoint responds. Tailscale
+Serve state remembers the published port so stop/restart also cleans stale
+routes after a port change or an unexpected server exit.
+
+The updater downloads the `runraid-linux-x86_64` asset and its SHA-256 file from
+a Rust component release, verifies both the digest and reported version, then
+atomically replaces the overlay. Public CLI `update` and `reset` commands commit
+their change immediately. The settings controller uses internal staged commands
+to snapshot the prior overlay; if the new runtime fails its health-checked
+startup, it rolls back the binary and restores the previous service. Reset
+returns to the plugin-bundled binary. Update checks occur only after an explicit
+click.
 
 Existing Python-era `UNRAID_MCP_*` settings are translated at launch and surfaced
 through the new Rust settings UI. Saving a migrated field removes its old key.
+Live settings changes are transactional: if runraid rejects the health-checked
+restart, the previous env and service are restored automatically.
+The settings page also exposes `UNRAID_RMCP_ENABLED_TOOLS` and
+`UNRAID_RMCP_DISABLED_TOOLS` for granular action allow/deny policies; deny
+selectors win.
 
 ## Upgrading from the Python plugin
 
@@ -53,17 +69,19 @@ through the new Rust settings UI. Saving a migrated field removes its old key.
 cd unraid-rs
 cargo build --release --locked --target x86_64-unknown-linux-gnu --bin runraid
 cd ../plugins/mcp
-./scripts/build-txz.sh 0.3.0 ../../unraid-rs/target/x86_64-unknown-linux-gnu/release/runraid
+./scripts/build-txz.sh 0.4.1 ../../unraid-rs/target/x86_64-unknown-linux-gnu/release/runraid
 ```
 
 The builder verifies `runraid --version`, builds the web bundle, creates a
 deterministic root-owned archive, checks the generated manifest, confirms the
-embedded x86-64 ELF binary, and rejects any retired Python runtime tree.
+embedded x86-64 ELF binary, rejects any retired Python runtime tree, and rejects
+binaries requiring newer than glibc 2.40 (the library shipped by the minimum
+supported Unraid 7.0.0).
 
 ## Release and Community Applications
 
 The `rust-release` workflow builds the binary and plugin from the same
-`unraid-rs-vX.Y.Z` source. It attaches the versioned `.txz` and `.plg` to that
+`unraid-rs-vX.Y.Z` source using the repository-pinned Rust 1.97.1 toolchain. It attaches the versioned `.txz` and `.plg` to that
 release and refreshes the rolling `unraid-plugin-latest` release asset consumed
 by Community Applications. The package manifest itself points back to the
 versioned Rust release, so installs remain immutable and checksum-pinned.

--- a/plugins/mcp/scripts/build-txz.sh
+++ b/plugins/mcp/scripts/build-txz.sh
@@ -82,6 +82,7 @@ EOF
 find "${STAGE}" -type d -exec chmod 755 {} +
 chmod +x "${STAGE}/usr/local/emhttp/plugins/unraid-mcp/scripts/"* \
          "${STAGE}/usr/local/emhttp/plugins/unraid-mcp/event/"* \
+         "${STAGE}/usr/local/emhttp/plugins/unraid-mcp/nchan/"* \
          "${STAGE}/usr/local/unraid-mcp/bin/runraid"
 
 echo "==> [3/3] assembling ${PKG_NAME}"

--- a/plugins/mcp/scripts/verify-package.sh
+++ b/plugins/mcp/scripts/verify-package.sh
@@ -49,6 +49,10 @@ if grep -Eq '(^/|(^|/)\.\.(/|$))' "$list"; then
   echo "package contains an absolute or traversal path" >&2
   exit 1
 fi
+if tar -tvJf "$archive" | awk '$1 ~ /^[lh]/ { print $NF; found=1 } END { exit !found }' | grep -q .; then
+  echo "package contains a symbolic or hard link; links are forbidden in the root-owned payload" >&2
+  exit 1
+fi
 tar -xJf "$archive" -C "$tree"
 
 bad_owner="$(tar --numeric-owner -tvJf "$archive" | awk '$2 != "0/0" { print $NF; exit }')"
@@ -66,15 +70,17 @@ required=(
   usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
   usr/local/emhttp/plugins/unraid-mcp/event/disks_mounted
   usr/local/emhttp/plugins/unraid-mcp/event/unmounting_disks
+  usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp
   usr/local/emhttp/plugins/unraid-mcp/web/unraid-mcp-settings.js
   usr/local/emhttp/plugins/unraid-mcp/web/unraid-mcp-settings.css
+  usr/local/emhttp/plugins/unraid-mcp/web/unraid-mcp-widget.js
   usr/local/emhttp/plugins/unraid-mcp/unraid-mcp.png
   usr/local/unraid-mcp/bin/runraid
 )
 for path in "${required[@]}"; do
   grep -Fxq "$path" "$list" || { echo "package missing required member: $path" >&2; exit 1; }
 done
-for path in usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh usr/local/emhttp/plugins/unraid-mcp/event/disks_mounted usr/local/emhttp/plugins/unraid-mcp/event/unmounting_disks usr/local/unraid-mcp/bin/runraid; do
+for path in usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh usr/local/emhttp/plugins/unraid-mcp/event/disks_mounted usr/local/emhttp/plugins/unraid-mcp/event/unmounting_disks usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp usr/local/unraid-mcp/bin/runraid; do
   [[ -x "$tree/$path" ]] || { echo "required package executable lacks execute mode: $path" >&2; exit 1; }
 done
 
@@ -92,9 +98,22 @@ file "$binary" | grep -Eq 'ELF 64-bit.*x86-64' || { echo "runraid is not an x86-
 actual_version="$("$binary" --version)"
 [[ "$actual_version" == "unraid-rmcp $rust_version" ]] || { echo "bundled runraid version differs: $actual_version != unraid-rmcp $rust_version" >&2; exit 1; }
 
+# Unraid 7.0.0 (the manifest minimum) ships glibc 2.40. Reject a binary that
+# imports a newer symbol version, otherwise installation succeeds but the
+# service fails immediately with an opaque loader error on supported systems.
+command -v objdump >/dev/null 2>&1 || { echo "objdump is required to verify glibc compatibility" >&2; exit 1; }
+max_glibc="$(objdump -T "$binary" | sed -n 's/.*(GLIBC_\([0-9][0-9.]*\)).*/\1/p' | sort -V | tail -n1)"
+[[ -n "$max_glibc" ]] || { echo "could not determine runraid glibc requirements" >&2; exit 1; }
+min_unraid_glibc="2.40"
+if [[ "$(printf '%s\n%s\n' "$max_glibc" "$min_unraid_glibc" | sort -V | tail -n1)" != "$min_unraid_glibc" ]]; then
+  echo "runraid requires glibc $max_glibc, newer than Unraid 7.0.0 glibc $min_unraid_glibc" >&2
+  exit 1
+fi
+
 echo "Unraid MCP package verification passed"
 echo "version=$version"
 echo "runraid=$rust_version"
+echo "glibc_required=$max_glibc"
 echo "package=$archive"
 echo "md5=$md5"
 echo "sha256=$sha256"

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/UnraidMCP.page
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/UnraidMCP.page
@@ -24,7 +24,7 @@ if ($mcp_csrf === '') {
 $mcp_web = '/usr/local/emhttp/plugins/unraid-mcp/web';
 $mcp_v = @filemtime("$mcp_web/unraid-mcp-settings.js") ?: '0';
 ?>
-<script>window.csrf_token = "<?= htmlspecialchars($mcp_csrf, ENT_QUOTES) ?>";</script>
+<script>window.csrf_token = <?= json_encode((string) $mcp_csrf, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;</script>
 <link rel="stylesheet" href="/plugins/unraid-mcp/web/unraid-mcp-settings.css?v=<?= $mcp_v ?>">
 <unraid-mcp-settings-app></unraid-mcp-settings-app>
 <script type="module" src="/plugins/unraid-mcp/web/unraid-mcp-settings.js?v=<?= $mcp_v ?>"></script>

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php
@@ -15,6 +15,9 @@
  */
 
 header('Content-Type: application/json');
+header('Cache-Control: no-store, max-age=0');
+header('Pragma: no-cache');
+header('X-Content-Type-Options: nosniff');
 
 const CFG_DIR = '/boot/config/plugins/unraid-mcp';
 const ENV_FILE = CFG_DIR . '/.env';
@@ -35,6 +38,14 @@ const SECRET_KEYS = [
     'UNRAID_MCP_GOOGLE_ENCRYPTION_KEY',
 ];
 
+/** Secrets the settings UI legitimately needs to copy or inspect. Legacy JWT
+ * and encryption keys remain hidden but can never be returned to the browser. */
+const REVEALABLE_SECRET_KEYS = [
+    'UNRAID_API_KEY',
+    'UNRAID_RMCP_TOKEN',
+    'UNRAID_RMCP_GOOGLE_CLIENT_SECRET',
+];
+
 /** Keys the Rust settings UI may persist. Must match web/src/fields.ts. */
 const ALLOWED_KEYS = [
     'UNRAID_API_URL',
@@ -49,6 +60,8 @@ const ALLOWED_KEYS = [
     'UNRAID_NOAUTH',
     'UNRAID_RMCP_ALLOWED_HOSTS',
     'UNRAID_RMCP_ALLOWED_ORIGINS',
+    'UNRAID_RMCP_ENABLED_TOOLS',
+    'UNRAID_RMCP_DISABLED_TOOLS',
     'UNRAID_RMCP_AUTH_MODE',
     'UNRAID_RMCP_PUBLIC_URL',
     'UNRAID_RMCP_GOOGLE_CLIENT_ID',
@@ -95,9 +108,22 @@ function read_env(string $path): array
         }
         [$k, $v] = explode('=', $line, 2);
         $k = trim($k);
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $k) !== 1) {
+            continue; // never preserve a line that could become shell syntax
+        }
         $v = trim($v);
-        if (strlen($v) >= 2 && ($v[0] === '"' || $v[0] === "'") && str_ends_with($v, $v[0])) {
+        if (strlen($v) >= 2 && $v[0] === "'" && str_ends_with($v, "'")) {
             $v = substr($v, 1, -1);
+            // Reverse write_env()'s POSIX-shell single-quote encoding:
+            // foo'bar is serialized as 'foo'\''bar'.
+            $v = str_replace("'\\''", "'", $v);
+        } elseif (strlen($v) >= 2 && $v[0] === '"' && str_ends_with($v, '"')) {
+            $v = substr($v, 1, -1);
+            $v = str_replace('\\"', '"', $v);
+            $v = str_replace('\\\\', '\\', $v);
+        }
+        if (preg_match('/[\x00\r\n]/', $v) === 1) {
+            continue;
         }
         $out[$k] = $v;
     }
@@ -110,6 +136,12 @@ function write_env(string $path, array $env): void
     $lines = ["# unraid-mcp configuration — managed by the plugin settings page.",
               "# Manual edits are preserved for keys the UI does not manage."];
     foreach ($env as $k => $v) {
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', (string) $k) !== 1) {
+            fail(500, 'refusing invalid config key');
+        }
+        if (preg_match('/[\x00\r\n]/', (string) $v) === 1) {
+            fail(500, 'refusing config value with NUL or line break');
+        }
         $lines[] = $k . "='" . str_replace("'", "'\\''", (string) $v) . "'";
     }
     $tmp = $path . '.tmp';
@@ -134,6 +166,201 @@ function write_env(string $path, array $env): void
     @chmod($path, 0600);
 }
 
+function command_result(string $command): array
+{
+    $out = [];
+    $code = 0;
+    exec($command . ' 2>&1', $out, $code);
+    return [$code, trim(implode(PHP_EOL, array_slice($out, -8)))];
+}
+
+function rc_result(string $op): array
+{
+    return command_result(escapeshellarg(RC) . ' ' . escapeshellarg($op));
+}
+
+function require_rc(string $op): void
+{
+    [$code, $output] = rc_result($op);
+    if ($code !== 0) {
+        fail(500, "service $op failed" . ($output !== '' ? ": $output" : ''));
+    }
+}
+
+function write_service_state(bool $enabled): void
+{
+    $tmp = CFG_FILE . '.tmp';
+    if (is_link($tmp)) {
+        @unlink($tmp);
+    }
+    $old = umask(0077);
+    $ok = @file_put_contents($tmp, 'SERVICE="' . ($enabled ? 'enabled' : 'disabled') . '"' . PHP_EOL);
+    umask($old);
+    if ($ok === false || !@rename($tmp, CFG_FILE)) {
+        @unlink($tmp);
+        fail(500, 'failed to persist service state');
+    }
+    @chmod(CFG_FILE, 0600);
+}
+
+function process_is_runraid_server(int $pid): bool
+{
+    if ($pid <= 0 || !is_dir("/proc/$pid")) {
+        return false;
+    }
+    $cmdline = @file_get_contents("/proc/$pid/cmdline");
+    if ($cmdline === false) {
+        return false;
+    }
+    $args = explode(chr(0), rtrim($cmdline, chr(0)));
+    foreach ($args as $index => $arg) {
+        if (basename($arg) === 'runraid' && ($args[$index + 1] ?? '') === 'serve') {
+            return true;
+        }
+    }
+    return false;
+}
+
+function is_true_value(string $value): bool
+{
+    return in_array(strtolower($value), ['1', 'true', 'yes'], true);
+}
+
+function validate_bool_value(array $env, string $key): void
+{
+    $value = resolve_value($env, $key);
+    if ($value !== '' && !in_array(strtolower($value), ['1', '0', 'true', 'false', 'yes', 'no'], true)) {
+        fail(400, "$key must be true or false");
+    }
+}
+
+function validate_url_value(string $key, string $value, bool $httpsOnly = false): void
+{
+    if ($value === '') {
+        return;
+    }
+    $parts = parse_url($value);
+    if ($parts === false || !isset($parts['host'])) {
+        fail(400, "$key must be a complete http:// or https:// URL");
+    }
+    $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+    if (!in_array($scheme, ['http', 'https'], true)) {
+        fail(400, "$key must be a complete http:// or https:// URL");
+    }
+    if (isset($parts['user']) || isset($parts['pass'])) {
+        fail(400, "$key must not contain embedded credentials");
+    }
+    if ($httpsOnly && $scheme !== 'https') {
+        fail(400, "$key must use https://");
+    }
+    if ($httpsOnly && (isset($parts['query']) || isset($parts['fragment']))) {
+        fail(400, "$key must not contain a query string or fragment");
+    }
+}
+
+function is_valid_bind_host(string $host): bool
+{
+    $value = trim($host, '[]');
+    if (filter_var($value, FILTER_VALIDATE_IP) !== false) {
+        return true;
+    }
+    if (preg_match('/^[0-9]+(?:\.[0-9]+){3}$/', $value) === 1) {
+        return false;
+    }
+    if (strlen($value) > 253 || str_ends_with($value, '.')) {
+        $value = rtrim($value, '.');
+    }
+    if ($value === '' || strlen($value) > 253) {
+        return false;
+    }
+    foreach (explode('.', $value) as $label) {
+        if ($label === '' || strlen($label) > 63
+            || preg_match('/^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/', $label) !== 1) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function is_loopback_host(string $host): bool
+{
+    $host = trim($host, '[]');
+    return strcasecmp($host, 'localhost') === 0
+        || $host === '::1'
+        || (str_starts_with($host, '127.') && filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false);
+}
+
+function validate_env(array $env): void
+{
+    $apiUrl = resolve_value($env, 'UNRAID_API_URL');
+    if ($apiUrl === '') {
+        fail(400, 'UNRAID_API_URL is required');
+    }
+    validate_url_value('UNRAID_API_URL', $apiUrl);
+
+    $host = resolve_value($env, 'UNRAID_RMCP_HOST') ?: '0.0.0.0';
+    if (strpbrk($host, " \t\r\n/") !== false || !is_valid_bind_host($host)) {
+        fail(400, 'UNRAID_RMCP_HOST must be a valid IP address or hostname without a path');
+    }
+
+    $port = resolve_value($env, 'UNRAID_RMCP_PORT') ?: '40010';
+    if (!ctype_digit($port) || (int) $port < 1 || (int) $port > 65535) {
+        fail(400, 'UNRAID_RMCP_PORT must be an integer from 1 to 65535');
+    }
+
+    foreach (['UNRAID_API_SKIP_TLS_VERIFY', 'UNRAID_MCP_TAILSCALE_SERVE', 'UNRAID_RMCP_DISABLE_HTTP_AUTH', 'UNRAID_NOAUTH'] as $key) {
+        validate_bool_value($env, $key);
+    }
+
+    $logLevel = strtolower(resolve_value($env, 'RUST_LOG'));
+    if ($logLevel !== '' && !in_array($logLevel, ['trace', 'debug', 'info', 'warn', 'error'], true)) {
+        fail(400, 'RUST_LOG must be trace, debug, info, warn, or error');
+    }
+
+    $authMode = strtolower(resolve_value($env, 'UNRAID_RMCP_AUTH_MODE') ?: 'bearer');
+    if (!in_array($authMode, ['bearer', 'oauth'], true)) {
+        fail(400, 'UNRAID_RMCP_AUTH_MODE must be bearer or oauth');
+    }
+
+    $authDisabled = is_true_value(resolve_value($env, 'UNRAID_RMCP_DISABLE_HTTP_AUTH'));
+    $networkOverride = is_true_value(resolve_value($env, 'UNRAID_NOAUTH'));
+    if ($authDisabled && !is_loopback_host($host) && !$networkOverride) {
+        fail(400, 'Disabling HTTP auth on a non-loopback bind also requires UNRAID_NOAUTH=true');
+    }
+
+    if (!$authDisabled && $authMode === 'bearer' && resolve_value($env, 'UNRAID_RMCP_TOKEN') === '') {
+        fail(400, 'UNRAID_RMCP_TOKEN is required in bearer mode');
+    }
+
+    if (!$authDisabled && $authMode === 'oauth') {
+        validate_url_value('UNRAID_RMCP_PUBLIC_URL', resolve_value($env, 'UNRAID_RMCP_PUBLIC_URL'), true);
+        foreach (['UNRAID_RMCP_PUBLIC_URL', 'UNRAID_RMCP_GOOGLE_CLIENT_ID', 'UNRAID_RMCP_GOOGLE_CLIENT_SECRET', 'UNRAID_RMCP_AUTH_ADMIN_EMAIL'] as $key) {
+            if (resolve_value($env, $key) === '') {
+                fail(400, "$key is required in OAuth mode");
+            }
+        }
+        $email = resolve_value($env, 'UNRAID_RMCP_AUTH_ADMIN_EMAIL');
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            fail(400, 'UNRAID_RMCP_AUTH_ADMIN_EMAIL must be a valid email address');
+        }
+    }
+
+    foreach (['UNRAID_RMCP_ENABLED_TOOLS', 'UNRAID_RMCP_DISABLED_TOOLS'] as $key) {
+        $value = resolve_value($env, $key);
+        if ($value !== '' && count(array_filter(array_map('trim', explode(',', $value)))) === 0) {
+            fail(400, "$key must contain at least one selector when set");
+        }
+    }
+}
+
+function validate_startable_env(array $env): void
+{
+    validate_env($env);
+    if (resolve_value($env, 'UNRAID_API_KEY') === '') {
+        fail(400, 'UNRAID_API_KEY is required before the service can start');
+    }
+}
+
 function service_running(): bool
 {
     exec(RC . ' status 2>/dev/null', $out, $code);
@@ -155,7 +382,9 @@ function tailscale_info(): array
     $env = read_env(ENV_FILE);
     $port = (int) (resolve_value($env, 'UNRAID_RMCP_PORT') ?: 40010);
     exec($bin . ' serve status 2>/dev/null', $serveOut, $serveCode);
-    $serveActive = $serveCode === 0 && str_contains(implode("\n", $serveOut), ':' . $port);
+    $serveText = implode("\n", $serveOut);
+    $serveActive = $serveCode === 0
+        && preg_match('/:' . preg_quote((string) $port, '/') . '(?:[^0-9]|$)/', $serveText) === 1;
     // serveActive is a heuristic; the rc script owns the authoritative state.
     return ['available' => $dns !== '', 'dnsName' => $dns, 'serveActive' => $serveActive];
 }
@@ -163,10 +392,10 @@ function tailscale_info(): array
 function process_stats(): array
 {
     $pid = (int) @trim((string) @file_get_contents(PID_FILE));
-    if ($pid <= 0 || !is_dir("/proc/$pid")) {
+    if (!process_is_runraid_server($pid)) {
         return ['pid' => 0, 'cpu' => 0.0, 'memMB' => 0.0, 'uptime' => 0];
     }
-    // Sum the process group (parent + worker threads/children share the tree).
+    // Read the server process identified by the validated PID file.
     $out = [];
     exec('ps -o %cpu=,rss=,etimes= -p ' . $pid . ' 2>/dev/null', $out);
     $cpu = 0.0;
@@ -206,13 +435,16 @@ function current_payload(): array
         if ($key === 'UNRAID_NOAUTH' && !array_key_exists('UNRAID_NOAUTH', $env)) {
             // Mirror unraid-mcp-env.sh: legacy TRUST_PROXY only implies no-auth
             // when the legacy disable-http-auth switch is actually on.
-            if (resolve_value($env, 'UNRAID_RMCP_DISABLE_HTTP_AUTH') !== 'true') {
+            if (!is_true_value(resolve_value($env, 'UNRAID_RMCP_DISABLE_HTTP_AUTH'))) {
                 $value = '';
             }
         }
         if ($key === 'UNRAID_API_SKIP_TLS_VERIFY' && $value === '') {
-            $value = (($env['UNRAID_VERIFY_SSL'] ?? 'true') === 'false'
-                && ($env['UNRAID_ALLOW_INSECURE_TLS'] ?? 'false') === 'true') ? 'true' : 'false';
+            $value = (!is_true_value($env['UNRAID_VERIFY_SSL'] ?? 'true')
+                && is_true_value($env['UNRAID_ALLOW_INSECURE_TLS'] ?? 'false')) ? 'true' : 'false';
+        }
+        if (in_array($key, ['UNRAID_API_SKIP_TLS_VERIFY', 'UNRAID_MCP_TAILSCALE_SERVE', 'UNRAID_RMCP_DISABLE_HTTP_AUTH', 'UNRAID_NOAUTH'], true)) {
+            $value = is_true_value($value) ? 'true' : 'false';
         }
         if ($key === 'UNRAID_RMCP_AUTH_MODE' && $value === '') {
             $value = 'bearer';
@@ -238,7 +470,8 @@ function current_payload(): array
         if (!in_array($k, ALLOWED_KEYS, true)
             && !in_array($k, SECRET_KEYS, true)
             && !in_array($k, $legacyKeys, true)
-            && !in_array($k, ['UNRAID_VERIFY_SSL', 'UNRAID_ALLOW_INSECURE_TLS'], true)) {
+            && !in_array($k, ['UNRAID_VERIFY_SSL', 'UNRAID_ALLOW_INSECURE_TLS'], true)
+            && preg_match('/(?:KEY|TOKEN|SECRET)/i', $k) !== 1) {
             $extra[$k] = $v;
         }
     }
@@ -253,6 +486,10 @@ function current_payload(): array
         'version' => version_info(),
         'process' => process_stats(),
     ];
+}
+
+if (defined('UNRAID_MCP_CONFIG_LIBRARY_ONLY') && UNRAID_MCP_CONFIG_LIBRARY_ONLY === true) {
+    return;
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
@@ -278,8 +515,8 @@ if ($action === 'reveal') {
     // Return a stored secret to the (already session+CSRF authenticated)
     // webGUI admin — the bearer token exists to be copied into MCP clients.
     $key = $body['key'] ?? '';
-    if (!in_array($key, SECRET_KEYS, true)) {
-        fail(400, 'not a secret key');
+    if (!in_array($key, REVEALABLE_SECRET_KEYS, true)) {
+        fail(400, 'secret is not revealable');
     }
     $env = read_env(ENV_FILE);
     echo json_encode(['key' => $key, 'value' => resolve_value($env, $key)]);
@@ -300,9 +537,12 @@ if ($action === 'stats') {
 }
 
 if ($action === 'checkUpdate') {
-    // Contacts GitHub — kept behind an explicit user click, not in every GET.
-    $latest = trim((string) @shell_exec(escapeshellarg(UPDATE_SH) . ' latest 2>/dev/null'));
-    echo json_encode(['latest' => $latest]);
+    // Contacts GitHub only after an explicit user click.
+    [$code, $latest] = command_result(escapeshellarg(UPDATE_SH) . ' latest');
+    if ($code !== 0 || $latest === '') {
+        fail(502, 'update check failed' . ($latest !== '' ? ': ' . $latest : ''));
+    }
+    echo json_encode(['latest' => trim($latest)]);
     exit;
 }
 
@@ -312,23 +552,60 @@ if ($action === 'update' || $action === 'resetVersion') {
         if ($ver !== '' && !preg_match('/^(?:unraid-rs-v|v)?\\d+\\.\\d+\\.\\d+$/', $ver)) {
             fail(400, 'invalid version');
         }
-        $cmd = escapeshellarg(UPDATE_SH) . ' update ' . escapeshellarg($ver);
+        $cmd = escapeshellarg(UPDATE_SH) . ' stage-update ' . escapeshellarg($ver);
     } else {
-        $cmd = escapeshellarg(UPDATE_SH) . ' reset';
+        $cmd = escapeshellarg(UPDATE_SH) . ' stage-reset';
     }
     // Stop first so the active overlay binary is not replaced mid-process.
     $wasRunning = service_running();
     if ($wasRunning) {
-        exec(RC . ' stop >/dev/null 2>&1');
+        [$stopCode, $stopOutput] = rc_result('stop');
+        if ($stopCode !== 0) {
+            fail(500, 'could not stop the service before the version change' . ($stopOutput !== '' ? ': ' . $stopOutput : ''));
+        }
     }
-    $out = [];
-    $code = 0;
-    exec($cmd . ' 2>&1', $out, $code);
-    if ($wasRunning) {
-        exec(RC . ' start >/dev/null 2>&1');
-    }
+
+    $updateCommand = escapeshellarg(UPDATE_SH);
+    [$code, $output] = command_result($cmd);
     if ($code !== 0) {
-        fail(500, 'update failed: ' . trim(implode(' ', array_slice($out, -3))));
+        // A transaction may or may not have started before the updater failed.
+        // Rollback is best-effort here; "no previous transaction" simply means
+        // the original overlay was never touched.
+        command_result($updateCommand . ' rollback');
+        $restoreCode = 0;
+        $restoreOutput = '';
+        if ($wasRunning) {
+            [$restoreCode, $restoreOutput] = rc_result('start');
+        }
+        $message = 'version change failed' . ($output !== '' ? ': ' . $output : '');
+        if ($restoreCode !== 0) {
+            $message .= '; restoring the previous service also failed' . ($restoreOutput !== '' ? ': ' . $restoreOutput : '');
+        }
+        fail(500, $message);
+    }
+
+    if ($wasRunning) {
+        [$restartCode, $restartOutput] = rc_result('start');
+        if ($restartCode !== 0) {
+            [$rollbackCode, $rollbackOutput] = command_result($updateCommand . ' rollback');
+            $restoreCode = 1;
+            $restoreOutput = '';
+            if ($rollbackCode === 0) {
+                [$restoreCode, $restoreOutput] = rc_result('start');
+            }
+            $message = 'the new runtime failed to start and was rolled back' . ($restartOutput !== '' ? ': ' . $restartOutput : '');
+            if ($rollbackCode !== 0) {
+                $message .= '; runtime rollback also failed' . ($rollbackOutput !== '' ? ': ' . $rollbackOutput : '');
+            } elseif ($restoreCode !== 0) {
+                $message .= '; the previous service failed to restart' . ($restoreOutput !== '' ? ': ' . $restoreOutput : '');
+            }
+            fail(500, $message);
+        }
+    }
+
+    [$commitCode, $commitOutput] = command_result($updateCommand . ' commit');
+    if ($commitCode !== 0) {
+        fail(500, 'version changed successfully, but transaction cleanup failed' . ($commitOutput !== '' ? ': ' . $commitOutput : ''));
     }
     echo json_encode(current_payload());
     exit;
@@ -355,19 +632,25 @@ if ($action === 'logs') {
 
 if ($action === 'service') {
     // {action: "service", op: "start"|"stop"|"restart"|"enable"|"disable"}
-    $op = $body['op'] ?? '';
-    if (in_array($op, ['enable', 'disable'], true)) {
-        $enabled = $op === 'enable' ? 'enabled' : 'disabled';
-        @file_put_contents(CFG_FILE, "SERVICE=\"$enabled\"\n");
-        @chmod(CFG_FILE, 0600);
-        if ($op === 'enable' && !service_running()) {
-            exec(RC . ' start >/dev/null 2>&1');
+    $op = (string) ($body['op'] ?? '');
+    if ($op === 'enable') {
+        validate_startable_env(read_env(ENV_FILE));
+        write_service_state(true);
+        if (!service_running()) {
+            [$code, $output] = rc_result('start');
+            if ($code !== 0) {
+                write_service_state(false);
+                fail(500, 'service enable failed' . ($output !== '' ? ': ' . $output : ''));
+            }
         }
-        if ($op === 'disable' && service_running()) {
-            exec(RC . ' stop >/dev/null 2>&1');
-        }
-    } elseif (in_array($op, ['start', 'stop', 'restart'], true)) {
-        exec(RC . ' ' . $op . ' >/dev/null 2>&1');
+    } elseif ($op === 'disable') {
+        write_service_state(false);
+        require_rc('stop');
+    } elseif (in_array($op, ['start', 'restart'], true)) {
+        validate_startable_env(read_env(ENV_FILE));
+        require_rc($op);
+    } elseif ($op === 'stop') {
+        require_rc('stop');
     } else {
         fail(400, 'unknown service op');
     }
@@ -385,6 +668,7 @@ if (!is_array($changes)) {
 }
 
 $env = read_env(ENV_FILE);
+$previousEnv = $env;
 foreach ($changes as $key => $value) {
     if (!in_array($key, ALLOWED_KEYS, true)) {
         fail(400, "key not allowed: $key");
@@ -392,8 +676,8 @@ foreach ($changes as $key => $value) {
     if (!is_string($value)) {
         fail(400, "value for $key must be a string");
     }
-    if (preg_match('/[\r\n]/', $value)) {
-        fail(400, "value for $key must not contain newlines");
+    if (preg_match('/[\x00\r\n]/', $value)) {
+        fail(400, "value for $key must not contain NUL or line breaks");
     }
     $legacy = LEGACY_KEYS[$key] ?? '';
     if ($legacy !== '') {
@@ -408,9 +692,33 @@ foreach ($changes as $key => $value) {
         $env[$key] = $value;
     }
 }
+$wasRunning = service_running();
+if ($wasRunning) {
+    validate_startable_env($env);
+} else {
+    validate_env($env);
+}
 write_env(ENV_FILE, $env);
 
-if (service_running()) {
-    exec(RC . ' restart >/dev/null 2>&1');
+if ($wasRunning) {
+    [$restartCode, $restartOutput] = rc_result('restart');
+    if ($restartCode !== 0) {
+        // The new config was syntactically valid to the web layer but rejected
+        // by runraid or failed at runtime. Restore the exact prior env and bring
+        // the previous service back instead of persisting a broken deployment.
+        write_env(ENV_FILE, $previousEnv);
+        [$restoreCode, $restoreOutput] = rc_result('start');
+        $message = 'settings were rejected by the running service; the previous configuration was restored';
+        if ($restartOutput !== '') {
+            $message .= ': ' . $restartOutput;
+        }
+        if ($restoreCode !== 0) {
+            $message .= '; restoring the previous service also failed';
+            if ($restoreOutput !== '') {
+                $message .= ': ' . $restoreOutput;
+            }
+        }
+        fail(500, $message);
+    }
 }
 echo json_encode(current_payload());

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp
@@ -1,39 +1,57 @@
 #!/bin/bash
 # nchan publisher for the Unraid MCP dashboard widget.
 #
-# monitor_nchan discovers and runs this (it manages every
-# /usr/local/emhttp/*/nchan/* process) ONLY while the dashboard has a live
-# subscriber, pausing it otherwise. It publishes the server's status as JSON to
-# the "unraid_mcp" channel over nginx's local pub socket; buffer_length=1 means
-# a freshly-opened dashboard immediately receives the last status.
+# monitor_nchan runs this only while the dashboard has a subscriber. It publishes
+# the service status to nginx's local Nchan socket every three seconds.
 
 socket="/var/run/nginx.socket"
 chan="http://localhost/pub/unraid_mcp?buffer_length=1"
 pidfile="/var/run/unraid-mcp.pid"
 interval=3
+export LC_ALL=C
 
-# Escape for a JSON string: backslash, quote, and — per RFC 8259 §7 — strip any
-# control characters (a malformed version string must degrade to plain text, not
-# an invalid frame that wedges the widget).
-json_escape() { printf '%s' "$1" | tr -d '\000-\037' | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+json_escape() {
+    printf '%s' "$1" | tr -d '\000-\037' | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+pid_matches() {
+    local pid="$1"
+    [[ "${pid}" =~ ^[0-9]+$ ]] && [ -d "/proc/${pid}" ] || return 1
+    tr '\0' ' ' <"/proc/${pid}/cmdline" 2>/dev/null | grep -qE '(^|[ /])runraid +serve( |$)'
+}
+
+numeric_or_zero() {
+    if [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+        printf '%s' "$1"
+    else
+        printf '0'
+    fi
+}
 
 status_json() {
-    local pid running=false cpu=0 mem=0 uptime=0 version
-    pid="$(cat "$pidfile" 2>/dev/null)"
-    if [[ -n "$pid" && -d "/proc/$pid" ]]; then
+    local pid running=false cpu=0 rss=0 mem=0 uptime=0 version
+    pid="$(tr -dc '0-9' <"${pidfile}" 2>/dev/null)"
+    if pid_matches "${pid}"; then
         running=true
-        # %cpu, rss(KiB), elapsed seconds for the server process.
-        read -r cpu rss uptime < <(ps -o %cpu=,rss=,etimes= -p "$pid" 2>/dev/null | awk '{print $1, $2, $3}')
-        cpu="${cpu:-0}"
-        mem=$(( ${rss:-0} / 1024 ))
-        uptime="${uptime:-0}"
+        read -r cpu rss uptime < <(ps -o %cpu=,rss=,etimes= -p "${pid}" 2>/dev/null | awk 'NR == 1 {print $1, $2, $3}')
+        cpu="$(numeric_or_zero "${cpu:-0}")"
+        rss="$(numeric_or_zero "${rss:-0}")"
+        uptime="$(numeric_or_zero "${uptime:-0}")"
+        # RSS and elapsed time are integer fields; reject any unexpected decimal.
+        [[ "${rss}" =~ ^[0-9]+$ ]] || rss=0
+        [[ "${uptime}" =~ ^[0-9]+$ ]] || uptime=0
+        mem=$((rss / 1024))
+    else
+        pid=0
     fi
-    version="$(timeout 5 /usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh installed 2>/dev/null)"
+
+    version="$(timeout 5 /usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh installed 2>/dev/null || true)"
     printf '{"running":%s,"pid":%s,"cpu":%s,"memMB":%s,"uptime":%s,"version":"%s"}' \
-        "$running" "${pid:-0}" "${cpu:-0}" "${mem:-0}" "${uptime:-0}" "$(json_escape "${version:-unknown}")"
+        "${running}" "${pid}" "${cpu}" "${mem}" "${uptime}" \
+        "$(json_escape "${version:-unknown}")"
 }
 
 while :; do
-    curl -s --max-time 2 --unix-socket "$socket" --data-raw "$(status_json)" "$chan" >/dev/null 2>&1
-    sleep "$interval"
+    curl -s --max-time 2 --unix-socket "${socket}" --data-raw "$(status_json)" "${chan}" >/dev/null 2>&1
+    sleep "${interval}"
 done

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp
@@ -7,30 +7,65 @@ PLUGIN_NAME="unraid-mcp"
 EMHTTP_DIR="/usr/local/emhttp/plugins/${PLUGIN_NAME}"
 PREFIX="/usr/local/${PLUGIN_NAME}"
 BUNDLED_BIN="${PREFIX}/bin/runraid"
-OVERLAY_BIN="/mnt/user/appdata/unraid-mcp/bin/runraid"
+APPDATA_DIR="/mnt/user/appdata/unraid-mcp"
+OVERLAY_BIN="${APPDATA_DIR}/bin/runraid"
 PID_FILE="/var/run/${PLUGIN_NAME}.pid"
+TAILSCALE_PORT_FILE="/var/run/${PLUGIN_NAME}.tailscale-port"
 LOG_DIR="/var/log/${PLUGIN_NAME}"
 LOG_FILE="${LOG_DIR}/server.log"
 LOG_MAX_BYTES=$((5 * 1024 * 1024))
+TAILSCALE_BIN="/usr/local/sbin/tailscale"
 
 # shellcheck source=unraid-mcp-env.sh
 source "${EMHTTP_DIR}/scripts/unraid-mcp-env.sh"
 
 log() {
+    mkdir -p "${LOG_DIR}" 2>/dev/null || true
     echo "$(date '+%Y-%m-%d %H:%M:%S') rc.${PLUGIN_NAME}: $*" >>"${LOG_FILE}" 2>/dev/null
     echo "rc.${PLUGIN_NAME}: $*"
 }
 
+array_mounted() {
+    grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts
+}
+
+prepare_appdata() {
+    if ! array_mounted; then
+        log "FATAL: /mnt/user is not mounted; refusing to create appdata in the RAM rootfs"
+        return 1
+    fi
+    local path
+    for path in /mnt/user/appdata "${APPDATA_DIR}"; do
+        if [ -L "${path}" ]; then
+            log "FATAL: refusing symlinked appdata path ${path}"
+            return 1
+        fi
+    done
+    mkdir -p "${APPDATA_DIR}"
+    if [ ! -d "${APPDATA_DIR}" ] || [ -L "${APPDATA_DIR}" ]; then
+        log "FATAL: appdata directory is not a real directory: ${APPDATA_DIR}"
+        return 1
+    fi
+    chmod 700 "${APPDATA_DIR}" 2>/dev/null || true
+}
+
 pid_matches() {
     local pid="$1"
-    [ -n "$pid" ] && [ -d "/proc/${pid}" ] || return 1
-    # Require the `serve` subcommand: a bare `runraid` match would also hit an
-    # admin's interactive CLI session on a recycled PID and kill -9 it.
+    [ -n "${pid}" ] && [ -d "/proc/${pid}" ] || return 1
+    # Require the serve subcommand so PID recycling cannot target an interactive
+    # runraid CLI process.
     tr '\0' ' ' <"/proc/${pid}/cmdline" 2>/dev/null | grep -qE '(^|[ /])runraid +serve( |$)'
 }
 
+overlay_valid() {
+    [ -f "${OVERLAY_BIN}" ] \
+        && [ ! -L "${OVERLAY_BIN}" ] \
+        && [ -x "${OVERLAY_BIN}" ] \
+        && [ "$(stat -c %u "${OVERLAY_BIN}" 2>/dev/null)" = "0" ]
+}
+
 server_binary() {
-    if [ -x "${OVERLAY_BIN}" ]; then
+    if overlay_valid; then
         echo "${OVERLAY_BIN}"
     else
         echo "${BUNDLED_BIN}"
@@ -38,19 +73,51 @@ server_binary() {
 }
 
 plugin_port() {
-    # unraid-mcp-env.sh (sourced above) guarantees UNRAID_RMCP_PORT is set,
-    # including the legacy UNRAID_MCP_PORT fallback.
     echo "${UNRAID_RMCP_PORT}"
 }
 
-TAILSCALE_BIN="/usr/local/sbin/tailscale"
+health_url() {
+    local host="${UNRAID_RMCP_HOST:-0.0.0.0}"
+    case "${host}" in
+        ''|0.0.0.0) host="127.0.0.1" ;;
+        '::'|'[::]') host="[::1]" ;;
+        '['*']') ;;
+        *:*) host="[${host}]" ;;
+    esac
+    printf 'http://%s:%s/health\n' "${host}" "$(plugin_port)"
+}
+
+valid_port() {
+    [[ "$1" =~ ^[0-9]+$ ]] && [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+}
 
 serve_start() {
-    [ "${UNRAID_MCP_TAILSCALE_SERVE:-false}" = "true" ] || return 0
-    [ -x "$TAILSCALE_BIN" ] || { log "tailscale serve requested but tailscale CLI not found"; return 0; }
-    local port
+    if ! unraid_mcp_is_true "${UNRAID_MCP_TAILSCALE_SERVE:-false}"; then
+        [ ! -r "${TAILSCALE_PORT_FILE}" ] || serve_stop
+        return 0
+    fi
+    [ -x "${TAILSCALE_BIN}" ] || {
+        log "tailscale serve requested but tailscale CLI not found"
+        return 0
+    }
+
+    local port previous=""
     port="$(plugin_port)"
-    if "$TAILSCALE_BIN" serve --bg --https="$port" "http://127.0.0.1:${port}" >/dev/null 2>&1; then
+    if [ -r "${TAILSCALE_PORT_FILE}" ]; then
+        previous="$(tr -dc '0-9' <"${TAILSCALE_PORT_FILE}" 2>/dev/null)"
+    fi
+    if valid_port "${previous}" && [ "${previous}" != "${port}" ]; then
+        if "${TAILSCALE_BIN}" serve --https="${previous}" off >/dev/null 2>&1; then
+            rm -f "${TAILSCALE_PORT_FILE}"
+        else
+            log "tailscale serve cleanup failed for old https :${previous}; preserving its state for a later retry"
+            return 1
+        fi
+    fi
+
+    if "${TAILSCALE_BIN}" serve --bg --https="${port}" "http://127.0.0.1:${port}" >/dev/null 2>&1; then
+        umask 0077
+        printf '%s\n' "${port}" >"${TAILSCALE_PORT_FILE}"
         log "tailscale serve enabled: https :${port} -> 127.0.0.1:${port}"
     else
         log "tailscale serve setup failed (is HTTPS enabled for the tailnet?)"
@@ -58,10 +125,19 @@ serve_start() {
 }
 
 serve_stop() {
-    [ -x "$TAILSCALE_BIN" ] || return 0
-    local port
-    port="$(plugin_port)"
-    "$TAILSCALE_BIN" serve --https="$port" off >/dev/null 2>&1 || true
+    local port=""
+    if [ -r "${TAILSCALE_PORT_FILE}" ]; then
+        port="$(tr -dc '0-9' <"${TAILSCALE_PORT_FILE}" 2>/dev/null)"
+    fi
+    valid_port "${port}" || port="$(plugin_port)"
+
+    if [ -x "${TAILSCALE_BIN}" ]; then
+        if "${TAILSCALE_BIN}" serve --https="${port}" off >/dev/null 2>&1; then
+            rm -f "${TAILSCALE_PORT_FILE}"
+        else
+            log "tailscale serve cleanup failed for https :${port}; will retry on the next stop/start"
+        fi
+    fi
 }
 
 rotate_log() {
@@ -74,7 +150,26 @@ rotate_log() {
 is_running() {
     local pid
     pid="$(cat "${PID_FILE}" 2>/dev/null)"
-    pid_matches "$pid"
+    pid_matches "${pid}"
+}
+
+validate_required_config() {
+    if [ -z "${UNRAID_API_URL:-}" ]; then
+        log "FATAL: UNRAID_API_URL is not configured"
+        return 1
+    fi
+    if [ -z "${UNRAID_API_KEY:-}" ]; then
+        log "FATAL: UNRAID_API_KEY is not configured; create or paste an admin API key in Settings -> Unraid MCP"
+        return 1
+    fi
+}
+
+warn_legacy_oauth() {
+    if ! grep -q '^UNRAID_RMCP_AUTH_MODE=' "${UNRAID_MCP_ENV_FILE}" 2>/dev/null \
+        && [ -n "${UNRAID_MCP_GOOGLE_CLIENT_ID:-}" ] \
+        && [ -n "${UNRAID_MCP_GOOGLE_CLIENT_SECRET:-}" ]; then
+        log "WARNING: legacy OAuth credentials detected; set UNRAID_RMCP_AUTH_MODE=oauth and UNRAID_RMCP_AUTH_ADMIN_EMAIL to restore OAuth"
+    fi
 }
 
 start() {
@@ -82,46 +177,71 @@ start() {
         log "already running (pid $(cat "${PID_FILE}"))"
         return 0
     fi
-    local bin
+    validate_required_config || return 1
+    prepare_appdata || return 1
+    warn_legacy_oauth
+
+    if [ -e "${OVERLAY_BIN}" ] && ! overlay_valid; then
+        log "WARNING: ignoring unsafe overlay binary (must be a root-owned regular executable): ${OVERLAY_BIN}"
+    fi
+
+    local bin pid url
     bin="$(server_binary)"
-    if [ ! -x "$bin" ]; then
+    if [ ! -x "${bin}" ]; then
         log "FATAL: runraid binary missing at ${bin}"
         return 1
     fi
+
     rotate_log
-    log "starting $("$bin" --version 2>/dev/null || echo runraid)"
-    setsid "$bin" serve >>"${LOG_FILE}" 2>&1 &
-    local pid=$!
-    echo "$pid" >"${PID_FILE}"
-    for _ in $(seq 1 10); do
-        sleep 1
-        if ! pid_matches "$pid"; then
+    log "starting $("${bin}" --version 2>/dev/null || echo runraid)"
+    setsid "${bin}" serve >>"${LOG_FILE}" 2>&1 &
+    pid=$!
+    printf '%s\n' "${pid}" >"${PID_FILE}"
+    url="$(health_url)"
+
+    for _ in $(seq 1 30); do
+        if ! pid_matches "${pid}"; then
             log "FATAL: server exited during startup — check ${LOG_FILE}"
             rm -f "${PID_FILE}"
+            serve_stop
             return 1
         fi
+        if curl -fsS --noproxy '*' --max-time 2 "${url}" >/dev/null 2>&1; then
+            log "started (pid ${pid}, health ${url})"
+            serve_start
+            return 0
+        fi
+        sleep 1
     done
-    log "started (pid ${pid})"
-    serve_start
+
+    log "FATAL: server did not become healthy at ${url} within 30 seconds"
+    kill "${pid}" 2>/dev/null || true
+    sleep 1
+    pid_matches "${pid}" && kill -9 "${pid}" 2>/dev/null || true
+    rm -f "${PID_FILE}"
+    serve_stop
+    return 1
 }
 
 stop() {
     local pid
     pid="$(cat "${PID_FILE}" 2>/dev/null)"
-    if ! pid_matches "$pid"; then
+    if ! pid_matches "${pid}"; then
         log "not running"
         rm -f "${PID_FILE}"
+        serve_stop
         return 0
     fi
+
     log "stopping (pid ${pid})"
-    kill "$pid" 2>/dev/null
+    kill "${pid}" 2>/dev/null || true
     for _ in $(seq 1 15); do
-        pid_matches "$pid" || break
+        pid_matches "${pid}" || break
         sleep 1
     done
-    if pid_matches "$pid"; then
+    if pid_matches "${pid}"; then
         log "did not exit after 15s, sending SIGKILL"
-        kill -9 "$pid" 2>/dev/null
+        kill -9 "${pid}" 2>/dev/null || true
     fi
     rm -f "${PID_FILE}"
     serve_stop
@@ -140,7 +260,7 @@ status() {
 case "${1:-}" in
     start) start ;;
     stop) stop ;;
-    restart) stop; sleep 1; start ;;
+    restart) stop && sleep 1 && start ;;
     status) status ;;
     *) echo "usage: $0 start|stop|restart|status"; exit 1 ;;
 esac

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
@@ -2,22 +2,73 @@
 # Scoped runtime environment for the native runraid server. Sourced only by
 # rc.unraid-mcp so plugin settings never leak into login shells or other services.
 
-UNRAID_MCP_CONFIG_DIR="/boot/config/plugins/unraid-mcp"
-UNRAID_MCP_APPDATA_DIR="/mnt/user/appdata/unraid-mcp"
-UNRAID_MCP_ENV_FILE="${UNRAID_MCP_CONFIG_DIR}/.env"
+UNRAID_MCP_CONFIG_DIR="${UNRAID_MCP_CONFIG_DIR:-/boot/config/plugins/unraid-mcp}"
+UNRAID_MCP_APPDATA_DIR="${UNRAID_MCP_APPDATA_DIR:-/mnt/user/appdata/unraid-mcp}"
+UNRAID_MCP_ENV_FILE="${UNRAID_MCP_ENV_FILE:-${UNRAID_MCP_CONFIG_DIR}/.env}"
 
-mkdir -p "${UNRAID_MCP_APPDATA_DIR}"
-chmod 700 "${UNRAID_MCP_APPDATA_DIR}" 2>/dev/null || true
-export HOME="${UNRAID_MCP_APPDATA_DIR}"
+unraid_mcp_is_true() {
+    case "${1,,}" in
+        1|true|yes) return 0 ;;
+        *) return 1 ;;
+    esac
+}
 
-# The settings endpoint writes shell-safe, single-quoted assignments and rejects
-# newlines. Export them into runraid's process environment without exposing them
-# globally.
+unraid_mcp_is_false() {
+    case "${1,,}" in
+        0|false|no) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Do not create anything under /mnt/user while merely running status/stop. The
+# rc script prepares this directory only when starting with the array mounted.
+# runraid honors UNRAID_HOME as its exact data directory, avoiding the former
+# accidental /mnt/user/appdata/unraid-mcp/.unraid nesting.
+export UNRAID_HOME="${UNRAID_MCP_APPDATA_DIR}"
+
+# Load dotenv assignments as literal data. Never source the file: even a
+# root-owned config can be manually malformed, and command substitutions must
+# not become executable shell syntax. The parser supports the plugin writer's
+# POSIX single-quote encoding plus simple legacy quoted/unquoted values.
+unraid_mcp_trim() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s' "${value}"
+}
+
+unraid_mcp_load_env() {
+    local file="$1" line key raw value
+    while IFS= read -r line || [ -n "${line}" ]; do
+        line="${line%$'\r'}"
+        line="$(unraid_mcp_trim "${line}")"
+        [ -n "${line}" ] || continue
+        [[ "${line}" == \#* ]] && continue
+        if [[ "${line}" != *=* ]]; then
+            echo "unraid-mcp: ignoring malformed env line without =" >&2
+            continue
+        fi
+        key="$(unraid_mcp_trim "${line%%=*}")"
+        raw="$(unraid_mcp_trim "${line#*=}")"
+        if [[ ! "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            echo "unraid-mcp: ignoring invalid env key ${key}" >&2
+            continue
+        fi
+
+        value="${raw}"
+        if [ "${#raw}" -ge 2 ] && [ "${raw:0:1}" = "'" ] && [ "${raw: -1}" = "'" ]; then
+            value="${raw:1:${#raw}-2}"
+            value="$(printf '%s' "${value}" | sed "s/'\\\\''/'/g")"
+        elif [ "${#raw}" -ge 2 ] && [ "${raw:0:1}" = '"' ] && [ "${raw: -1}" = '"' ]; then
+            value="${raw:1:${#raw}-2}"
+            value="$(printf '%s' "${value}" | sed 's/\\"/"/g; s/\\\\/\\/g')"
+        fi
+        export "${key}=${value}"
+    done <"${file}"
+}
+
 if [ -r "${UNRAID_MCP_ENV_FILE}" ]; then
-    set -a
-    # shellcheck source=/dev/null
-    source "${UNRAID_MCP_ENV_FILE}"
-    set +a
+    unraid_mcp_load_env "${UNRAID_MCP_ENV_FILE}"
 fi
 
 # Preserve existing installations while the settings page migrates from the
@@ -33,35 +84,23 @@ fi
 export UNRAID_RMCP_HOST UNRAID_RMCP_PORT UNRAID_RMCP_TOKEN UNRAID_RMCP_DISABLE_HTTP_AUTH
 export UNRAID_RMCP_PUBLIC_URL UNRAID_RMCP_GOOGLE_CLIENT_ID UNRAID_RMCP_GOOGLE_CLIENT_SECRET
 
-# A legacy Python-era install with Google OAuth credentials auto-enabled OAuth;
-# runraid needs an explicit UNRAID_RMCP_AUTH_MODE=oauth plus an admin email
-# (which has no legacy source), so we can only warn loudly — never auto-switch,
-# since a missing admin email would crash startup.
-if [ -z "${UNRAID_RMCP_AUTH_MODE:-}" ] \
-    && [ -n "${UNRAID_MCP_GOOGLE_CLIENT_ID:-}" ] \
-    && [ -n "${UNRAID_MCP_GOOGLE_CLIENT_SECRET:-}" ]; then
-    unraid_mcp_oauth_warn="unraid-mcp: WARNING: OAuth credentials detected but auth mode defaulting to bearer; set UNRAID_RMCP_AUTH_MODE=oauth and UNRAID_RMCP_AUTH_ADMIN_EMAIL to restore OAuth"
-    echo "${unraid_mcp_oauth_warn}" >&2
-    mkdir -p /var/log/unraid-mcp 2>/dev/null || true
-    # stderr first so a failed append-open is silenced too (best effort only).
-    echo "$(date '+%Y-%m-%d %H:%M:%S') ${unraid_mcp_oauth_warn}" 2>/dev/null >>/var/log/unraid-mcp/server.log || true
-    unset unraid_mcp_oauth_warn
-fi
-
+# A legacy Python-era install may contain Google credentials but no Rust auth
+# mode/admin email. Default safely to bearer; rc.unraid-mcp emits one warning
+# only when the operator actually starts the service.
 : "${UNRAID_RMCP_AUTH_MODE:=bearer}"
 export UNRAID_RMCP_AUTH_MODE
 
 # Translate the former two-switch TLS guard into runraid's explicit skip flag.
 if [ -z "${UNRAID_API_SKIP_TLS_VERIFY:-}" ] \
-    && [ "${UNRAID_VERIFY_SSL:-true}" = "false" ] \
-    && [ "${UNRAID_ALLOW_INSECURE_TLS:-false}" = "true" ]; then
+    && unraid_mcp_is_false "${UNRAID_VERIFY_SSL:-true}" \
+    && unraid_mcp_is_true "${UNRAID_ALLOW_INSECURE_TLS:-false}"; then
     export UNRAID_API_SKIP_TLS_VERIFY="true"
 fi
 
 # A legacy trusted-proxy opt-in is the equivalent explicit acknowledgement
 # required by runraid before allowing no-auth on a non-loopback bind.
-if [ "${UNRAID_RMCP_DISABLE_HTTP_AUTH}" = "true" ] \
-    && [ "${UNRAID_MCP_TRUST_PROXY:-false}" = "true" ] \
+if unraid_mcp_is_true "${UNRAID_RMCP_DISABLE_HTTP_AUTH}" \
+    && unraid_mcp_is_true "${UNRAID_MCP_TRUST_PROXY:-false}" \
     && [ -z "${UNRAID_NOAUTH:-}" ]; then
     export UNRAID_NOAUTH="true"
 fi

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
@@ -3,34 +3,97 @@
 #
 # The plugin ships /usr/local/unraid-mcp/bin/runraid in the RAM rootfs. This
 # script maintains a persistent, checksum-verified binary overlay on the array;
-# rc.unraid-mcp prefers the overlay when present.
+# rc.unraid-mcp prefers the overlay when it is a safe root-owned regular file.
 #
 #   unraid-mcp-update.sh installed    -> print the active version
 #   unraid-mcp-update.sh latest       -> print the latest unraid-rs-vX.Y.Z tag
 #   unraid-mcp-update.sh update [ver] -> install a release (default: latest)
 #   unraid-mcp-update.sh reset        -> remove the overlay (revert to bundled)
 #   unraid-mcp-update.sh which        -> print the active binary path
+#
+# stage-update/stage-reset/commit/rollback are internal transaction commands
+# used by the webGUI so a runtime that fails to start can be reverted.
 set -euo pipefail
 
 PREFIX="/usr/local/unraid-mcp"
 BUNDLED_BIN="${PREFIX}/bin/runraid"
-OVERLAY_DIR="/mnt/user/appdata/unraid-mcp/bin"
+APPDATA_DIR="/mnt/user/appdata/unraid-mcp"
+OVERLAY_DIR="${APPDATA_DIR}/bin"
 OVERLAY_BIN="${OVERLAY_DIR}/runraid"
+PREVIOUS_BIN="${OVERLAY_DIR}/runraid.previous"
+PREVIOUS_ABSENT="${OVERLAY_DIR}/runraid.previous.absent"
 REPO="dinglebear-ai/unraid"
 ASSET="runraid-linux-x86_64"
 
-active_binary() {
-    if [ -x "$OVERLAY_BIN" ]; then
-        echo "$OVERLAY_BIN"
+array_mounted() {
+    grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts
+}
+
+prepare_overlay_dir() {
+    if ! array_mounted; then
+        echo "error: /mnt/user is not mounted; refusing to write an overlay into the RAM rootfs" >&2
+        return 1
+    fi
+
+    local path
+    for path in /mnt/user/appdata "${APPDATA_DIR}" "${OVERLAY_DIR}"; do
+        if [ -L "${path}" ]; then
+            echo "error: refusing symlinked overlay path ${path}" >&2
+            return 1
+        fi
+    done
+
+    mkdir -p "${OVERLAY_DIR}"
+    for path in "${APPDATA_DIR}" "${OVERLAY_DIR}"; do
+        if [ ! -d "${path}" ] || [ -L "${path}" ]; then
+            echo "error: overlay path is not a real directory: ${path}" >&2
+            return 1
+        fi
+        chown 0:0 "${path}" 2>/dev/null || true
+        chmod 700 "${path}" 2>/dev/null || true
+    done
+}
+
+overlay_valid() {
+    [ -f "${OVERLAY_BIN}" ] \
+        && [ ! -L "${OVERLAY_BIN}" ] \
+        && [ -x "${OVERLAY_BIN}" ] \
+        && [ "$(stat -c %u "${OVERLAY_BIN}" 2>/dev/null)" = "0" ]
+}
+
+previous_binary_valid() {
+    [ -f "${PREVIOUS_BIN}" ] \
+        && [ ! -L "${PREVIOUS_BIN}" ] \
+        && [ "$(stat -c %u "${PREVIOUS_BIN}" 2>/dev/null)" = "0" ]
+}
+
+clear_previous() {
+    rm -f "${PREVIOUS_BIN}" "${PREVIOUS_ABSENT}"
+}
+
+snapshot_previous() {
+    clear_previous
+    if overlay_valid; then
+        install -o 0 -g 0 -m 0755 "${OVERLAY_BIN}" "${PREVIOUS_BIN}"
     else
-        echo "$BUNDLED_BIN"
+        umask 0077
+        : >"${PREVIOUS_ABSENT}"
+        chown 0:0 "${PREVIOUS_ABSENT}" 2>/dev/null || true
+    fi
+}
+
+active_binary() {
+    if overlay_valid; then
+        echo "${OVERLAY_BIN}"
+    else
+        echo "${BUNDLED_BIN}"
     fi
 }
 
 installed_version() {
     local line
     line="$("$(active_binary)" --version 2>/dev/null || true)"
-    case "$line" in
+    case "${line}" in
         "unraid-rmcp "*) echo "${line#unraid-rmcp }" ;;
         *) echo "unknown" ;;
     esac
@@ -50,11 +113,11 @@ normalize_target() {
     local target="$1"
     target="${target#unraid-rs-v}"
     target="${target#v}"
-    if [[ ! "$target" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    if [[ ! "${target}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         echo "error: refusing non-release version '$1'" >&2
         return 1
     fi
-    echo "$target"
+    echo "${target}"
 }
 
 # Returns success when $1 is strictly older than $2.
@@ -66,77 +129,113 @@ version_lt() {
 do_update() {
     local requested="${1:-}"
     local tag
-    if [ -z "$requested" ]; then
-        # `|| true` keeps set -e from killing the script inside the command
-        # substitution before the guard below can print an actionable error.
+    if [ -z "${requested}" ]; then
         tag="$(latest_tag)" || true
-        if [ -z "$tag" ]; then
+        if [ -z "${tag}" ]; then
             echo "error: could not resolve the latest unraid-rs release from the GitHub API" >&2
-            echo "       likely causes: no network/DNS on this box, a GitHub API outage, or API rate limiting" >&2
+            echo "       likely causes: no network/DNS, a GitHub outage, or API rate limiting" >&2
             exit 1
         fi
-    elif [[ "$requested" == unraid-rs-v* ]]; then
-        tag="$requested"
+    elif [[ "${requested}" == unraid-rs-v* ]]; then
+        tag="${requested}"
     else
-        tag="unraid-rs-v$(normalize_target "$requested")"
+        tag="unraid-rs-v$(normalize_target "${requested}")"
     fi
 
     local version
-    version="$(normalize_target "$tag")"
+    version="$(normalize_target "${tag}")"
     local current
     current="$(installed_version)"
-    if [ "$current" != "unknown" ] && version_lt "$version" "$current"; then
+    if [ "${current}" != "unknown" ] && version_lt "${version}" "${current}"; then
         echo "error: ${version} is older than installed ${current}; refusing to downgrade" >&2
         echo "run 'reset' to revert to the bundled version instead" >&2
         exit 1
     fi
 
+    prepare_overlay_dir
+
     local base="https://github.com/${REPO}/releases/download/${tag}"
-    local tmp_dir candidate checksum expected actual
-    mkdir -p "$OVERLAY_DIR"
-    chmod 700 "$(dirname "$OVERLAY_DIR")" "$OVERLAY_DIR" 2>/dev/null || true
+    local tmp_dir candidate checksum expected actual staged
     tmp_dir="$(mktemp -d "${OVERLAY_DIR}/.update.XXXXXX")"
     trap 'rm -rf "$tmp_dir"' EXIT
     candidate="${tmp_dir}/${ASSET}"
     checksum="${tmp_dir}/${ASSET}.sha256"
+    staged="${OVERLAY_DIR}/.runraid.new.$$"
 
-    curl -fL --retry 3 --retry-delay 2 -o "$candidate" "${base}/${ASSET}"
-    curl -fL --retry 3 --retry-delay 2 -o "$checksum" "${base}/${ASSET}.sha256"
-    expected="$(sed -n '1{s/[[:space:]].*//;p;}' "$checksum")"
-    actual="$(sha256sum "$candidate" | cut -d' ' -f1)"
-    if [[ ! "$expected" =~ ^[0-9a-f]{64}$ ]] || [ "$actual" != "$expected" ]; then
+    curl -fL --retry 3 --retry-delay 2 -o "${candidate}" "${base}/${ASSET}"
+    curl -fL --retry 3 --retry-delay 2 -o "${checksum}" "${base}/${ASSET}.sha256"
+    expected="$(sed -n '1{s/[[:space:]].*//;p;}' "${checksum}")"
+    actual="$(sha256sum "${candidate}" | cut -d' ' -f1)"
+    if [[ ! "${expected}" =~ ^[0-9a-f]{64}$ ]] || [ "${actual}" != "${expected}" ]; then
         echo "error: checksum verification failed for ${tag}/${ASSET}" >&2
         echo "expected: ${expected:-<missing>}" >&2
         echo "actual:   ${actual}" >&2
         exit 1
     fi
 
-    chmod 755 "$candidate"
+    chmod 755 "${candidate}"
     local got
-    got="$("$candidate" --version 2>/dev/null || true)"
-    if [ "$got" != "unraid-rmcp ${version}" ]; then
+    got="$("${candidate}" --version 2>/dev/null || true)"
+    if [ "${got}" != "unraid-rmcp ${version}" ]; then
         echo "error: downloaded binary reports '${got:-nothing}', expected 'unraid-rmcp ${version}'" >&2
         exit 1
     fi
 
-    mv -f "$candidate" "$OVERLAY_BIN"
-    chmod 755 "$OVERLAY_BIN"
-    rm -rf "$tmp_dir"
+    snapshot_previous
+    rm -f "${staged}"
+    install -o 0 -g 0 -m 0755 "${candidate}" "${staged}"
+    mv -f "${staged}" "${OVERLAY_BIN}"
+    rm -rf "${tmp_dir}"
     trap - EXIT
-    echo "$version"
+    echo "${version}"
 }
 
 do_reset() {
-    rm -f "$OVERLAY_BIN"
-    rmdir "$OVERLAY_DIR" 2>/dev/null || true
+    prepare_overlay_dir
+    snapshot_previous
+    rm -f "${OVERLAY_BIN}"
+    installed_version
+}
+
+do_commit() {
+    if ! array_mounted; then
+        echo "error: /mnt/user is not mounted; refusing to commit an overlay transaction" >&2
+        exit 1
+    fi
+    if [ -L "${APPDATA_DIR}" ] || [ -L "${OVERLAY_DIR}" ]; then
+        echo "error: refusing symlinked overlay directory" >&2
+        exit 1
+    fi
+    clear_previous
+    rmdir "${OVERLAY_DIR}" 2>/dev/null || true
+}
+
+do_rollback() {
+    prepare_overlay_dir
+    if previous_binary_valid; then
+        install -o 0 -g 0 -m 0755 "${PREVIOUS_BIN}" "${OVERLAY_BIN}"
+        clear_previous
+    elif [ -f "${PREVIOUS_ABSENT}" ] \
+        && [ ! -L "${PREVIOUS_ABSENT}" ] \
+        && [ "$(stat -c %u "${PREVIOUS_ABSENT}" 2>/dev/null)" = "0" ]; then
+        rm -f "${OVERLAY_BIN}"
+        clear_previous
+    else
+        echo "error: no valid previous overlay transaction is available" >&2
+        exit 1
+    fi
     installed_version
 }
 
 case "${1:-installed}" in
     installed) installed_version ;;
     latest) latest_tag ;;
-    update) do_update "${2:-}" ;;
-    reset) do_reset ;;
+    update) do_update "${2:-}"; do_commit ;;
+    reset) do_reset; do_commit ;;
+    stage-update) do_update "${2:-}" ;;
+    stage-reset) do_reset ;;
+    commit) do_commit ;;
+    rollback) do_rollback ;;
     which) active_binary ;;
     *) echo "usage: $0 installed|latest|update [version]|reset|which" >&2; exit 1 ;;
 esac

--- a/plugins/mcp/tests/config-endpoint.php
+++ b/plugins/mcp/tests/config-endpoint.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+define('UNRAID_MCP_CONFIG_LIBRARY_ONLY', true);
+require __DIR__ . '/../source/usr/local/emhttp/plugins/unraid-mcp/include/config.php';
+
+$case = $argv[1] ?? '';
+if ($case === 'unsafe-noauth') {
+    validate_env([
+        'UNRAID_API_URL' => 'http://127.0.0.1/graphql',
+        'UNRAID_RMCP_HOST' => '0.0.0.0',
+        'UNRAID_RMCP_PORT' => '40010',
+        'UNRAID_RMCP_AUTH_MODE' => 'bearer',
+        'UNRAID_RMCP_DISABLE_HTTP_AUTH' => 'true',
+        'UNRAID_NOAUTH' => 'false',
+    ]);
+    fwrite(STDERR, "unsafe no-auth configuration was accepted
+");
+    exit(1);
+}
+if ($case === 'missing-api-key') {
+    validate_startable_env([
+        'UNRAID_API_URL' => 'http://127.0.0.1/graphql',
+        'UNRAID_RMCP_HOST' => '127.0.0.1',
+        'UNRAID_RMCP_PORT' => '40010',
+        'UNRAID_RMCP_AUTH_MODE' => 'bearer',
+        'UNRAID_RMCP_TOKEN' => 'test-token',
+        'UNRAID_RMCP_DISABLE_HTTP_AUTH' => 'false',
+    ]);
+    fwrite(STDERR, "startable config accepted a missing API key" . PHP_EOL);
+    exit(1);
+}
+if ($case === 'incomplete-oauth') {
+    validate_env([
+        'UNRAID_API_URL' => 'http://127.0.0.1/graphql',
+        'UNRAID_RMCP_HOST' => '127.0.0.1',
+        'UNRAID_RMCP_PORT' => '40010',
+        'UNRAID_RMCP_AUTH_MODE' => 'oauth',
+        'UNRAID_RMCP_DISABLE_HTTP_AUTH' => 'false',
+        'UNRAID_NOAUTH' => 'false',
+        'UNRAID_RMCP_PUBLIC_URL' => 'http://mcp.example.com',
+    ]);
+    fwrite(STDERR, "incomplete OAuth configuration was accepted
+");
+    exit(1);
+}
+
+function expect_same(mixed $expected, mixed $actual, string $message): void
+{
+    if ($expected !== $actual) {
+        fwrite(STDERR, $message . PHP_EOL);
+        fwrite(STDERR, 'expected: ' . var_export($expected, true) . PHP_EOL);
+        fwrite(STDERR, 'actual:   ' . var_export($actual, true) . PHP_EOL);
+        exit(1);
+    }
+}
+
+$tmp = tempnam(sys_get_temp_dir(), 'unraid-mcp-env-');
+if ($tmp === false) {
+    throw new RuntimeException('could not create temp env file');
+}
+
+$values = [
+    'PLAIN' => 'hello world',
+    'APOSTROPHE' => "Jake's server",
+    'BACKSLASH' => 'C:\server\path',
+    'SHELL_TEXT' => '$(not-a-command) still-text',
+];
+write_env($tmp, $values);
+expect_same($values, read_env($tmp), 'dotenv values did not round-trip');
+$serialized = (string) file_get_contents($tmp);
+if (!str_contains($serialized, "APOSTROPHE='Jake'\\''s server'")) {
+    fwrite(STDERR, 'apostrophe was not serialized with POSIX shell quoting' . PHP_EOL);
+    exit(1);
+}
+file_put_contents($tmp, "BAD;KEY='must-not-survive'" . PHP_EOL, FILE_APPEND);
+expect_same(false, array_key_exists('BAD;KEY', read_env($tmp)), 'invalid dotenv key was preserved');
+@unlink($tmp);
+
+$valid = [
+    'UNRAID_API_URL' => 'http://127.0.0.1/graphql',
+    'UNRAID_RMCP_HOST' => '127.0.0.1',
+    'UNRAID_RMCP_PORT' => '40010',
+    'UNRAID_RMCP_AUTH_MODE' => 'bearer',
+    'UNRAID_RMCP_TOKEN' => 'test-token',
+    'UNRAID_API_SKIP_TLS_VERIFY' => 'false',
+    'UNRAID_MCP_TAILSCALE_SERVE' => 'false',
+    'UNRAID_RMCP_DISABLE_HTTP_AUTH' => 'false',
+    'UNRAID_NOAUTH' => 'false',
+    'RUST_LOG' => 'info',
+    'UNRAID_RMCP_ENABLED_TOOLS' => 'array,docker',
+];
+validate_env($valid);
+expect_same(true, is_valid_bind_host('tower.local'), 'valid hostname was rejected');
+expect_same(false, is_valid_bind_host('127.999.1.1'), 'invalid dotted numeric address was accepted');
+expect_same(true, is_loopback_host('127.42.1.9'), '127/8 loopback was not recognized');
+expect_same(true, is_loopback_host('[::1]'), 'IPv6 loopback was not recognized');
+expect_same(false, process_is_runraid_server(getmypid()), 'PHP test process was mistaken for runraid serve');
+expect_same(false, in_array('UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY', REVEALABLE_SECRET_KEYS, true), 'legacy JWT key became browser-revealable');
+expect_same(true, in_array('UNRAID_RMCP_TOKEN', REVEALABLE_SECRET_KEYS, true), 'bearer token must remain copyable');
+
+echo "Unraid MCP config endpoint tests passed\n";

--- a/plugins/mcp/tests/runtime-contract.sh
+++ b/plugins/mcp/tests/runtime-contract.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -euo pipefail
+
+plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+env_script="$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh"
+rc_script="$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp"
+update_script="$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh"
+nchan_script="$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp"
+verifier="$plugin_dir/scripts/verify-package.sh"
+
+php "$plugin_dir/tests/config-endpoint.php"
+
+# The runtime env parser must treat shell-looking text as literal data.
+env_tmp="$(mktemp -d)"
+marker="${env_tmp}/executed"
+{
+    printf '%s\n' "PLAIN='hello world'"
+    printf '%s\n' "APOSTROPHE='Jake'\\''s server'"
+    printf '%s\n' "BACKSLASH='C:\server\path'"
+    printf '%s\n' "SHELL_TEXT='\$(touch ${marker})'"
+    printf '%s\n' "UNQUOTED=\$(touch ${marker})"
+    printf '%s\n' "INVALID;KEY='ignored'"
+} >"${env_tmp}/.env"
+(
+    unset PLAIN APOSTROPHE BACKSLASH SHELL_TEXT UNQUOTED
+    unset UNRAID_MCP_ENV_FILE UNRAID_MCP_CONFIG_DIR UNRAID_MCP_APPDATA_DIR
+    export UNRAID_MCP_CONFIG_DIR="${env_tmp}"
+    export UNRAID_MCP_APPDATA_DIR="${env_tmp}/appdata"
+    # shellcheck source=/dev/null
+    source "$env_script" 2>"${env_tmp}/parser.err"
+    test "$PLAIN" = "hello world"
+    test "$APOSTROPHE" = "Jake's server"
+    test "$BACKSLASH" = "C:\server\path"
+    test "$SHELL_TEXT" = "\$(touch ${marker})"
+    test "$UNQUOTED" = "\$(touch ${marker})"
+)
+test ! -e "$marker"
+grep -Fq 'ignoring invalid env key INVALID;KEY' "${env_tmp}/parser.err"
+rm -rf "$env_tmp"
+
+unsafe_output="$(php "$plugin_dir/tests/config-endpoint.php" unsafe-noauth)"
+grep -Fq 'Disabling HTTP auth on a non-loopback bind' <<<"$unsafe_output"
+oauth_output="$(php "$plugin_dir/tests/config-endpoint.php" incomplete-oauth)"
+grep -Fq 'UNRAID_RMCP_PUBLIC_URL must use https:' <<<"$oauth_output"
+api_key_output="$(php "$plugin_dir/tests/config-endpoint.php" missing-api-key)"
+grep -Fq 'UNRAID_API_KEY is required before the service can start' <<<"$api_key_output"
+
+# Sourcing the environment must select the exact persistent directory without
+# creating /mnt/user paths merely for status/stop operations.
+appdata=/mnt/user/appdata/unraid-mcp
+existed=false
+[ -e "$appdata" ] && existed=true
+(
+    unset UNRAID_HOME HOME
+    # shellcheck source=/dev/null
+    source "$env_script"
+    test "$UNRAID_HOME" = "$appdata"
+    unraid_mcp_is_true yes
+    unraid_mcp_is_true 1
+    unraid_mcp_is_false no
+    unraid_mcp_is_false 0
+)
+if [ "$existed" = false ]; then
+    test ! -e "$appdata" || { echo "env script created appdata while the array was unavailable" >&2; exit 1; }
+fi
+
+# CI runners have no Unraid FUSE mount. In that state update/reset must fail
+# closed rather than constructing a convincing /mnt/user tree in RAM.
+if ! grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts; then
+    if "$update_script" reset >/tmp/unraid-mcp-reset.out 2>/tmp/unraid-mcp-reset.err; then
+        echo "reset unexpectedly succeeded without /mnt/user mounted" >&2
+        exit 1
+    fi
+    grep -Fq '/mnt/user is not mounted' /tmp/unraid-mcp-reset.err
+    rm -f /tmp/unraid-mcp-reset.out /tmp/unraid-mcp-reset.err
+fi
+
+grep -Fq "curl -fsS --noproxy '*' --max-time 2" "$rc_script"
+grep -Fq 'TAILSCALE_PORT_FILE=' "$rc_script"
+grep -Fq 'validate_required_config || return 1' "$rc_script"
+grep -Fq 'process_is_runraid_server' "$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php"
+grep -Fq 'runraid +serve' "$nchan_script"
+grep -Fq 'unraid-mcp-widget.js' "$verifier"
+grep -Fq 'nchan/unraid_mcp' "$verifier"
+grep -Fq 'stage-update) do_update' "$update_script"
+grep -Fq 'update) do_update "${2:-}"; do_commit' "$update_script"
+grep -Fq 'rollback) do_rollback' "$update_script"
+grep -Fq "command_result(\$updateCommand . ' rollback')" "$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php"
+grep -Fq 'objdump -T' "$verifier"
+grep -Fq 'JSON_HEX_TAG' "$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/UnraidMCP.page"
+grep -Fq 'REVEALABLE_SECRET_KEYS' "$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php"
+
+echo 'Unraid MCP runtime contract tests passed'

--- a/plugins/mcp/web/package-lock.json
+++ b/plugins/mcp/web/package-lock.json
@@ -190,24 +190,6 @@
         "@swc/helpers": "^0.5.0"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -294,17 +276,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1413,32 +1384,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -1469,9 +1414,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1522,26 +1467,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -1570,21 +1495,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1607,13 +1517,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/editorconfig": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
@@ -1632,13 +1535,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.3",
@@ -1707,23 +1603,6 @@
         }
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1740,22 +1619,57 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1793,39 +1707,6 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -2128,11 +2009,14 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2230,13 +2114,6 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -2244,28 +2121,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2404,48 +2271,12 @@
         "node": ">=10"
       }
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2469,110 +2300,6 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.1",
@@ -2906,22 +2633,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2934,104 +2645,6 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/plugins/mcp/web/package.json
+++ b/plugins/mcp/web/package.json
@@ -17,6 +17,11 @@
     "tailwind-merge": "^2.6.0",
     "vue": "^3.5.20"
   },
+  "overrides": {
+    "js-beautify": {
+      "glob": "^13.0.6"
+    }
+  },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.12",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/plugins/mcp/web/src/App.vue
+++ b/plugins/mcp/web/src/App.vue
@@ -4,6 +4,15 @@ import { Badge, Button, HelpText, Input, Label, Select, Switch } from "./compone
 import { SECTIONS, type FieldDef, type Section } from "./fields";
 import LogView from "./LogView.vue";
 import {
+  buildEndpoint,
+  buildMcpClientConfig,
+  isLoopbackHost,
+  isValidBindHost,
+  isValidHttpUrl,
+  rustVersion,
+  updateIsNewer,
+} from "./lib/client-config";
+import {
   checkUpdate,
   fetchStats,
   loadConfig,
@@ -85,22 +94,64 @@ const dirty = computed(() => {
   });
 });
 
-const URL_KEYS = new Set(["UNRAID_API_URL", "UNRAID_RMCP_PUBLIC_URL"]);
 function fieldError(key: string): string {
   const v = form[key] ?? "";
-  if (v === "") return "";
+  if (v === "") return key === "UNRAID_API_URL" ? "GraphQL URL is required" : "";
   if (key === "UNRAID_RMCP_PORT") {
     const n = Number(v);
     if (!Number.isInteger(n) || n < 1 || n > 65535) return "Port must be 1–65535";
   }
-  if (URL_KEYS.has(key) && !/^https?:\/\/.+/i.test(v)) return "Must start with http:// or https://";
+  if (key === "UNRAID_RMCP_HOST" && !isValidBindHost(v)) return "Enter a valid IP address or hostname";
+  if (key === "UNRAID_API_URL" && !isValidHttpUrl(v)) {
+    return "Enter a complete http:// or https:// URL without embedded credentials";
+  }
+  const activeOAuth = !boolVal("UNRAID_RMCP_DISABLE_HTTP_AUTH") && form.UNRAID_RMCP_AUTH_MODE === "oauth";
+  if (key === "UNRAID_RMCP_PUBLIC_URL" && activeOAuth && !isValidHttpUrl(v, true)) {
+    return "OAuth public URL must use https:// without a query or fragment";
+  }
+  if (key === "UNRAID_RMCP_AUTH_ADMIN_EMAIL" && activeOAuth && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(v)) {
+    return "Enter a valid email address";
+  }
+  if ((key === "UNRAID_RMCP_ENABLED_TOOLS" || key === "UNRAID_RMCP_DISABLED_TOOLS") && !v.split(",").some((item) => item.trim())) {
+    return "Enter at least one comma-separated selector";
+  }
   return "";
 }
+
+function secretAvailable(key: string): boolean {
+  const edit = secretEdits[key];
+  if (edit?.clear) return false;
+  if (edit?.value) return true;
+  return secretConfigured(key);
+}
+
+const configurationError = computed(() => {
+  const authDisabled = boolVal("UNRAID_RMCP_DISABLE_HTTP_AUTH");
+  const host = form.UNRAID_RMCP_HOST || "0.0.0.0";
+  if (authDisabled && !isLoopbackHost(host) && !boolVal("UNRAID_NOAUTH")) {
+    return "Disabling HTTP auth on a network bind requires the explicit unauthenticated-network acknowledgement.";
+  }
+  if (!authDisabled && form.UNRAID_RMCP_AUTH_MODE === "bearer" && !secretAvailable("UNRAID_RMCP_TOKEN")) {
+    return "Bearer mode requires a bearer token.";
+  }
+  if (!authDisabled && form.UNRAID_RMCP_AUTH_MODE === "oauth") {
+    if (!form.UNRAID_RMCP_PUBLIC_URL || !form.UNRAID_RMCP_GOOGLE_CLIENT_ID || !form.UNRAID_RMCP_AUTH_ADMIN_EMAIL) {
+      return "OAuth mode requires the public URL, Google client ID, client secret, and admin email.";
+    }
+    if (!secretAvailable("UNRAID_RMCP_GOOGLE_CLIENT_SECRET")) {
+      return "OAuth mode requires a Google client secret.";
+    }
+  }
+  return "";
+});
+
 // Only validate sections whose fields are actually visible — otherwise an
 // invalid value inside a collapsed/gated section could disable Apply globally
 // with no error text on screen to explain why.
-const hasErrors = computed(() =>
-  SECTIONS.some((s) => sectionShowsFields(s) && s.fields.some((f) => fieldError(f.key) !== "")),
+const hasErrors = computed(
+  () =>
+    configurationError.value !== "" ||
+    SECTIONS.some((s) => sectionShowsFields(s) && s.fields.some((f) => fieldError(f.key) !== "")),
 );
 
 // ── Google OAuth gate: keep the section compact until opted in ─────────────
@@ -126,9 +177,23 @@ function sparkPoints(hist: number[]): string {
 const apiKeyMissing = computed(() => {
   if (!payload.value) return false;
   const edit = secretEdits.UNRAID_API_KEY;
-  if (edit?.value && !edit.clear) return false; // a key was typed but not yet saved
+  if (edit?.clear) return true;
+  if (edit?.value) return false; // a key was typed but not yet saved
   return !secretConfigured("UNRAID_API_KEY");
 });
+
+const runtimeStartError = computed(() => {
+  if (configurationError.value) return configurationError.value;
+  for (const section of SECTIONS) {
+    for (const field of section.fields) {
+      const issue = fieldError(field.key);
+      if (issue) return `${field.label}: ${issue}`;
+    }
+  }
+  if (apiKeyMissing.value) return "An Unraid API key is required before the service can start.";
+  return "";
+});
+const runtimeReady = computed(() => runtimeStartError.value === "");
 
 const service = computed(() => payload.value?.service ?? { enabled: false, running: false });
 const tailscale = computed(
@@ -136,10 +201,7 @@ const tailscale = computed(
 );
 const version = computed(() => payload.value?.version ?? { installed: "unknown", overlay: false });
 const proc = computed(() => payload.value?.process ?? { pid: 0, cpu: 0, memMB: 0, uptime: 0 });
-const updateAvailable = computed(() => {
-  const l = latestVersion.value.replace(/^unraid-rs-v/, "");
-  return l !== "" && l !== version.value.installed;
-});
+const updateAvailable = computed(() => updateIsNewer(version.value.installed, latestVersion.value));
 
 const uptimeText = computed(() => {
   const s = proc.value.uptime;
@@ -152,17 +214,17 @@ const uptimeText = computed(() => {
   return `${m}m`;
 });
 
-const endpoint = computed(() => {
-  const port = form.UNRAID_RMCP_PORT || "40010";
-  if (boolVal("UNRAID_MCP_TAILSCALE_SERVE") && tailscale.value.dnsName) {
-    return `https://${tailscale.value.dnsName}:${port}/mcp`;
-  }
-  const host =
-    !form.UNRAID_RMCP_HOST || form.UNRAID_RMCP_HOST === "0.0.0.0"
-      ? window.location.hostname
-      : form.UNRAID_RMCP_HOST;
-  return `http://${host}:${port}/mcp`;
-});
+const endpoint = computed(() =>
+  buildEndpoint({
+    host: form.UNRAID_RMCP_HOST ?? "",
+    port: form.UNRAID_RMCP_PORT || "40010",
+    pageHostname: window.location.hostname,
+    tailscaleEnabled: boolVal("UNRAID_MCP_TAILSCALE_SERVE"),
+    tailscaleDnsName: tailscale.value.dnsName,
+    authMode: form.UNRAID_RMCP_AUTH_MODE === "oauth" ? "oauth" : "bearer",
+    publicUrl: form.UNRAID_RMCP_PUBLIC_URL ?? "",
+  }),
+);
 
 async function copyEndpoint() {
   if (!endpoint.value) return;
@@ -175,27 +237,38 @@ async function copyEndpoint() {
   }
 }
 
-/** Copy a ready-to-paste MCP client config (mcpServers block) with the token. */
+const clientConfigHint = computed(() => {
+  if (boolVal("UNRAID_RMCP_DISABLE_HTTP_AUTH")) return "URL-only config for an intentionally unauthenticated endpoint";
+  if (form.UNRAID_RMCP_AUTH_MODE === "oauth") return "URL-only config; compatible clients discover OAuth automatically";
+  return "mcpServers block with your bearer token, ready to paste";
+});
+
+/** Copy a ready-to-paste MCP client config for the selected auth mode. */
 async function copyConfig() {
   if (!endpoint.value) return;
+  const authMode = form.UNRAID_RMCP_AUTH_MODE === "oauth" ? "oauth" : "bearer";
+  const authDisabled = boolVal("UNRAID_RMCP_DISABLE_HTTP_AUTH");
   let token = "<your bearer token>";
-  // Prefer an unsaved edit so the copied config matches what's in the field,
-  // not the last-persisted value.
-  const edit = secretEdits.UNRAID_RMCP_TOKEN;
-  if (edit?.value && !edit.clear) {
-    token = edit.value;
-  } else if (!edit?.clear && secretConfigured("UNRAID_RMCP_TOKEN")) {
-    try {
-      token = await revealSecret("UNRAID_RMCP_TOKEN");
-    } catch {
-      /* fall back to the placeholder */
+  if (!authDisabled && authMode === "bearer") {
+    // Prefer an unsaved edit so the copied config matches what's in the field,
+    // not the last-persisted value.
+    const edit = secretEdits.UNRAID_RMCP_TOKEN;
+    if (edit?.value && !edit.clear) {
+      token = edit.value;
+    } else if (!edit?.clear && secretConfigured("UNRAID_RMCP_TOKEN")) {
+      try {
+        token = await revealSecret("UNRAID_RMCP_TOKEN");
+      } catch {
+        /* fall back to the placeholder */
+      }
     }
   }
-  const cfg = {
-    mcpServers: {
-      unraid: { url: endpoint.value, headers: { Authorization: `Bearer ${token}` } },
-    },
-  };
+  const cfg = buildMcpClientConfig({
+    url: endpoint.value,
+    authMode,
+    authDisabled,
+    token,
+  });
   try {
     await navigator.clipboard.writeText(JSON.stringify(cfg, null, 2));
     copiedConfig.value = true;
@@ -212,7 +285,9 @@ function setBool(key: string, v: boolean) {
   form[key] = v ? "true" : "false";
 }
 function fieldDisabled(field: FieldDef): boolean {
-  return field.key === "UNRAID_MCP_TAILSCALE_SERVE" && !tailscale.value.available;
+  return field.key === "UNRAID_MCP_TAILSCALE_SERVE"
+    && !tailscale.value.available
+    && !boolVal("UNRAID_MCP_TAILSCALE_SERVE");
 }
 
 async function run(fn: () => Promise<ConfigPayload>) {
@@ -352,7 +427,6 @@ function onTabKey(e: KeyboardEvent, current: Tab) {
 onMounted(async () => {
   await run(() => loadConfig());
   loading.value = false;
-  void doCheckUpdate();
   setStatsPolling(true);
 });
 onBeforeUnmount(() => {
@@ -385,6 +459,9 @@ onBeforeUnmount(() => {
     <div v-if="error" role="alert" class="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
       {{ error }}
     </div>
+    <div v-if="!loading && tab === 'settings' && configurationError" role="alert" class="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      {{ configurationError }}
+    </div>
 
     <div v-if="loading" class="text-sm text-muted-foreground">Loading…</div>
 
@@ -405,15 +482,28 @@ onBeforeUnmount(() => {
               <Badge v-if="boolVal('UNRAID_MCP_TAILSCALE_SERVE') && tailscale.available" variant="orange" size="sm">tailnet</Badge>
             </div>
             <div class="flex items-center gap-2">
-              <Button size="sm" variant="outline" :disabled="busy" @click="svc(service.running ? 'stop' : 'start')">
+              <Button
+                size="sm"
+                variant="outline"
+                :disabled="busy || (!service.running && !runtimeReady)"
+                :title="!service.running && runtimeStartError ? runtimeStartError : undefined"
+                @click="svc(service.running ? 'stop' : 'start')"
+              >
                 {{ service.running ? "Stop" : "Start" }}
               </Button>
               <Button size="sm" variant="outline" :disabled="busy || !service.running" @click="svc('restart')">Restart</Button>
               <div class="ms-auto flex items-center gap-1.5" :title="service.enabled ? 'Starts with the array' : 'Does not start with the array'">
-                <Switch :model-value="service.enabled" :disabled="busy" @update:model-value="svc($event ? 'enable' : 'disable')" />
+                <Switch
+                  :model-value="service.enabled"
+                  :disabled="busy || (!service.enabled && !runtimeReady)"
+                  @update:model-value="svc($event ? 'enable' : 'disable')"
+                />
                 <span class="text-sm text-muted-foreground">Autostart</span>
               </div>
             </div>
+            <p v-if="!service.running && runtimeStartError" class="text-xs text-destructive">
+              {{ runtimeStartError }}
+            </p>
           </section>
 
           <section class="rounded-lg border border-border bg-card p-4 flex flex-col gap-2">
@@ -432,7 +522,7 @@ onBeforeUnmount(() => {
               <Button size="sm" variant="outline" @click="copyConfig">
                 {{ copiedConfig ? "Config copied" : "Copy MCP client config" }}
               </Button>
-              <span class="text-xs text-muted-foreground">mcpServers block with your bearer token, ready to paste</span>
+              <span class="text-xs text-muted-foreground">{{ clientConfigHint }}</span>
             </div>
             <p class="text-xs text-muted-foreground">
               Runtime <span class="font-mono text-foreground">runraid (Rust)</span>
@@ -475,14 +565,14 @@ onBeforeUnmount(() => {
               <Badge v-if="updateAvailable" variant="orange" size="sm">update available</Badge>
             </div>
             <p v-if="latestVersion" class="text-xs text-muted-foreground">
-              latest release <span class="font-mono text-foreground">{{ latestVersion.replace(/^unraid-rs-v/, "") }}</span>
+              latest release <span class="font-mono text-foreground">{{ rustVersion(latestVersion) }}</span>
             </p>
             <div class="flex items-center gap-2">
               <Button size="sm" variant="ghost" class="px-2" :disabled="checkingUpdate || updating" @click="doCheckUpdate">
                 {{ checkingUpdate ? "Checking…" : "Check" }}
               </Button>
               <Button v-if="updateAvailable" size="sm" :disabled="updating" @click="doUpdate">
-                {{ updating ? "Updating…" : `Update to ${latestVersion.replace(/^unraid-rs-v/, "")}` }}
+                {{ updating ? "Updating…" : `Update to ${rustVersion(latestVersion)}` }}
               </Button>
               <Button v-if="version.overlay" size="sm" variant="outline" :disabled="updating" @click="doReset">Revert to bundled</Button>
             </div>

--- a/plugins/mcp/web/src/LogView.vue
+++ b/plugins/mcp/web/src/LogView.vue
@@ -70,7 +70,7 @@ interface Seg {
 // message text) instead of a lookbehind, so the pattern parses on older
 // engines too.
 const TOKEN_RE =
-  /(?<ts>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?)|\b(?<lvl>DEBUG|INFO|NOTICE|WARNING|WARN|ERROR|CRITICAL|FATAL)\b|(?<pre>"\s+)(?<status>[1-5]\d{2})\b|\b(?<mod>(?:unraid_mcp|rc\.unraid-mcp|uvicorn|fastmcp)[\w.-]*)/g;
+  /(?<ts>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?)|\b(?<lvl>DEBUG|INFO|NOTICE|WARNING|WARN|ERROR|CRITICAL|FATAL)\b|(?<pre>"\s+)(?<status>[1-5]\d{2})\b|\b(?<mod>(?:unraid_mcp|unraid_rmcp|runraid|rc\.unraid-mcp|uvicorn|fastmcp)[\w.-]*)/g;
 
 function tokenize(line: string): Seg[] {
   const segs: Seg[] = [];

--- a/plugins/mcp/web/src/Widget.vue
+++ b/plugins/mcp/web/src/Widget.vue
@@ -22,6 +22,12 @@ const status = ref<Status | null>(null);
 const connected = ref(false);
 let es: EventSource | null = null;
 
+const stateText = computed(() => {
+  if (!status.value) return connected.value ? "Waiting…" : "Connecting…";
+  if (!connected.value) return "Reconnecting…";
+  return status.value.running ? "Running" : "Stopped";
+});
+
 const uptimeText = computed(() => {
   const s = status.value?.uptime ?? 0;
   if (!s || !status.value?.running) return "—";
@@ -42,6 +48,7 @@ function connect() {
       // Validate before trusting fields the template calls .toFixed() on — a
       // future publisher change or partial frame must not throw in render.
       if (typeof d.running !== "boolean") return;
+      connected.value = true;
       status.value = {
         running: d.running,
         pid: Number(d.pid) || 0,
@@ -72,20 +79,21 @@ onBeforeUnmount(() => es?.close());
           width: '9px',
           height: '9px',
           borderRadius: '50%',
-          background: status?.running ? '#63a659' : '#8a8a8a',
+          background: !connected ? '#c6a36b' : status?.running ? '#63a659' : '#8a8a8a',
         }"
       ></span>
-      <strong>{{ status?.running ? "Running" : status ? "Stopped" : "Connecting…" }}</strong>
+      <strong>{{ stateText }}</strong>
       <span v-if="status" style="opacity: 0.7">v{{ status.version }}</span>
       <a href="/Settings/UnraidMCP" style="margin-left: auto; font-size: 1.15rem">Settings ›</a>
     </div>
 
-    <div v-if="status?.running" style="display: flex; gap: 18px; opacity: 0.9">
+    <div v-if="status?.running && connected" style="display: flex; gap: 18px; opacity: 0.9">
       <span><b>{{ status.cpu.toFixed(1) }}%</b> cpu</span>
       <span><b>{{ status.memMB }}</b> MB</span>
       <span><b>{{ uptimeText }}</b> up</span>
       <span style="opacity: 0.6">pid {{ status.pid }}</span>
     </div>
-    <div v-else-if="status" style="opacity: 0.7">Service is not running.</div>
+    <div v-else-if="status && connected" style="opacity: 0.7">Service is not running.</div>
+    <div v-else-if="status" style="opacity: 0.7">Live status unavailable; reconnecting.</div>
   </div>
 </template>

--- a/plugins/mcp/web/src/fields.ts
+++ b/plugins/mcp/web/src/fields.ts
@@ -124,6 +124,28 @@ export const SECTIONS: Section[] = [
     ],
   },
   {
+    title: "Tool exposure",
+    col: "b",
+    fields: [
+      {
+        key: "UNRAID_RMCP_ENABLED_TOOLS",
+        label: "Enabled tools",
+        help: "Optional comma-separated allowlist of action names (for example array,docker) or *, unraid, or unraid.*. Empty exposes all actions not denied below.",
+        kind: "text",
+        mono: true,
+        placeholder: "array,docker,status",
+      },
+      {
+        key: "UNRAID_RMCP_DISABLED_TOOLS",
+        label: "Disabled tools",
+        help: "Optional comma-separated denylist. Deny selectors win when an action appears in both lists.",
+        kind: "text",
+        mono: true,
+        placeholder: "vm_reset,array_stop",
+      },
+    ],
+  },
+  {
     title: "Google OAuth",
     col: "c",
     gated: true,

--- a/plugins/mcp/web/src/lib/client-config.test.ts
+++ b/plugins/mcp/web/src/lib/client-config.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEndpoint,
+  buildMcpClientConfig,
+  compareRustVersions,
+  isLoopbackHost,
+  isValidBindHost,
+  isValidHttpUrl,
+  updateIsNewer,
+} from "./client-config";
+
+describe("client configuration helpers", () => {
+  it("compares semantic versions numerically", () => {
+    expect(compareRustVersions("0.3.9", "unraid-rs-v0.3.10")).toBe(-1);
+    expect(updateIsNewer("0.4.0", "unraid-rs-v0.3.10")).toBe(false);
+    expect(updateIsNewer("unknown", "unraid-rs-v0.3.10")).toBe(false);
+  });
+
+  it("uses the OAuth public URL and avoids a bearer header", () => {
+    const url = buildEndpoint({
+      host: "0.0.0.0",
+      port: "40010",
+      pageHostname: "tower.local",
+      tailscaleEnabled: false,
+      tailscaleDnsName: "",
+      authMode: "oauth",
+      publicUrl: "https://mcp.example.com/",
+    });
+    expect(url).toBe("https://mcp.example.com/mcp");
+    expect(buildMcpClientConfig({ url, authMode: "oauth", authDisabled: false, token: "secret" }))
+      .toEqual({ mcpServers: { unraid: { url } } });
+  });
+
+  it("brackets IPv6 and emits bearer auth only in bearer mode", () => {
+    const url = buildEndpoint({
+      host: "::1",
+      port: "40010",
+      pageHostname: "tower.local",
+      tailscaleEnabled: false,
+      tailscaleDnsName: "",
+      authMode: "bearer",
+      publicUrl: "",
+    });
+    expect(url).toBe("http://[::1]:40010/mcp");
+    expect(buildMcpClientConfig({ url, authMode: "bearer", authDisabled: false, token: "abc" }))
+      .toEqual({ mcpServers: { unraid: { url, headers: { Authorization: "Bearer abc" } } } });
+  });
+
+  it("omits auth headers for explicitly unauthenticated endpoints", () => {
+    const url = "http://tower.local:40010/mcp";
+    expect(buildMcpClientConfig({ url, authMode: "bearer", authDisabled: true, token: "abc" }))
+      .toEqual({ mcpServers: { unraid: { url } } });
+  });
+
+  it("validates bind and loopback hosts without accepting malformed addresses", () => {
+    expect(isValidBindHost("0.0.0.0")).toBe(true);
+    expect(isValidBindHost("tower.local")).toBe(true);
+    expect(isValidBindHost("::1")).toBe(true);
+    expect(isValidBindHost("127.999.1.1")).toBe(false);
+    expect(isValidBindHost("bad_host.example")).toBe(false);
+    expect(isLoopbackHost("127.42.1.9")).toBe(true);
+    expect(isLoopbackHost("127.999.1.1")).toBe(false);
+    expect(isLoopbackHost("[::1]")).toBe(true);
+    expect(isLoopbackHost("127.evil.example")).toBe(false);
+  });
+
+  it("validates HTTP URLs and strict OAuth public URLs", () => {
+    expect(isValidHttpUrl("http://127.0.0.1/graphql")).toBe(true);
+    expect(isValidHttpUrl("https://mcp.example.com", true)).toBe(true);
+    expect(isValidHttpUrl("https://user:pass@mcp.example.com")).toBe(false);
+    expect(isValidHttpUrl("https://mcp.example.com?redirect=evil", true)).toBe(false);
+    expect(isValidHttpUrl("http://mcp.example.com", true)).toBe(false);
+  });
+});

--- a/plugins/mcp/web/src/lib/client-config.ts
+++ b/plugins/mcp/web/src/lib/client-config.ts
@@ -1,0 +1,124 @@
+export type ClientAuthMode = "bearer" | "oauth";
+
+export interface EndpointOptions {
+  host: string;
+  port: string;
+  pageHostname: string;
+  tailscaleEnabled: boolean;
+  tailscaleDnsName: string;
+  authMode: ClientAuthMode;
+  publicUrl: string;
+}
+
+export interface ClientConfigOptions {
+  url: string;
+  authMode: ClientAuthMode;
+  authDisabled: boolean;
+  token: string;
+}
+
+export function rustVersion(tagOrVersion: string): string {
+  return tagOrVersion.trim().replace(/^unraid-rs-v/, "").replace(/^v/, "");
+}
+
+function semverParts(value: string): [number, number, number] | null {
+  const match = rustVersion(value).match(/^(\d+)\.(\d+)\.(\d+)$/);
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+}
+
+export function compareRustVersions(left: string, right: string): number {
+  const a = semverParts(left);
+  const b = semverParts(right);
+  if (!a || !b) return 0;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+export function updateIsNewer(installed: string, latestTag: string): boolean {
+  return compareRustVersions(installed, latestTag) < 0;
+}
+
+export function isValidBindHost(host: string): boolean {
+  let value = host.trim().replace(/^\[|\]$/g, "");
+  if (!value) return false;
+
+  if (value.includes(":")) {
+    try {
+      const parsed = new URL(`http://[${value}]/`);
+      return parsed.hostname.length > 2;
+    } catch {
+      return false;
+    }
+  }
+
+  const octets = value.split(".");
+  if (octets.length === 4 && octets.every((part) => /^\d+$/.test(part))) {
+    return octets.every((part) => part.length <= 3 && Number(part) <= 255);
+  }
+
+  if (value.endsWith(".")) value = value.slice(0, -1);
+  if (!value || value.length > 253) return false;
+  return value.split(".").every(
+    (label) => label.length > 0
+      && label.length <= 63
+      && /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(label),
+  );
+}
+
+export function isLoopbackHost(host: string): boolean {
+  const value = host.trim().replace(/^\[|\]$/g, "").toLowerCase();
+  if (value === "localhost" || value === "::1") return true;
+  const octets = value.split(".");
+  return octets.length === 4
+    && octets[0] === "127"
+    && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255);
+}
+
+export function isValidHttpUrl(value: string, httpsOnly = false): boolean {
+  try {
+    const url = new URL(value);
+    if (!url.hostname || !["http:", "https:"].includes(url.protocol)) return false;
+    if (url.username || url.password) return false;
+    if (httpsOnly && (url.protocol !== "https:" || url.search || url.hash)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function bracketIpv6(host: string): string {
+  const value = host.trim();
+  if (value.startsWith("[") && value.endsWith("]")) return value;
+  return value.includes(":") ? `[${value}]` : value;
+}
+
+function mcpUrl(base: string): string {
+  const clean = base.trim().replace(/\/+$/, "");
+  return clean.endsWith("/mcp") ? clean : `${clean}/mcp`;
+}
+
+export function buildEndpoint(options: EndpointOptions): string {
+  if (options.authMode === "oauth" && options.publicUrl.trim()) {
+    return mcpUrl(options.publicUrl);
+  }
+
+  if (options.tailscaleEnabled && options.tailscaleDnsName.trim()) {
+    return `https://${options.tailscaleDnsName.trim()}:${options.port}/mcp`;
+  }
+
+  const configured = options.host.trim();
+  const host = !configured || configured === "0.0.0.0" || configured === "::" || configured === "[::]"
+    ? options.pageHostname
+    : configured;
+  return `http://${bracketIpv6(host)}:${options.port}/mcp`;
+}
+
+export function buildMcpClientConfig(options: ClientConfigOptions): object {
+  const server: { url: string; headers?: Record<string, string> } = { url: options.url };
+  if (!options.authDisabled && options.authMode === "bearer") {
+    server.headers = { Authorization: `Bearer ${options.token || "<your bearer token>"}` };
+  }
+  return { mcpServers: { unraid: server } };
+}

--- a/plugins/mcp/web/src/lib/config-client.ts
+++ b/plugins/mcp/web/src/lib/config-client.ts
@@ -57,7 +57,7 @@ async function csrfToken(): Promise<string> {
     if (window.csrf_token) return window.csrf_token;
     await new Promise((r) => setTimeout(r, 100));
   }
-  return window.csrf_token ?? "";
+  throw new Error("Unraid CSRF token is unavailable; reload the webGUI and try again");
 }
 
 async function request(init?: RequestInit): Promise<ConfigPayload> {

--- a/unraid-rs/src/config.rs
+++ b/unraid-rs/src/config.rs
@@ -90,29 +90,47 @@ pub enum AuthMode {
 
 // ── defaults ──────────────────────────────────────────────────────────────────
 
-/// Returns the data directory: `/data` in containers, `~/.unraid/` locally.
-/// Container detection: checks for `/.dockerenv` or `RUNNING_IN_CONTAINER` env.
-pub fn default_data_dir() -> std::path::PathBuf {
-    if std::path::Path::new("/.dockerenv").exists()
-        || std::env::var("RUNNING_IN_CONTAINER")
-            .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
-            .unwrap_or(false)
-    {
-        std::path::PathBuf::from("/data")
-    } else {
-        let home = std::env::var("HOME").unwrap_or_else(|_| {
-            tracing::warn!(
-                "HOME is not set; falling back to /tmp for the data directory — secrets \
-                 (.env, auth.db, JWT key) will be world-readable and non-persistent. \
-                 Set HOME (or run in a container, which uses /data) to fix this."
-            );
-            "/tmp".to_string()
-        });
-        std::path::PathBuf::from(home).join(".unraid")
+fn data_dir_from_sources(
+    unraid_home: Option<std::ffi::OsString>,
+    is_container: bool,
+    home: Option<std::ffi::OsString>,
+) -> std::path::PathBuf {
+    if let Some(path) = unraid_home.filter(|value| !value.is_empty()) {
+        return std::path::PathBuf::from(path);
     }
+    if is_container {
+        return std::path::PathBuf::from("/data");
+    }
+    std::path::PathBuf::from(home.unwrap_or_else(|| std::ffi::OsString::from("/tmp")))
+        .join(".unraid")
 }
 
-/// Load `~/.unraid/.env` (or `/data/.env` in a container) into the process
+/// Returns the data directory. `UNRAID_HOME` is an explicit override used by
+/// native service integrations such as the Unraid plugin; otherwise containers
+/// use `/data` and local installs use `~/.unraid/`.
+/// Container detection checks for `/.dockerenv` or `RUNNING_IN_CONTAINER`.
+pub fn default_data_dir() -> std::path::PathBuf {
+    let unraid_home = std::env::var_os("UNRAID_HOME");
+    let is_container = std::path::Path::new("/.dockerenv").exists()
+        || std::env::var("RUNNING_IN_CONTAINER")
+            .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+    let home = std::env::var_os("HOME");
+
+    if unraid_home.as_ref().is_none_or(|value| value.is_empty()) && !is_container && home.is_none()
+    {
+        tracing::warn!(
+            "HOME is not set; falling back to /tmp for the data directory — secrets \
+             (.env, auth.db, JWT key) will be world-readable and non-persistent. \
+             Set HOME (or run in a container, which uses /data) to fix this."
+        );
+    }
+
+    data_dir_from_sources(unraid_home, is_container, home)
+}
+
+/// Load `<UNRAID_HOME>/.env` when explicitly configured, otherwise
+/// `~/.unraid/.env` (or `/data/.env` in a container), into the process
 /// environment if present.
 ///
 /// Best-effort: a missing file is ignored, and existing env vars are NOT
@@ -374,5 +392,55 @@ fn env_list(key: &str, target: &mut Vec<String>) {
         if !items.is_empty() {
             *target = items;
         }
+    }
+}
+
+#[cfg(test)]
+mod data_dir_tests {
+    use super::data_dir_from_sources;
+    use std::{ffi::OsString, path::PathBuf};
+
+    #[test]
+    fn explicit_unraid_home_wins_over_all_other_sources() {
+        assert_eq!(
+            data_dir_from_sources(
+                Some(OsString::from("/mnt/user/appdata/unraid-mcp")),
+                true,
+                Some(OsString::from("/home/ignored")),
+            ),
+            PathBuf::from("/mnt/user/appdata/unraid-mcp")
+        );
+    }
+
+    #[test]
+    fn empty_unraid_home_is_ignored() {
+        assert_eq!(
+            data_dir_from_sources(
+                Some(OsString::new()),
+                false,
+                Some(OsString::from("/home/jake")),
+            ),
+            PathBuf::from("/home/jake/.unraid")
+        );
+    }
+
+    #[test]
+    fn container_uses_data_when_no_override_exists() {
+        assert_eq!(
+            data_dir_from_sources(None, true, Some(OsString::from("/home/ignored"))),
+            PathBuf::from("/data")
+        );
+    }
+
+    #[test]
+    fn local_install_uses_home_and_has_a_tmp_fallback() {
+        assert_eq!(
+            data_dir_from_sources(None, false, Some(OsString::from("/home/jake"))),
+            PathBuf::from("/home/jake/.unraid")
+        );
+        assert_eq!(
+            data_dir_from_sources(None, false, None),
+            PathBuf::from("/tmp/.unraid")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- harden the native runraid service lifecycle, appdata safety, health checks, PID validation, and Tailscale Serve cleanup
- make settings and runtime updates transactional with rollback on failed startup
- replace executable dotenv sourcing with literal parsing and tighten secret/CSRF handling
- align the Vue UI with bearer, OAuth, no-auth, IPv6, tool filtering, and update semantics
- strengthen package verification, glibc compatibility, CI coverage, provenance, and dependency auditing

## Verification
- shell syntax and ShellCheck
- PHP and Unraid page lint
- actionlint, XML, CA metadata, action pin, and plugin version-ordering checks
- runtime and settings contract tests
- npm audit: 0 vulnerabilities
- Vue typecheck, 9 tests, and production bundles
- Rust fmt, locked check, Clippy with warnings denied, and 10 targeted tests
- reproducible plugin package built twice from runraid 0.4.1
- final package SHA-256: `3525d645a6ee88a425bd3431144abeab3912b4b87dd61096a41adf448ea2fc7d`
- required glibc: 2.39, below the Unraid 7.0.0 glibc 2.40 ceiling
