### PR TITLE
ci(mcp): actually test web-bundle reproducibility

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -138,8 +138,11 @@ jobs:
           FIRST: ${{ steps.package.outputs.first }}
         run: |
           set -euo pipefail
-          UNRAID_MCP_SKIP_WEB_BUILD=true SOURCE_DATE_EPOCH=0 \
-            ./scripts/build-txz.sh "$VERSION" "$BINARY"
+          # Deliberately no UNRAID_MCP_SKIP_WEB_BUILD here: reusing the first
+          # run's Vite output made this compare tar determinism only, leaving
+          # the web bundle — the likeliest source of nondeterminism — untested.
+          # Now that this step is main-only, the extra Vite build is cheap.
+          SOURCE_DATE_EPOCH=0 ./scripts/build-txz.sh "$VERSION" "$BINARY"
           second="$(sha256sum "$PACKAGE" | cut -d' ' -f1)"
           test "$FIRST" = "$second" || { echo "::error::package is not reproducible: $FIRST != $second"; exit 1; }
           echo "reproducible package sha256=$second"


### PR DESCRIPTION
## Summary

The plugin package reproducibility check built twice, but the second build passed `UNRAID_MCP_SKIP_WEB_BUILD=true` — so it reused the first run's Vite output. It therefore proved only that `tar` is deterministic, while the web bundle, the likeliest source of nondeterminism, was never rebuilt or compared. Dropping the flag makes the comparison mean what its name says.

This sits on top of #354, which made the reproduce step main-only. That change makes this one cheaper: the extra Vite build no longer costs anything at PR time.

Found during the review sweep of #343 (filed as a deferred P3 at the time).

## Test plan
- [x] Confirmed the Vite build is deterministic on its own: two `npm run build` runs produce byte-identical `unraid-mcp-settings.js` / `.css` / `-widget.js`
- [x] Ran the full check as CI does — two complete `build-txz.sh` runs including `npm ci` + `vite build` — giving an identical package sha256 (`54bcabfa…4cd33c` for `unraid-mcp-3.000.004.001-x86_64-2.txz`), so the stricter gate passes today rather than immediately reddening main
- [x] YAML parses