### PR TITLE
ci: use an explicit if for the Playwright version guard (SC2015)

### DIFF
--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -45,8 +45,10 @@ jobs:
         run: |
           set -euo pipefail
           version="$(node -p "require('./web-src/package-lock.json').packages['node_modules/playwright'].version")"
-          [ -n "$version" ] && [ "$version" != "undefined" ] \
-            || { echo "::error::could not resolve playwright version from web-src/package-lock.json"; exit 1; }
+          if [ -z "$version" ] || [ "$version" = "undefined" ]; then
+            echo "::error::could not resolve playwright version from web-src/package-lock.json"
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright browsers
         id: playwright-cache

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -43,8 +43,10 @@ jobs:
         run: |
           set -euo pipefail
           version="$(node -p "require('./web-src/package-lock.json').packages['node_modules/playwright'].version")"
-          [ -n "$version" ] && [ "$version" != "undefined" ] \
-            || { echo "::error::could not resolve playwright version from web-src/package-lock.json"; exit 1; }
+          if [ -z "$version" ] || [ "$version" = "undefined" ]; then
+            echo "::error::could not resolve playwright version from web-src/package-lock.json"
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright browsers
         id: playwright-cache


### PR DESCRIPTION
Fixes meta-ci on `main`, red since #354 ([run](https://github.com/dinglebear-ai/unraid/actions/runs/31036062557)).

actionlint's shellcheck pass flags the guard added to `codex-ci.yml` and `codex-release.yml`:

```
SC2015:info: Note that A && B || C is not if-then-else. C may run when A is true
```

The guard was `[ -n "$version" ] && [ "$version" != "undefined" ] || { ...; }`. The `||` branch only fires when the conjunction is false, so the logic was correct — but it is exactly the shape SC2015 warns about, and actionlint surfaces shellcheck info-level findings as errors. Rewritten as a plain `if`.

**Why #354 was not caught pre-merge, twice over:**

1. The pre-push `actionlint` run was clean. actionlint only reports what shellcheck reports, and the shellcheck on the dev box (0.11.0) does not emit SC2015 for this construct — `shellcheck -S info` on the extracted snippet also exits 0. `ubuntu-latest` ships an older shellcheck that does. The explicit `if` is correct under every version rather than depending on which one runs.
2. `main`'s only required status check is `Repository Contract`, so `--auto` merged #354 at 18:43 as soon as that passed — before `validate` reported at all. The meta-ci failure arrived after the merge. Worth knowing for any future `--squash --auto`: on this repo, auto-merge does **not** wait for meta-ci, rust-ci, mcp-ci, codex-ci or incus-ci.

Validated on this branch: `actionlint -shellcheck /usr/bin/shellcheck` clean, `check-actions-allowlist.py` (94 refs / 19 workflows), `check-action-pin-comments.py` (19 pairs), `yaml.safe_load` over every workflow.