### PR TITLE
fix(unraid-rs): harden granular MCP tool controls

### DIFF
--- a/agents/unraid-rs/.claude-plugin/plugin.json
+++ b/agents/unraid-rs/.claude-plugin/plugin.json
@@ -39,13 +39,13 @@
     "enabled_tools": {
       "type": "string",
       "title": "Enabled MCP tools/actions",
-      "description": "Optional comma-separated allowlist. Empty means all actions. Use action names such as array,docker,status,help or qualified selectors such as unraid.array.",
+      "description": "Optional comma-separated allowlist. Empty inherits the server's persisted .env/config policy; when none exists, all actions are enabled. Use action names such as array,docker,status,help or qualified selectors such as unraid.array.",
       "default": ""
     },
     "disabled_tools": {
       "type": "string",
       "title": "Disabled MCP tools/actions",
-      "description": "Optional comma-separated denylist. Deny rules override enabled rules. Use * or unraid to disable the whole tool, or selectors such as vm_reset or unraid.docker_remove_container.",
+      "description": "Optional comma-separated denylist. Empty inherits the server's persisted .env/config policy. Deny rules override enabled rules. Use * or unraid to disable the whole tool, or selectors such as vm_reset or unraid.docker_remove_container.",
       "default": ""
     },
     "auth_mode": {

--- a/unraid-rs/.env.example
+++ b/unraid-rs/.env.example
@@ -13,7 +13,8 @@ UNRAID_RMCP_PORT=40010
 # Optional comma-separated MCP tool/action selectors. Empty enabled means all;
 # disabled always wins. Examples: docker_logs,unraid.vm_reset or * to disable all.
 # A set, non-empty value REPLACES the matching [mcp.tools] list in config.toml
-# (no merge); "" is treated as unset. MCP surface only — the CLI is unaffected.
+# (no merge). An empty process value inherits this .env value when present; if no
+# persisted value exists it is treated as unset. MCP surface only — CLI unaffected.
 # UNRAID_RMCP_ENABLED_TOOLS=array,docker,status,help
 # UNRAID_RMCP_DISABLED_TOOLS=unraid.vm_reset,docker_remove_container
 

--- a/unraid-rs/CLAUDE.md
+++ b/unraid-rs/CLAUDE.md
@@ -51,8 +51,11 @@
 UNRAID_API_URL                Unraid GraphQL endpoint (required)
 UNRAID_API_KEY                API key for x-api-key header (required)
 UNRAID_API_SKIP_TLS_VERIFY    Skip TLS cert check (default false)
+UNRAID_HOME                   Exact data directory; overrides /data or ~/.unraid
 UNRAID_RMCP_HOST               Bind host (default 0.0.0.0)
 UNRAID_RMCP_PORT               Bind port (default 40010)
+UNRAID_RMCP_ENABLED_TOOLS      Comma-separated MCP tool/action allowlist
+UNRAID_RMCP_DISABLED_TOOLS     Comma-separated MCP tool/action denylist
 UNRAID_RMCP_TOKEN              Static bearer token for /mcp
 UNRAID_RMCP_DISABLE_HTTP_AUTH  Disable MCP auth entirely (1/true/yes)
 UNRAID_RMCP_NO_AUTH            Alias that disables MCP auth entirely (1/true/yes)
@@ -70,9 +73,11 @@ UNRAID_NOAUTH                 Permits a NON-loopback bind without auth being mou
 RUST_LOG                      Log filter
 ```
 
-The binary also loads `~/.unraid/.env` (or `/data/.env` in a container) at startup
-via `dotenvy` before `Config::load` — see `load_dotenv()` in `config.rs`. A symlinked
-`.env` is refused (symlink-attack guard); already-set env vars are not overridden.
+The binary loads `<UNRAID_HOME>/.env` when the override is set, otherwise
+`~/.unraid/.env` (or `/data/.env` in a container), before `Config::load` — see
+`load_dotenv()` in `config.rs`. A symlinked `.env` is refused (symlink-attack guard).
+Non-empty process values win; empty plugin placeholders are filled from `.env` when
+a persisted value exists.
 
 ## How to add a new action
 

--- a/unraid-rs/CLAUDE.md
+++ b/unraid-rs/CLAUDE.md
@@ -77,7 +77,8 @@ The binary loads `<UNRAID_HOME>/.env` when the override is set, otherwise
 `~/.unraid/.env` (or `/data/.env` in a container), before `Config::load` — see
 `load_dotenv()` in `config.rs`. A symlinked `.env` is refused (symlink-attack guard).
 Non-empty process values win; empty plugin placeholders are filled from `.env` when
-a persisted value exists.
+a persisted value exists. A malformed persisted `.env` fails startup instead of
+silently skipping later policy or credential entries.
 
 ## How to add a new action
 
@@ -85,8 +86,10 @@ The set of valid actions lives in ONE place: the `ACTIONS: &[ActionSpec]` slice 
 `src/mcp/schemas.rs`. From there, `enabled_action_names()` in `tool_filter.rs`
 filters `ACTIONS` through the configured `[mcp.tools]` enable/disable policy
 (`UNRAID_RMCP_ENABLED_TOOLS` / `UNRAID_RMCP_DISABLED_TOOLS`), and that filtered
-list feeds both the JSON Schema enum — via `tool_definitions(action_names)` in
-`schemas.rs` — and the error-message action list in `tools.rs`. The MCP scope
+list feeds the JSON Schema enum and filters the visible parameter set through
+`action_params.rs` before `tool_definitions(action_names)` returns discovery. A
+unit tripwire scans `dispatch_action` so argument/catalog drift fails tests. The
+MCP scope
 gating (`required_scope_for` in `rmcp_server.rs`) is still derived directly from
 `ACTIONS`. Do not hand-maintain any of these lists.
 

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -289,7 +289,7 @@ the operation.
 | `connect` | Unraid Connect dynamic remote access state. |
 | `plugins` | Installed community plugins with versions. |
 | `status` | Server observability: version, PID, uptime, and counters. |
-| `help` | Markdown reference for all actions. |
+| `help` | Markdown reference for the actions enabled by server policy. |
 
 Pagination and filtering are MCP-only. List actions return a paginated envelope
 with `items`, `total`, `limit`, `offset`, `has_more`, and `next_offset`.
@@ -332,14 +332,17 @@ runraid setup repair [--json]
 
 ## Configuration
 
-Host installs read `~/.unraid/.env` before loading config. Containers read
-`/data/.env`. Process environment overrides both.
+When `UNRAID_HOME` is non-empty, the binary reads `<UNRAID_HOME>/.env`.
+Otherwise host installs read `~/.unraid/.env` and containers read `/data/.env`.
+Non-empty process environment values override `.env`; empty plugin placeholders
+inherit persisted `.env` values instead of clearing them.
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `UNRAID_API_URL` | unset | Full Unraid GraphQL endpoint URL. |
 | `UNRAID_API_KEY` | unset | API key for the `x-api-key` header. |
 | `UNRAID_API_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification for self-signed endpoints. |
+| `UNRAID_HOME` | platform default | Exact data directory for `.env`, auth DB, and JWT key; overrides `/data` or `~/.unraid`. |
 | `UNRAID_RMCP_HOST` | `0.0.0.0` | HTTP bind host. |
 | `UNRAID_RMCP_PORT` | `40010` | HTTP bind port. |
 | `UNRAID_RMCP_ENABLED_TOOLS` | unset | Comma-separated MCP tool/action allowlist; empty means all. |
@@ -365,10 +368,11 @@ stale cached schema. Invalid selectors fail configuration loading.
 A set, non-empty `UNRAID_RMCP_ENABLED_TOOLS` / `UNRAID_RMCP_DISABLED_TOOLS`
 **replaces** the corresponding `[mcp.tools]` list from `config.toml` — env and
 toml are never merged, so the env var is the complete policy for that list.
-An env var set to the empty string is treated as unset, while a non-empty
-value that parses to zero selectors (for example `","`) fails startup.
-This policy governs the MCP surface only; the `runraid` CLI is not filtered
-by `[mcp.tools]`.
+An env var set to the empty string is treated as a placeholder: a matching
+value from `<UNRAID_HOME>/.env`, `~/.unraid/.env`, or `/data/.env` is loaded when
+present, otherwise it behaves as unset. A non-empty value that parses to zero selectors (for example
+`","`) fails startup. This policy governs the MCP surface only; the `runraid`
+CLI is not filtered by `[mcp.tools]`.
 
 ## Authentication
 

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -335,7 +335,8 @@ runraid setup repair [--json]
 When `UNRAID_HOME` is non-empty, the binary reads `<UNRAID_HOME>/.env`.
 Otherwise host installs read `~/.unraid/.env` and containers read `/data/.env`.
 Non-empty process environment values override `.env`; empty plugin placeholders
-inherit persisted `.env` values instead of clearing them.
+inherit persisted `.env` values instead of clearing them. A present but malformed
+`.env` is rejected so parsing cannot silently skip a later deny rule or credential.
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -361,9 +362,10 @@ inherit persisted `.env` values instead of clearing them.
 | `UNRAID_RMCP_AUTH_ADMIN_EMAIL` | unset | Admin email for OAuth bootstrap. |
 
 Tool selectors may target the entire tool (`*`, `unraid`, or `unraid.*`) or
-a single action (`docker_logs` or `unraid.vm_reset`). The advertised action
-schema is filtered, and disabled calls are rejected even when a client uses a
-stale cached schema. Invalid selectors fail configuration loading.
+a single action (`docker_logs` or `unraid.vm_reset`). Tool discovery and the
+schema resource expose only enabled actions and parameters used by those
+actions; disabled calls are still rejected when a client uses a stale cached
+schema. Invalid selectors and unknown TOML fields fail configuration loading.
 
 A set, non-empty `UNRAID_RMCP_ENABLED_TOOLS` / `UNRAID_RMCP_DISABLED_TOOLS`
 **replaces** the corresponding `[mcp.tools]` list from `config.toml` — env and

--- a/unraid-rs/config.toml
+++ b/unraid-rs/config.toml
@@ -20,8 +20,9 @@ server_name = "unraid-rmcp"
 # Empty enabled means all actions. Disabled selectors always win.
 # Selectors: "*", "unraid", "unraid.*", "docker_logs", "unraid.vm_reset".
 # A set, non-empty UNRAID_RMCP_ENABLED_TOOLS / UNRAID_RMCP_DISABLED_TOOLS env
-# var REPLACES the matching list below (no merge). MCP surface only; the CLI
-# is not filtered by this policy.
+# var REPLACES the matching list below (no merge). Empty process placeholders
+# may inherit a matching value from <UNRAID_HOME>/.env, ~/.unraid/.env, or
+# /data/.env. MCP surface only; the CLI is not filtered by this policy.
 enabled = []
 disabled = []
 

--- a/unraid-rs/config.toml
+++ b/unraid-rs/config.toml
@@ -23,6 +23,7 @@ server_name = "unraid-rmcp"
 # var REPLACES the matching list below (no merge). Empty process placeholders
 # may inherit a matching value from <UNRAID_HOME>/.env, ~/.unraid/.env, or
 # /data/.env. MCP surface only; the CLI is not filtered by this policy.
+# Unknown keys or misspelled tables fail startup instead of being ignored.
 enabled = []
 disabled = []
 

--- a/unraid-rs/docs/INVENTORY.md
+++ b/unraid-rs/docs/INVENTORY.md
@@ -4,7 +4,7 @@ Complete listing of all MCP actions, CLI commands, env vars, HTTP endpoints, and
 
 ## MCP tool: `unraid`
 
-One tool is exposed. The required `action` argument selects the operation. All actions are read-only.
+One action-based tool is exposed when at least one action is enabled. The required `action` argument selects the operation; actions include read-only queries, local meta operations, and admin-scoped mutations.
 
 ### Core actions
 
@@ -70,7 +70,7 @@ One tool is exposed. The required `action` argument selects the operation. All a
 | Action | Description |
 |--------|-------------|
 | `status` | Server observability: version, PID, uptime, request counters (requires `unraid:read`; MCP-only) |
-| `help` | Markdown reference for all actions (no auth scope required) |
+| `help` | Markdown reference for actions enabled by server policy (no auth scope required) |
 
 ### Action parameters
 
@@ -99,7 +99,7 @@ List actions return a paginated envelope: `{items, total, limit, offset, has_mor
 
 | Name | Description |
 |------|-------------|
-| `server_summary` | Instructs the model to call `action=info` and summarise array, disks, VMs, containers, notifications |
+| `server_summary` | Advertised only when at least one summary-data action is enabled; instructs the model to call only the enabled subset of `info`, `array`, `disks`, `vms`, `docker`, and `notifications` |
 
 ## CLI commands
 
@@ -162,8 +162,11 @@ Server/transport commands:
 | `UNRAID_API_URL` | **yes** | — | Unraid GraphQL endpoint |
 | `UNRAID_API_KEY` | **yes** | — | API key sent as `x-api-key` header |
 | `UNRAID_API_SKIP_TLS_VERIFY` | no | `false` | Skip TLS certificate verification |
+| `UNRAID_HOME` | no | `/data` in containers, `~/.unraid` locally | Exact data directory for `.env`, auth DB, and JWT key |
 | `UNRAID_RMCP_HOST` | no | `0.0.0.0` | Bind host for the MCP HTTP server |
 | `UNRAID_RMCP_PORT` | no | `40010` | Bind port |
+| `UNRAID_RMCP_ENABLED_TOOLS` | no | — | Comma-separated MCP tool/action allowlist; empty inherits persisted `.env` policy |
+| `UNRAID_RMCP_DISABLED_TOOLS` | no | — | Comma-separated MCP tool/action denylist; deny rules win |
 | `UNRAID_RMCP_TOKEN` | no | — | Static bearer token for `/mcp` |
 | `UNRAID_RMCP_DISABLE_HTTP_AUTH` | no | `false` | Disable MCP auth (1/true/yes) |
 | `UNRAID_RMCP_NO_AUTH` | no | `false` | Alias for disabling auth |
@@ -179,7 +182,7 @@ Server/transport commands:
 |-------|---------|
 | `tokio` | Async runtime |
 | `axum` | HTTP framework |
-| `rmcp` 1.6 | MCP protocol and transports |
+| `rmcp` 3.1 | MCP protocol and transports |
 | `tower-http` | CORS, body limit, tracing middleware |
 | `reqwest` | GraphQL HTTP client (rustls, no OpenSSL) |
 | `serde` / `serde_json` | Serialization |

--- a/unraid-rs/docs/INVENTORY.md
+++ b/unraid-rs/docs/INVENTORY.md
@@ -93,7 +93,7 @@ List actions return a paginated envelope: `{items, total, limit, offset, has_mor
 
 | URI | MIME type | Description |
 |-----|-----------|-------------|
-| `unraid://schema/mcp-tool` | `application/json` | JSON Schema for the `unraid` tool and its parameters |
+| `unraid://schema/mcp-tool` | `application/json` | Policy-filtered JSON Schema containing only enabled actions and their parameters |
 
 ## MCP prompts
 

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -289,7 +289,7 @@ the operation.
 | `connect` | Unraid Connect dynamic remote access state. |
 | `plugins` | Installed community plugins with versions. |
 | `status` | Server observability: version, PID, uptime, and counters. |
-| `help` | Markdown reference for all actions. |
+| `help` | Markdown reference for the actions enabled by server policy. |
 
 Pagination and filtering are MCP-only. List actions return a paginated envelope
 with `items`, `total`, `limit`, `offset`, `has_more`, and `next_offset`.
@@ -332,14 +332,17 @@ runraid setup repair [--json]
 
 ## Configuration
 
-Host installs read `~/.unraid/.env` before loading config. Containers read
-`/data/.env`. Process environment overrides both.
+When `UNRAID_HOME` is non-empty, the binary reads `<UNRAID_HOME>/.env`.
+Otherwise host installs read `~/.unraid/.env` and containers read `/data/.env`.
+Non-empty process environment values override `.env`; empty plugin placeholders
+inherit persisted `.env` values instead of clearing them.
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `UNRAID_API_URL` | unset | Full Unraid GraphQL endpoint URL. |
 | `UNRAID_API_KEY` | unset | API key for the `x-api-key` header. |
 | `UNRAID_API_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification for self-signed endpoints. |
+| `UNRAID_HOME` | platform default | Exact data directory for `.env`, auth DB, and JWT key; overrides `/data` or `~/.unraid`. |
 | `UNRAID_RMCP_HOST` | `0.0.0.0` | HTTP bind host. |
 | `UNRAID_RMCP_PORT` | `40010` | HTTP bind port. |
 | `UNRAID_RMCP_ENABLED_TOOLS` | unset | Comma-separated MCP tool/action allowlist; empty means all. |
@@ -365,10 +368,11 @@ stale cached schema. Invalid selectors fail configuration loading.
 A set, non-empty `UNRAID_RMCP_ENABLED_TOOLS` / `UNRAID_RMCP_DISABLED_TOOLS`
 **replaces** the corresponding `[mcp.tools]` list from `config.toml` — env and
 toml are never merged, so the env var is the complete policy for that list.
-An env var set to the empty string is treated as unset, while a non-empty
-value that parses to zero selectors (for example `","`) fails startup.
-This policy governs the MCP surface only; the `runraid` CLI is not filtered
-by `[mcp.tools]`.
+An env var set to the empty string is treated as a placeholder: a matching
+value from `<UNRAID_HOME>/.env`, `~/.unraid/.env`, or `/data/.env` is loaded when
+present, otherwise it behaves as unset. A non-empty value that parses to zero selectors (for example
+`","`) fails startup. This policy governs the MCP surface only; the `runraid`
+CLI is not filtered by `[mcp.tools]`.
 
 ## Authentication
 

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -335,7 +335,8 @@ runraid setup repair [--json]
 When `UNRAID_HOME` is non-empty, the binary reads `<UNRAID_HOME>/.env`.
 Otherwise host installs read `~/.unraid/.env` and containers read `/data/.env`.
 Non-empty process environment values override `.env`; empty plugin placeholders
-inherit persisted `.env` values instead of clearing them.
+inherit persisted `.env` values instead of clearing them. A present but malformed
+`.env` is rejected so parsing cannot silently skip a later deny rule or credential.
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -361,9 +362,10 @@ inherit persisted `.env` values instead of clearing them.
 | `UNRAID_RMCP_AUTH_ADMIN_EMAIL` | unset | Admin email for OAuth bootstrap. |
 
 Tool selectors may target the entire tool (`*`, `unraid`, or `unraid.*`) or
-a single action (`docker_logs` or `unraid.vm_reset`). The advertised action
-schema is filtered, and disabled calls are rejected even when a client uses a
-stale cached schema. Invalid selectors fail configuration loading.
+a single action (`docker_logs` or `unraid.vm_reset`). Tool discovery and the
+schema resource expose only enabled actions and parameters used by those
+actions; disabled calls are still rejected when a client uses a stale cached
+schema. Invalid selectors and unknown TOML fields fail configuration loading.
 
 A set, non-empty `UNRAID_RMCP_ENABLED_TOOLS` / `UNRAID_RMCP_DISABLED_TOOLS`
 **replaces** the corresponding `[mcp.tools]` list from `config.toml` — env and

--- a/unraid-rs/src/config.rs
+++ b/unraid-rs/src/config.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub mcp: McpConfig,
     pub unraid: UnraidConfig,
@@ -11,7 +11,7 @@ pub struct Config {
 
 /// Unraid GraphQL API connection config
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct UnraidConfig {
     /// Full GraphQL endpoint URL (UNRAID_API_URL)
     pub api_url: String,
@@ -23,7 +23,7 @@ pub struct UnraidConfig {
 
 /// MCP HTTP server configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct McpConfig {
     #[serde(default = "default_mcp_host")]
     pub host: String,
@@ -63,7 +63,7 @@ pub struct McpToolsConfig {
 
 /// OAuth / auth sub-config (nested under `[mcp.auth]` in config.toml)
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AuthConfig {
     pub mode: AuthMode,
     pub public_url: Option<String>,
@@ -135,13 +135,14 @@ pub fn default_data_dir() -> std::path::PathBuf {
 /// `~/.unraid/.env` (or `/data/.env` in a container), into the process
 /// environment if present.
 ///
-/// Best-effort: a missing file is ignored, and existing NON-EMPTY env vars are
-/// not overridden — values injected by docker-compose/systemd or plugin config
-/// still take precedence. Empty process values are treated as placeholders and
-/// may be filled from `.env`; this prevents optional `${user_config.*}` entries
-/// from masking persisted credentials or tool policy. Call once at startup before
-/// `Config::load`. A symlinked `.env` is refused (the dir holds secrets; mirrors
-/// axon).
+/// A missing file is ignored, and existing NON-EMPTY env vars are not
+/// overridden — values injected by docker-compose/systemd or plugin config still
+/// take precedence. Empty process values are treated as placeholders and may be
+/// filled from `.env`, preventing optional plugin entries from masking persisted
+/// credentials or tool policy. A present but malformed file is fatal so a parse
+/// error cannot silently skip a later deny rule or credential. Call once at
+/// startup before `Config::load`. A symlinked `.env` is refused (the dir holds
+/// secrets; mirrors axon).
 pub fn load_dotenv() {
     let env_path = default_data_dir().join(".env");
     match std::fs::symlink_metadata(&env_path) {
@@ -152,20 +153,24 @@ pub fn load_dotenv() {
             );
             std::process::exit(1);
         }
-        Ok(_) => load_dotenv_file(&env_path),
+        Ok(_) => {
+            if let Err(error) = load_dotenv_file(&env_path) {
+                eprintln!(
+                    "error: failed to parse .env at {}: {error}",
+                    env_path.display()
+                );
+                std::process::exit(1);
+            }
+        }
         Err(_) => {}
     }
 }
 
-fn load_dotenv_file(path: &std::path::Path) {
-    let Ok(iter) = dotenvy::from_path_iter(path) else {
-        return;
-    };
+fn load_dotenv_file(path: &std::path::Path) -> Result<(), dotenvy::Error> {
+    let iter = dotenvy::from_path_iter(path)?;
     let mut seen = HashSet::new();
     for item in iter {
-        let Ok((key, value)) = item else {
-            break;
-        };
+        let (key, value) = item?;
         // Match dotenvy's normal first-declaration-wins behavior.
         if !seen.insert(key.clone()) {
             continue;
@@ -178,6 +183,7 @@ fn load_dotenv_file(path: &std::path::Path) {
             unsafe { std::env::set_var(key, value) };
         }
     }
+    Ok(())
 }
 
 fn default_mcp_host() -> String {

--- a/unraid-rs/src/config.rs
+++ b/unraid-rs/src/config.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -53,7 +55,7 @@ impl McpConfig {
 /// bare action such as `docker_logs`, or a qualified action such as
 /// `unraid.docker_logs`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct McpToolsConfig {
     pub enabled: Vec<String>,
     pub disabled: Vec<String>,
@@ -133,12 +135,13 @@ pub fn default_data_dir() -> std::path::PathBuf {
 /// `~/.unraid/.env` (or `/data/.env` in a container), into the process
 /// environment if present.
 ///
-/// Best-effort: a missing file is ignored, and existing env vars are NOT
-/// overridden — values injected by docker-compose/systemd or the plugin hook's
-/// `CLAUDE_PLUGIN_OPTION_*` mapping still take precedence. This lets the binary
-/// find its credentials directly from `~/.unraid/.env` without relying on a
-/// process manager. Call once at startup before `Config::load`. A symlinked
-/// `.env` is refused (the dir holds secrets; mirrors axon).
+/// Best-effort: a missing file is ignored, and existing NON-EMPTY env vars are
+/// not overridden — values injected by docker-compose/systemd or plugin config
+/// still take precedence. Empty process values are treated as placeholders and
+/// may be filled from `.env`; this prevents optional `${user_config.*}` entries
+/// from masking persisted credentials or tool policy. Call once at startup before
+/// `Config::load`. A symlinked `.env` is refused (the dir holds secrets; mirrors
+/// axon).
 pub fn load_dotenv() {
     let env_path = default_data_dir().join(".env");
     match std::fs::symlink_metadata(&env_path) {
@@ -149,10 +152,31 @@ pub fn load_dotenv() {
             );
             std::process::exit(1);
         }
-        Ok(_) => {
-            let _ = dotenvy::from_path(&env_path);
-        }
+        Ok(_) => load_dotenv_file(&env_path),
         Err(_) => {}
+    }
+}
+
+fn load_dotenv_file(path: &std::path::Path) {
+    let Ok(iter) = dotenvy::from_path_iter(path) else {
+        return;
+    };
+    let mut seen = HashSet::new();
+    for item in iter {
+        let Ok((key, value)) = item else {
+            break;
+        };
+        // Match dotenvy's normal first-declaration-wins behavior.
+        if !seen.insert(key.clone()) {
+            continue;
+        }
+        let should_set = std::env::var_os(&key).is_none_or(|existing| existing.is_empty());
+        if should_set {
+            // SAFETY: load_dotenv() runs once during process startup, before any
+            // worker threads or async tasks are created, so environment mutation
+            // cannot race another thread.
+            unsafe { std::env::set_var(key, value) };
+        }
     }
 }
 

--- a/unraid-rs/src/mcp.rs
+++ b/unraid-rs/src/mcp.rs
@@ -4,6 +4,7 @@ use lab_auth::AuthLayer;
 
 use crate::{app::UnraidService, config::McpConfig, observability::Counters};
 
+mod action_params;
 mod elicitation;
 pub(crate) mod host_filter;
 mod prompts;

--- a/unraid-rs/src/mcp/action_params.rs
+++ b/unraid-rs/src/mcp/action_params.rs
@@ -1,0 +1,323 @@
+use std::collections::HashSet;
+
+/// Canonical action-to-parameter usage for the action-based `unraid` tool.
+///
+/// The dispatcher remains authoritative for execution. This catalog drives MCP
+/// schema minimization so a restricted policy advertises only arguments used by
+/// enabled actions. Tests in `schemas.rs` pin the catalog against the schema
+/// property set and reject unknown action names.
+pub(super) const ACTION_PARAMETERS: &[(&str, &[&str])] = &[
+    ("docker", &["state", "limit", "offset"]),
+    ("docker_logs", &["id", "tail"]),
+    ("vms", &["limit", "offset"]),
+    ("shares", &["name", "limit", "offset"]),
+    ("notifications", &["limit", "offset"]),
+    ("log_files", &["limit", "offset"]),
+    ("log_file", &["path", "lines", "start_line"]),
+    ("services", &["limit", "offset"]),
+    ("ups", &["limit", "offset"]),
+    ("plugins", &["name", "limit", "offset"]),
+    ("parity_history", &["limit", "offset"]),
+    ("api_key", &["id"]),
+    ("disk", &["id"]),
+    ("oidc_provider", &["id"]),
+    ("ups_device_by_id", &["id"]),
+    ("plugin_install_operation", &["id"]),
+    ("validate_oidc_session", &["token"]),
+    ("get_permissions_for_roles", &["roles"]),
+    ("preview_effective_permissions", &["roles", "permissions"]),
+    ("archive_notification", &["id"]),
+    (
+        "create_notification",
+        &["title", "subject", "description", "importance", "link"],
+    ),
+    ("vm_start", &["id"]),
+    ("vm_stop", &["id"]),
+    ("vm_pause", &["id"]),
+    ("vm_resume", &["id"]),
+    ("vm_force_stop", &["id"]),
+    ("vm_reboot", &["id"]),
+    ("vm_reset", &["id"]),
+    ("docker_start", &["id"]),
+    ("docker_stop", &["id"]),
+    ("docker_restart", &["id"]),
+    ("docker_pause", &["id"]),
+    ("docker_unpause", &["id"]),
+    ("docker_update_container", &["id"]),
+    ("docker_remove_container", &["id", "with_image"]),
+    ("docker_update_containers", &["ids"]),
+    (
+        "docker_create_folder",
+        &["name", "parent_id", "children_ids"],
+    ),
+    (
+        "docker_create_folder_with_items",
+        &["name", "parent_id", "source_entry_ids", "position"],
+    ),
+    ("docker_set_folder_children", &["folder_id", "children_ids"]),
+    ("docker_delete_entries", &["entry_ids"]),
+    (
+        "docker_move_entries_to_folder",
+        &["source_entry_ids", "destination_folder_id"],
+    ),
+    (
+        "docker_move_items_to_position",
+        &["source_entry_ids", "destination_folder_id", "position"],
+    ),
+    ("docker_rename_folder", &["folder_id", "new_name"]),
+    ("docker_update_view_preferences", &["view_id", "prefs"]),
+    (
+        "docker_update_autostart_configuration",
+        &["entries", "persist_user_preferences"],
+    ),
+    ("customization_set_locale", &["locale"]),
+    ("customization_set_theme", &["theme"]),
+    (
+        "array_set_state",
+        &["desired_state", "decryption_password", "decryption_keyfile"],
+    ),
+    ("array_add_disk_to_array", &["id", "slot"]),
+    ("array_remove_disk_from_array", &["id", "slot"]),
+    ("array_mount_array_disk", &["id"]),
+    ("array_unmount_array_disk", &["id"]),
+    ("array_clear_array_disk_statistics", &["id"]),
+    ("parity_check_start", &["correct"]),
+    (
+        "api_key_create",
+        &["name", "description", "roles", "permissions", "overwrite"],
+    ),
+    ("api_key_add_role", &["api_key_id", "role"]),
+    ("api_key_remove_role", &["api_key_id", "role"]),
+    ("api_key_delete", &["ids"]),
+    (
+        "api_key_update",
+        &["id", "name", "description", "roles", "permissions"],
+    ),
+    (
+        "rclone_create_r_clone_remote",
+        &["name", "type", "parameters"],
+    ),
+    ("rclone_delete_r_clone_remote", &["name"]),
+    ("unraid_plugins_install_plugin", &["name", "url", "forced"]),
+    (
+        "unraid_plugins_install_language",
+        &["name", "url", "forced"],
+    ),
+    ("onboarding_set_onboarding_override", &["input"]),
+    (
+        "onboarding_create_internal_boot_pool",
+        &[
+            "pool_name",
+            "devices",
+            "boot_size_mib",
+            "update_bios",
+            "reboot",
+        ],
+    ),
+    ("archive_notifications", &["ids"]),
+    ("unarchive_notifications", &["ids"]),
+    ("unread_notification", &["id"]),
+    ("archive_all", &["importance"]),
+    ("unarchive_all", &["importance"]),
+    ("update_server_identity", &["name", "comment", "sys_model"]),
+    ("configure_ups", &["config"]),
+    ("update_system_time", &["input"]),
+    ("update_temperature_config", &["input"]),
+    ("add_plugin", &["input"]),
+    ("remove_plugin", &["input"]),
+    ("connect_sign_in", &["api_key", "user_info"]),
+    (
+        "setup_remote_access",
+        &["access_type", "forward_type", "port"],
+    ),
+    ("enable_dynamic_remote_access", &["enabled", "access_url"]),
+    (
+        "update_api_settings",
+        &["access_type", "forward_type", "port"],
+    ),
+    ("update_settings", &["input"]),
+    ("update_ssh_settings", &["enabled", "port"]),
+    (
+        "initiate_flash_backup",
+        &["remote_name", "source_path", "destination_path", "options"],
+    ),
+    (
+        "notify_if_unique",
+        &["title", "subject", "description", "importance", "link"],
+    ),
+];
+
+pub(super) fn visible_parameter_names(action_names: &[&str]) -> HashSet<&'static str> {
+    ACTION_PARAMETERS
+        .iter()
+        .filter(|(action, _)| action_names.contains(action))
+        .flat_map(|(_, parameters)| parameters.iter().copied())
+        .collect()
+}
+
+pub(super) fn enabled_actions_for_parameter<'a>(
+    action_names: &'a [&'a str],
+    parameter: &str,
+) -> Vec<&'a str> {
+    action_names
+        .iter()
+        .copied()
+        .filter(|action| {
+            ACTION_PARAMETERS
+                .iter()
+                .find(|(candidate, _)| candidate == action)
+                .is_some_and(|(_, parameters)| parameters.contains(&parameter))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::mcp::schemas::ACTIONS;
+
+    fn scan_call_keys(compact: &str) -> HashSet<String> {
+        let mut keys = HashSet::new();
+        for helper in ["string_arg", "string_array_arg", "usize_arg", "i64_arg"] {
+            let needle = format!("{helper}(args,\"");
+            let mut offset = 0;
+            while let Some(start) = compact[offset..].find(&needle) {
+                let value_start = offset + start + needle.len();
+                let Some(end) = compact[value_start..].find('\"') else {
+                    break;
+                };
+                keys.insert(compact[value_start..value_start + end].to_string());
+                offset = value_start + end + 1;
+            }
+        }
+        for needle in ["args.get(\"", "args.get_mut(\"", "req(\""] {
+            let mut offset = 0;
+            while let Some(start) = compact[offset..].find(needle) {
+                let value_start = offset + start + needle.len();
+                let Some(end) = compact[value_start..].find('\"') else {
+                    break;
+                };
+                keys.insert(compact[value_start..value_start + end].to_string());
+                offset = value_start + end + 1;
+            }
+        }
+        if compact.contains("require_id(args") {
+            keys.insert("id".to_string());
+        }
+        keys
+    }
+
+    fn dispatcher_parameter_usage() -> HashMap<String, HashSet<String>> {
+        let lines: Vec<&str> = include_str!("tools.rs").lines().collect();
+        let dispatch_start = lines
+            .iter()
+            .position(|line| line.starts_with("async fn dispatch_action"))
+            .unwrap();
+        let dispatch_end = lines[dispatch_start..]
+            .iter()
+            .position(|line| line.starts_with("// ── help text"))
+            .map(|offset| dispatch_start + offset)
+            .unwrap_or(lines.len());
+        let starts: Vec<(usize, Vec<String>)> = lines[dispatch_start..dispatch_end]
+            .iter()
+            .enumerate()
+            .filter_map(|(offset, line)| {
+                if !line.starts_with("        \"") || !line.contains("=>") {
+                    return None;
+                }
+                let lhs = line.split_once("=>")?.0;
+                let names = lhs
+                    .split('\"')
+                    .skip(1)
+                    .step_by(2)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>();
+                Some((dispatch_start + offset, names))
+            })
+            .collect();
+
+        let mut usage = HashMap::new();
+        for (index, (start, names)) in starts.iter().enumerate() {
+            let end = starts
+                .get(index + 1)
+                .map(|(next, _)| *next)
+                .unwrap_or(dispatch_end);
+            let compact = lines[*start..end]
+                .join("")
+                .chars()
+                .filter(|ch| !ch.is_whitespace())
+                .collect::<String>();
+            let keys = scan_call_keys(&compact);
+            for name in names {
+                usage.insert(name.clone(), keys.clone());
+            }
+        }
+        usage
+    }
+
+    #[test]
+    fn parameter_catalog_has_unique_canonical_actions() {
+        let canonical: HashSet<&str> = ACTIONS.iter().map(|spec| spec.name).collect();
+        let mut seen = HashSet::new();
+        for (action, _) in ACTION_PARAMETERS {
+            assert!(
+                canonical.contains(action),
+                "unknown action in parameter catalog: {action}"
+            );
+            assert!(
+                seen.insert(*action),
+                "duplicate action in parameter catalog: {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn parameter_catalog_matches_dispatcher_argument_access() {
+        let dispatcher = dispatcher_parameter_usage();
+        let catalog: HashMap<String, HashSet<String>> = ACTION_PARAMETERS
+            .iter()
+            .map(|(action, parameters)| {
+                (
+                    (*action).to_string(),
+                    parameters
+                        .iter()
+                        .map(|parameter| (*parameter).to_string())
+                        .collect(),
+                )
+            })
+            .collect();
+
+        for (action, actual) in dispatcher
+            .iter()
+            .filter(|(_, parameters)| !parameters.is_empty())
+        {
+            assert_eq!(
+                catalog.get(action),
+                Some(actual),
+                "parameter catalog drift for action {action}"
+            );
+        }
+        for (action, expected) in &catalog {
+            assert_eq!(
+                dispatcher.get(action),
+                Some(expected),
+                "catalog action missing from dispatcher scan: {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn visible_parameters_are_the_union_for_enabled_actions() {
+        assert_eq!(
+            visible_parameter_names(&["docker_logs", "status"]),
+            HashSet::from(["id", "tail"])
+        );
+        assert!(visible_parameter_names(&["status", "help"]).is_empty());
+        assert_eq!(
+            enabled_actions_for_parameter(&["vm_reset", "docker_logs"], "id"),
+            vec!["vm_reset", "docker_logs"]
+        );
+    }
+}

--- a/unraid-rs/src/mcp/prompts.rs
+++ b/unraid-rs/src/mcp/prompts.rs
@@ -2,26 +2,58 @@ use rmcp::model::{
     GetPromptRequestParams, GetPromptResult, ListPromptsResult, Prompt, PromptMessage, Role,
 };
 
-pub(super) fn list_prompts() -> ListPromptsResult {
-    ListPromptsResult {
-        prompts: vec![Prompt::new(
+const SERVER_SUMMARY_ACTIONS: &[&str] =
+    &["info", "array", "disks", "vms", "docker", "notifications"];
+
+pub(super) fn list_prompts(enabled_actions: &[&str]) -> ListPromptsResult {
+    let prompts = if enabled_summary_actions(enabled_actions).is_empty() {
+        Vec::new()
+    } else {
+        vec![Prompt::new(
             "server_summary",
-            Some("Generate a human-readable summary of the Unraid server status."),
+            Some("Generate a human-readable summary from the enabled Unraid status actions."),
             None,
-        )],
+        )]
+    };
+    ListPromptsResult {
+        prompts,
         ..Default::default()
     }
 }
 
-pub(super) fn get_prompt(request: GetPromptRequestParams) -> anyhow::Result<GetPromptResult> {
+pub(super) fn get_prompt(
+    request: GetPromptRequestParams,
+    enabled_actions: &[&str],
+) -> anyhow::Result<GetPromptResult> {
     match request.name.as_str() {
-        "server_summary" => Ok(GetPromptResult::new(vec![PromptMessage::new_text(
-            Role::User,
-            "Use the unraid tool with action=info to retrieve the current server status, \
-             then provide a concise summary covering array state, disk health, \
-             running VMs, Docker containers, and any active notifications.",
-        )])
-        .with_description("Summarize the Unraid server status")),
+        "server_summary" => {
+            let actions = enabled_summary_actions(enabled_actions);
+            if actions.is_empty() {
+                anyhow::bail!("prompt unavailable: none of the server_summary actions are enabled");
+            }
+            let calls = actions
+                .iter()
+                .map(|action| format!("action={action}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Ok(GetPromptResult::new(vec![PromptMessage::new_text(
+                Role::User,
+                format!(
+                    "Use the unraid tool to retrieve the currently enabled server summary data. \
+                     Call these actions: {calls}. Then provide a concise summary covering only \
+                     the categories returned by those calls, highlighting unhealthy or unusual values."
+                ),
+            )])
+            .with_description("Summarize the enabled Unraid server status data"))
+        }
         other => Err(anyhow::anyhow!("unknown prompt: {other}")),
     }
+}
+
+fn enabled_summary_actions(enabled_actions: &[&str]) -> Vec<&'static str> {
+    SERVER_SUMMARY_ACTIONS
+        .iter()
+        .copied()
+        .filter(|action| enabled_actions.contains(action))
+        .collect()
 }

--- a/unraid-rs/src/mcp/rmcp_server.rs
+++ b/unraid-rs/src/mcp/rmcp_server.rs
@@ -76,24 +76,37 @@ impl ServerHandler for UnraidRmcpServer {
             .to_owned();
 
         let auth = require_auth_context(&self.state, &context)?;
+        let started = Instant::now();
+        // Count every authenticated tools/call exactly once at the MCP boundary,
+        // including policy/scope denials, pre-dispatch validation, and serialization
+        // errors. Requests rejected by HTTP auth middleware never reach this handler.
+        self.state.counters.inc_requests();
+
         if let Err(message) =
             ensure_tool_call_enabled(&self.state.config.tools, &tool_name, &action)
         {
-            tracing::warn!(tool = %tool_name, action = %action, reason = %message, "MCP tool denied by server policy");
+            let elapsed = started.elapsed().as_millis();
+            self.state.counters.inc_errors();
+            tracing::warn!(
+                tool = %tool_name,
+                action = %action,
+                elapsed_ms = elapsed,
+                reason = %message,
+                "MCP tool denied by server policy"
+            );
             return Err(ErrorData::invalid_request(message, None));
         }
-        if let (Some(auth), Some(required_scope)) = (auth, required_scope_for(&action)) {
-            check_scope(auth, required_scope, &action)?;
+        if let (Some(auth), Some(required_scope)) = (auth, required_scope_for(&action))
+            && let Err(error) = check_scope(auth, required_scope, &action)
+        {
+            self.state.counters.inc_errors();
+            return Err(error);
         }
 
         let arguments = request
             .arguments
             .map(Value::Object)
             .unwrap_or_else(|| Value::Object(Map::new()));
-        let started = Instant::now();
-        // Count every tool call exactly once at the MCP boundary (see the note in
-        // `tools::dispatch`). Covers pre-dispatch validation and serialization errors.
-        self.state.counters.inc_requests();
         tracing::info!(tool = %tool_name, action = %action, "MCP tool execution started");
 
         if let Err(message) =
@@ -203,12 +216,8 @@ impl ServerHandler for UnraidRmcpServer {
         context: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, ErrorData> {
         require_auth_context(&self.state, &context)?;
-        // Every prompt instructs the client to call the unraid tool, so a fully
-        // disabled tool must not advertise prompts that reference it.
-        if !tool_is_enabled(&self.state.config.tools) {
-            return Ok(ListPromptsResult::default());
-        }
-        Ok(prompts::list_prompts())
+        let action_names = enabled_action_names(&self.state.config.tools);
+        Ok(prompts::list_prompts(&action_names))
     }
 
     async fn get_prompt(
@@ -223,7 +232,8 @@ impl ServerHandler for UnraidRmcpServer {
                 None,
             ));
         }
-        prompts::get_prompt(request)
+        let action_names = enabled_action_names(&self.state.config.tools);
+        prompts::get_prompt(request, &action_names)
             .map(Into::into)
             .map_err(|e| ErrorData::invalid_params(e.to_string(), None))
     }

--- a/unraid-rs/src/mcp/schemas.rs
+++ b/unraid-rs/src/mcp/schemas.rs
@@ -637,9 +637,18 @@ pub fn write_action_names() -> Vec<&'static str> {
 }
 
 pub(super) fn tool_definitions(action_names: &[&str]) -> Vec<Value> {
+    let help_hint = if action_names.contains(&"help") {
+        " Use action=help for documentation."
+    } else {
+        ""
+    };
+    let description = format!(
+        "Query and manage the Unraid server via its GraphQL API. Read actions need scope \
+         unraid:read; mutating actions need unraid:admin.{help_hint}"
+    );
     vec![json!({
         "name": "unraid",
-        "description": "Query and manage the Unraid server via its GraphQL API. Read actions need scope unraid:read; mutating actions need unraid:admin. Use action=help for documentation.",
+        "description": description,
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -782,6 +791,25 @@ mod tests {
         assert_eq!(
             definitions[0]["inputSchema"]["properties"]["action"]["enum"],
             json!(derived)
+        );
+    }
+
+    #[test]
+    fn schema_description_only_recommends_enabled_help() {
+        let with_help = tool_definitions(&["status", "help"]);
+        assert!(
+            with_help[0]["description"]
+                .as_str()
+                .unwrap()
+                .contains("action=help")
+        );
+
+        let without_help = tool_definitions(&["status"]);
+        assert!(
+            !without_help[0]["description"]
+                .as_str()
+                .unwrap()
+                .contains("action=help")
         );
     }
 

--- a/unraid-rs/src/mcp/schemas.rs
+++ b/unraid-rs/src/mcp/schemas.rs
@@ -1,5 +1,7 @@
 use serde_json::{Value, json};
 
+use super::action_params::{enabled_actions_for_parameter, visible_parameter_names};
+
 /// Canonical specification for one `unraid` tool action.
 ///
 /// This is the SINGLE source of truth for the set of valid actions and their
@@ -646,12 +648,8 @@ pub(super) fn tool_definitions(action_names: &[&str]) -> Vec<Value> {
         "Query and manage the Unraid server via its GraphQL API. Read actions need scope \
          unraid:read; mutating actions need unraid:admin.{help_hint}"
     );
-    vec![json!({
-        "name": "unraid",
-        "description": description,
-        "inputSchema": {
-            "type": "object",
-            "properties": {
+    let visible_parameters = visible_parameter_names(action_names);
+    let mut properties = json!({
                 "action": {
                     "type": "string",
                     "description": "Operation to perform.",
@@ -756,7 +754,37 @@ pub(super) fn tool_definitions(action_names: &[&str]) -> Vec<Value> {
                 "boot_size_mib": { "type": "integer", "description": "Boot partition size in MiB (onboarding_create_internal_boot_pool)." },
                 "update_bios": { "type": "boolean", "description": "Whether to update BIOS boot order (onboarding_create_internal_boot_pool)." },
                 "reboot": { "type": "boolean", "description": "Whether to reboot after creating the pool (onboarding_create_internal_boot_pool)." }
-            },
+    })
+    .as_object()
+    .expect("tool properties must be a JSON object")
+    .clone();
+    properties.retain(|name, _| name == "action" || visible_parameters.contains(name.as_str()));
+    for (name, schema) in &mut properties {
+        if name == "action" {
+            continue;
+        }
+        let actions = enabled_actions_for_parameter(action_names, name);
+        debug_assert!(
+            !actions.is_empty(),
+            "visible parameter without an enabled action: {name}"
+        );
+        if let Some(schema) = schema.as_object_mut() {
+            schema.insert(
+                "description".to_string(),
+                Value::String(format!(
+                    "Parameter for enabled action(s): {}.",
+                    actions.join(", ")
+                )),
+            );
+        }
+    }
+
+    vec![json!({
+        "name": "unraid",
+        "description": description,
+        "inputSchema": {
+            "type": "object",
+            "properties": properties,
             "required": ["action"]
         }
     })]
@@ -764,7 +792,19 @@ pub(super) fn tool_definitions(action_names: &[&str]) -> Vec<Value> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
+    use crate::mcp::action_params::ACTION_PARAMETERS;
+
+    fn schema_property_names(action_names: &[&str]) -> HashSet<String> {
+        tool_definitions(action_names)[0]["inputSchema"]["properties"]
+            .as_object()
+            .expect("schema properties must be an object")
+            .keys()
+            .cloned()
+            .collect()
+    }
 
     /// `help` is the only unscoped action; query actions are read-scoped and
     /// mutating actions are write-scoped. Guards against silently flipping scope.
@@ -792,6 +832,73 @@ mod tests {
             definitions[0]["inputSchema"]["properties"]["action"]["enum"],
             json!(derived)
         );
+    }
+
+    #[test]
+    fn restricted_schema_exposes_only_enabled_action_parameters() {
+        assert_eq!(
+            schema_property_names(&["status", "help"]),
+            HashSet::from(["action".to_string()])
+        );
+        assert_eq!(
+            schema_property_names(&["docker_logs", "status"]),
+            HashSet::from(["action".to_string(), "id".to_string(), "tail".to_string()])
+        );
+
+        let schema = tool_definitions(&["vm_reset"]);
+        let description = schema[0]["inputSchema"]["properties"]["id"]["description"]
+            .as_str()
+            .unwrap();
+        assert!(description.contains("vm_reset"));
+        assert!(!description.contains("docker_logs"));
+        assert!(!description.contains("ups_device"));
+    }
+
+    #[test]
+    fn every_single_action_schema_is_minimal_and_action_specific() {
+        for spec in ACTIONS {
+            let schema = tool_definitions(&[spec.name]);
+            let properties = schema[0]["inputSchema"]["properties"].as_object().unwrap();
+            let mut expected = HashSet::from(["action".to_string()]);
+            if let Some((_, parameters)) = ACTION_PARAMETERS
+                .iter()
+                .find(|(action, _)| *action == spec.name)
+            {
+                expected.extend(parameters.iter().map(|parameter| (*parameter).to_string()));
+            }
+            assert_eq!(
+                properties.keys().cloned().collect::<HashSet<_>>(),
+                expected,
+                "schema property leak for action {}",
+                spec.name
+            );
+            for (name, property) in properties {
+                if name == "action" {
+                    continue;
+                }
+                let expected_description =
+                    format!("Parameter for enabled action(s): {}.", spec.name);
+                assert_eq!(
+                    property["description"].as_str(),
+                    Some(expected_description.as_str()),
+                    "description leak for {}.{name}",
+                    spec.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parameter_catalog_matches_full_schema_property_catalog() {
+        let action_names: Vec<&str> = ACTIONS.iter().map(|spec| spec.name).collect();
+        let mut schema_parameters = schema_property_names(&action_names);
+        schema_parameters.remove("action");
+        let catalog_parameters: HashSet<String> = ACTION_PARAMETERS
+            .iter()
+            .flat_map(|(_, parameters)| parameters.iter().copied())
+            .map(str::to_string)
+            .collect();
+        assert_eq!(schema_parameters, catalog_parameters);
     }
 
     #[test]

--- a/unraid-rs/src/mcp/tool_filter.rs
+++ b/unraid-rs/src/mcp/tool_filter.rs
@@ -152,6 +152,35 @@ mod tests {
     }
 
     #[test]
+    fn every_action_supports_bare_and_qualified_selectors() {
+        for spec in ACTIONS {
+            let qualified = format!("unraid.{}", spec.name);
+            for selector in [spec.name, qualified.as_str()] {
+                let policy = config(&[selector], &[]);
+                assert_eq!(
+                    enabled_action_names(&policy),
+                    vec![spec.name],
+                    "allow selector {selector:?}"
+                );
+
+                let policy = config(&[], &[selector]);
+                assert!(
+                    !action_is_enabled(&policy, spec.name),
+                    "deny selector {selector:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn whole_tool_aliases_have_identical_effect() {
+        for selector in ["*", "unraid", "unraid.*"] {
+            assert!(enabled_action_names(&config(&[selector], &[])).len() == ACTIONS.len());
+            assert!(enabled_action_names(&config(&[], &[selector])).is_empty());
+        }
+    }
+
+    #[test]
     fn deny_rules_override_allow_rules() {
         let config = config(&["unraid"], &["docker", "unraid.vm_reset"]);
         assert!(action_is_enabled(&config, "array"));

--- a/unraid-rs/src/mcp/tools.rs
+++ b/unraid-rs/src/mcp/tools.rs
@@ -10,7 +10,7 @@ use crate::token_limit::truncate_if_needed;
 use self::arg_helpers::{i64_arg, string_arg, string_array_arg, usize_arg};
 use self::paginate::paginate_array;
 use super::AppState;
-use super::tool_filter::{enabled_action_names, ensure_tool_call_enabled};
+use super::tool_filter::{action_is_enabled, enabled_action_names, ensure_tool_call_enabled};
 
 /// Typed outcome of a tool dispatch, used to *route* failures at the MCP protocol
 /// boundary without matching on message prose.
@@ -52,13 +52,18 @@ impl ToolError {
 /// Routing is by typed source: if the error chain contains an [`UpstreamError`]
 /// (produced by `graphql.rs`), classify by its variant and wrap the message with
 /// helpful, action-specific guidance. Anything else is an internal failure.
-fn classify_service_error(err: anyhow::Error, action: &str) -> ToolError {
+fn classify_service_error(err: anyhow::Error, action: &str, status_enabled: bool) -> ToolError {
+    let status_hint = if status_enabled {
+        "\nUse action=status to check server health."
+    } else {
+        ""
+    };
     match err.downcast_ref::<UpstreamError>() {
         Some(UpstreamError::Unreachable(msg)) => ToolError::UpstreamUnreachable(format!(
             "ERROR: {action} failed — upstream unreachable\n\
              Reason: {msg}\n\
-             Hint: check that UNRAID_API_URL is reachable and UNRAID_API_KEY is valid.\n\
-             Use action=status to check server health."
+             Hint: check that UNRAID_API_URL is reachable and UNRAID_API_KEY is valid.\
+             {status_hint}"
         )),
         Some(UpstreamError::Auth(msg)) => ToolError::UpstreamAuth(format!(
             "ERROR: {action} failed — API key rejected\n\
@@ -68,10 +73,17 @@ fn classify_service_error(err: anyhow::Error, action: &str) -> ToolError {
         Some(UpstreamError::Other(msg)) => ToolError::Upstream(format!(
             "ERROR: {action} failed\n\
              Reason: {msg}\n\
-             Hint: check UNRAID_API_URL and UNRAID_API_KEY. \
-             Use action=status to check server health."
+             Hint: check UNRAID_API_URL and UNRAID_API_KEY.{status_hint}"
         )),
         None => ToolError::Internal(err.context(format!("{action} failed"))),
+    }
+}
+
+fn enabled_action_hint<'a>(state: &AppState, action: &str, hint: &'a str) -> &'a str {
+    if action_is_enabled(&state.config.tools, action) {
+        hint
+    } else {
+        ""
     }
 }
 
@@ -97,11 +109,14 @@ pub(crate) async fn execute_tool(
 
     match name {
         "unraid" => dispatch(state, args).await,
-        _ => Err(ToolError::InvalidParams(format!(
-            "unknown tool: {name}\n\
-             Hint: the only supported tool is \"unraid\".\n\
-             Use action=help for documentation."
-        ))),
+        _ => {
+            let help_hint =
+                enabled_action_hint(state, "help", "\nUse action=help for documentation.");
+            Err(ToolError::InvalidParams(format!(
+                "unknown tool: {name}\n\
+                 Hint: the only supported tool is \"unraid\".{help_hint}"
+            )))
+        }
     }
 }
 
@@ -117,12 +132,20 @@ async fn dispatch(state: &AppState, args: Value) -> Result<Value, ToolError> {
     let action = match string_arg(&args, "action") {
         Some(a) => a,
         None => {
-            let valid = enabled_action_names(&state.config.tools).join(", ");
+            let enabled = enabled_action_names(&state.config.tools);
+            let valid = enabled.join(", ");
+            let example = enabled
+                .iter()
+                .copied()
+                .find(|action| *action != "help")
+                .or_else(|| enabled.first().copied())
+                .unwrap_or("help");
+            let help_hint =
+                enabled_action_hint(state, "help", "\nSee: action=help for full documentation.");
             return Err(ToolError::InvalidParams(format!(
                 "\"action\" is required.\n\
                  Valid actions: {valid}\n\
-                 Example: {{\"action\": \"docker\"}}\n\
-                 See: action=help for full documentation."
+                 Example: {{\"action\": \"{example}\"}}{help_hint}"
             )));
         }
     };
@@ -156,7 +179,7 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
             state.counters.inc_upstream();
             ($fut).await.map_err(|e| {
                 state.counters.inc_upstream_err();
-                classify_service_error(e, action)
+                classify_service_error(e, action, action_is_enabled(&state.config.tools, "status"))
             })
         }};
     }
@@ -181,12 +204,15 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
 
         "docker_logs" => {
             let id = string_arg(args, "id").ok_or_else(|| {
-                ToolError::InvalidParams(
-                    "\"id\" is required for action=docker_logs.\n\
-                     Hint: call action=docker first to list available container IDs.\n\
-                     Example: {\"action\": \"docker_logs\", \"id\": \"<container_id>\", \"tail\": 100}"
-                        .to_string(),
-                )
+                let lookup_hint = enabled_action_hint(
+                    state,
+                    "docker",
+                    "\nHint: call action=docker first to list available container IDs.",
+                );
+                ToolError::InvalidParams(format!(
+                    "\"id\" is required for action=docker_logs.{lookup_hint}\n\
+                     Example: {{\"action\": \"docker_logs\", \"id\": \"<container_id>\", \"tail\": 100}}"
+                ))
             })?;
             let tail = arg!(i64_arg(args, "tail"));
             svc!(state.service.docker_logs(&id, tail))
@@ -233,12 +259,15 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
 
         "log_file" => {
             let path = string_arg(args, "path").ok_or_else(|| {
-                ToolError::InvalidParams(
-                    "\"path\" is required for action=log_file.\n\
-                     Hint: call action=log_files first to list available log file paths.\n\
-                     Example: {\"action\": \"log_file\", \"path\": \"/var/log/syslog\", \"lines\": 100}"
-                        .to_string(),
-                )
+                let lookup_hint = enabled_action_hint(
+                    state,
+                    "log_files",
+                    "\nHint: call action=log_files first to list available log file paths.",
+                );
+                ToolError::InvalidParams(format!(
+                    "\"path\" is required for action=log_file.{lookup_hint}\n\
+                     Example: {{\"action\": \"log_file\", \"path\": \"/var/log/syslog\", \"lines\": 100}}"
+                ))
             })?;
             let lines = arg!(i64_arg(args, "lines"));
             let start_line = arg!(i64_arg(args, "start_line"));
@@ -1087,17 +1116,21 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
             }))
         }
 
-        "help" => Ok(json!({
-            "help": HELP_TEXT,
-            "enabled_actions": enabled_action_names(&state.config.tools),
-        })),
+        "help" => {
+            let enabled_actions = enabled_action_names(&state.config.tools);
+            Ok(json!({
+                "help": enabled_help_text(&enabled_actions),
+                "enabled_actions": enabled_actions,
+            }))
+        }
 
         other => {
             let valid = enabled_action_names(&state.config.tools).join(", ");
+            let help_hint =
+                enabled_action_hint(state, "help", "\nSee: action=help for full documentation.");
             Err(ToolError::InvalidParams(format!(
                 "unknown unraid action: \"{other}\"\n\
-                 Valid actions: {valid}\n\
-                 See: action=help for full documentation."
+                 Valid actions: {valid}{help_hint}"
             )))
         }
     }
@@ -1105,62 +1138,18 @@ async fn dispatch_action(state: &AppState, action: &str, args: &Value) -> Result
 
 // ── help text ─────────────────────────────────────────────────────────────────
 
-const HELP_TEXT: &str = r#"# unraid MCP Tool
-
-Read-only access to the Unraid server via its GraphQL API.
-Set the required `action` argument to select the operation.
-The response's `enabled_actions` list is authoritative when server policy filters actions.
-
-## Core
-- `array`          — Array state, disk health, parity, capacity
-- `disks`          — Physical disks with SMART status and temps
-- `docker`         — All Docker containers (supports limit, offset, state filter)
-- `docker_logs`    — Container logs (requires `id`, optional `tail`)
-                     Hint: call action=docker first to get a container id.
-- `vms`            — Virtual machines and state (supports limit, offset)
-- `server`         — Server identity, IPs, online status
-- `info`           — OS, CPU, memory, Unraid/kernel versions
-- `shares`         — User shares with sizes and cache settings (supports limit, offset, name filter)
-- `notifications`  — Active warnings/alerts and overview counts (supports limit, offset)
-
-## System
-- `services`       — Running system services and uptime (supports limit, offset)
-- `network`        — Network access URLs
-- `metrics`        — Live CPU, memory, and temperature readings
-- `vars`           — System configuration variables
-- `registration`   — License registration state and expiry
-- `flash`          — USB flash drive info
-
-## Logs
-- `log_files`      — List available log files with sizes (supports limit, offset)
-                     Hint: call this first to get valid paths for action=log_file.
-- `log_file`       — Read a log file (requires `path`, optional `lines`, `start_line`)
-
-## Storage
-- `parity_history` — All past parity check results (supports limit, offset)
-- `rclone`         — Backup remote configurations
-
-## UPS
-- `ups`            — UPS devices: battery, power, status (supports limit, offset)
-- `ups_config`     — UPS monitoring configuration
-
-## Remote access
-- `remote_access`  — WAN access type, port forwarding config
-- `connect`        — Unraid Connect dynamic remote access status
-
-## Plugins
-- `plugins`        — Installed community plugins with versions (supports limit, offset, name filter)
-
-## Observability
-- `status`         — Server runtime state, request counters, pid
-
-## Pagination (for list actions)
-Pass `limit` (default 50, max 200) and `offset` (default 0) to page through results.
-Response shape: {items, total, limit, offset, has_more, next_offset}
-
-## Meta
-- `help`           — This documentation
-"#;
+fn enabled_help_text(enabled_actions: &[&str]) -> String {
+    let actions = enabled_actions
+        .iter()
+        .map(|action| format!("- `{action}`"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "# unraid MCP Tool\n\nEnabled actions on this server:\n{actions}\n\n\
+         Use the tools/list schema for action parameters. Disabled actions are omitted from \
+         discovery and help."
+    )
+}
 
 #[cfg(test)]
 mod tests {
@@ -1189,7 +1178,7 @@ mod tests {
     #[test]
     fn classify_maps_unreachable_upstream_error() {
         let err = anyhow::Error::from(UpstreamError::Unreachable("nope".into()));
-        let classified = classify_service_error(err, "array");
+        let classified = classify_service_error(err, "array", true);
         assert!(matches!(classified, ToolError::UpstreamUnreachable(_)));
         assert!(!classified.is_invalid_params());
         // Helpful, action-specific message text is preserved.
@@ -1197,9 +1186,19 @@ mod tests {
     }
 
     #[test]
+    fn classify_omits_status_hint_when_status_is_disabled() {
+        let err = anyhow::Error::from(UpstreamError::Unreachable("nope".into()));
+        let classified = classify_service_error(err, "array", false);
+        assert!(
+            !classified.to_string().contains("action=status"),
+            "disabled status action must not be recommended"
+        );
+    }
+
+    #[test]
     fn classify_maps_auth_upstream_error() {
         let err = anyhow::Error::from(UpstreamError::Auth("rejected".into()));
-        let classified = classify_service_error(err, "disks");
+        let classified = classify_service_error(err, "disks", true);
         assert!(matches!(classified, ToolError::UpstreamAuth(_)));
         assert!(!classified.is_invalid_params());
         assert!(classified.to_string().contains("API key rejected"));
@@ -1208,7 +1207,7 @@ mod tests {
     #[test]
     fn classify_maps_other_upstream_error() {
         let err = anyhow::Error::from(UpstreamError::Other("HTTP 500".into()));
-        let classified = classify_service_error(err, "metrics");
+        let classified = classify_service_error(err, "metrics", true);
         assert!(matches!(classified, ToolError::Upstream(_)));
         assert!(!classified.is_invalid_params());
     }
@@ -1218,7 +1217,7 @@ mod tests {
         // An error with no UpstreamError in its chain is an internal failure, and
         // routes in-band (not invalid_params).
         let err = anyhow::anyhow!("some non-upstream failure");
-        let classified = classify_service_error(err, "info");
+        let classified = classify_service_error(err, "info", false);
         assert!(matches!(classified, ToolError::Internal(_)));
         assert!(!classified.is_invalid_params());
     }
@@ -1229,7 +1228,7 @@ mod tests {
         // it does not match on the top-level message.
         let err = anyhow::Error::from(UpstreamError::Auth("401".into()))
             .context("while fetching docker containers");
-        let classified = classify_service_error(err, "docker");
+        let classified = classify_service_error(err, "docker", true);
         assert!(matches!(classified, ToolError::UpstreamAuth(_)));
     }
 }

--- a/unraid-rs/tests/auth_modes.rs
+++ b/unraid-rs/tests/auth_modes.rs
@@ -395,6 +395,7 @@ async fn static_bearer_token_reaches_ordinary_write_dispatch() {
 async fn policy_disabled_action_rejects_authenticated_caller_with_policy_error() {
     let mut state = testing::bearer_state("admin-token");
     state.config.tools.disabled = vec!["vm_stop".into()];
+    let counters = state.counters.clone();
     let (status, value) = post_mcp(
         router(state),
         tool_call_body(serde_json::json!({
@@ -419,6 +420,10 @@ async fn policy_disabled_action_rejects_authenticated_caller_with_policy_error()
         !body.contains("upstream unreachable"),
         "policy-disabled action must not reach dispatch; got: {body}"
     );
+    let snapshot = counters.snapshot();
+    assert_eq!(snapshot.requests_total, 1);
+    assert_eq!(snapshot.errors_total, 1);
+    assert_eq!(snapshot.upstream_calls, 0);
 }
 
 /// Destructive writes still require MCP elicitation after bearer authorization.

--- a/unraid-rs/tests/oauth_flow.rs
+++ b/unraid-rs/tests/oauth_flow.rs
@@ -170,6 +170,7 @@ async fn jwt_with_wrong_issuer_returns_401() {
 async fn jwt_with_empty_scope_is_denied_at_scope_check() {
     let dir = TempDir::new().unwrap();
     let (state, auth_state) = testing::oauth_state_with_auth_state(dir.path()).await;
+    let counters = state.counters.clone();
     let token = auth_state
         .signing_keys
         .issue_access_token(&make_claims(&auth_state, "", 60))
@@ -191,6 +192,10 @@ async fn jwt_with_empty_scope_is_denied_at_scope_check() {
         msg.contains("forbidden") || msg.contains("scope"),
         "error message should mention 'forbidden' or 'scope'; got: {msg}"
     );
+    let snapshot = counters.snapshot();
+    assert_eq!(snapshot.requests_total, 1);
+    assert_eq!(snapshot.errors_total, 1);
+    assert_eq!(snapshot.upstream_calls, 0);
 }
 
 /// `tools/list` with valid JWT -> 200 and unraid tool present.

--- a/unraid-rs/tests/real_binary.rs
+++ b/unraid-rs/tests/real_binary.rs
@@ -79,8 +79,11 @@ async fn binary_renders_representative_actions() {
 /// Spawn `runraid mcp` with the given tool-policy env and expect a startup
 /// failure: non-zero exit and the config error on stderr.
 fn run_runraid_startup_failure(env: &[(&str, &str)]) -> String {
+    let home = tempfile::tempdir().unwrap();
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_runraid"));
     cmd.arg("mcp")
+        .env("HOME", home.path())
+        .env_remove("UNRAID_HOME")
         .env("UNRAID_API_URL", "http://localhost:1/graphql")
         .env("UNRAID_API_KEY", "test")
         .env_remove("UNRAID_RMCP_ENABLED_TOOLS")
@@ -124,34 +127,65 @@ fn binary_refuses_to_start_on_separator_only_tool_selector_value() {
     );
 }
 
-/// Unknown keys under `[mcp.tools]` are security-sensitive typos and must
-/// fail closed instead of silently leaving actions exposed.
-#[test]
-fn binary_refuses_unknown_mcp_tools_toml_keys() {
+fn run_runraid_config_failure(config: &str) -> String {
     let dir = tempfile::tempdir().unwrap();
-    std::fs::write(
-        dir.path().join("config.toml"),
-        "[mcp.tools]\ndisable = [\"vm_reset\"]\n",
-    )
-    .unwrap();
-
+    std::fs::write(dir.path().join("config.toml"), config).unwrap();
     let out = Command::new(env!("CARGO_BIN_EXE_runraid"))
         .arg("mcp")
         .current_dir(dir.path())
+        .env("UNRAID_HOME", dir.path())
         .env("UNRAID_API_URL", "http://localhost:1/graphql")
         .env("UNRAID_API_KEY", "test")
         .env_remove("UNRAID_RMCP_ENABLED_TOOLS")
         .env_remove("UNRAID_RMCP_DISABLED_TOOLS")
         .output()
         .expect("spawn runraid");
-    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
     assert!(
         !out.status.success(),
-        "runraid must reject unknown [mcp.tools] keys; stderr: {stderr}"
+        "runraid must reject config {config:?}; stderr: {stderr}"
     );
+    stderr
+}
+
+/// Unknown keys under `[mcp.tools]` are security-sensitive typos and must
+/// fail closed instead of silently leaving actions exposed.
+#[test]
+fn binary_refuses_unknown_mcp_tools_toml_keys() {
+    let stderr = run_runraid_config_failure("[mcp.tools]\ndisable = [\"vm_reset\"]\n");
     assert!(
         stderr.contains("unknown field") && stderr.contains("disable"),
         "parse error must identify the typo; got: {stderr}"
+    );
+}
+
+#[test]
+fn binary_refuses_misspelled_mcp_tools_table() {
+    let stderr = run_runraid_config_failure("[mcp.tool]\ndisabled = [\"vm_reset\"]\n");
+    assert!(
+        stderr.contains("unknown field") && stderr.contains("tool"),
+        "parse error must identify the misspelled table; got: {stderr}"
+    );
+}
+
+#[test]
+fn binary_refuses_malformed_dotenv_before_policy() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut contents = vec![0xff, b'\n'];
+    contents.extend_from_slice(b"UNRAID_RMCP_DISABLED_TOOLS=*\n");
+    std::fs::write(dir.path().join(".env"), contents).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_runraid"))
+        .arg("definitely-not-a-command")
+        .env("UNRAID_HOME", dir.path())
+        .env("UNRAID_API_URL", "http://localhost:1/graphql")
+        .env("UNRAID_API_KEY", "test")
+        .output()
+        .expect("spawn runraid");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success(), "malformed .env must fail closed");
+    assert!(
+        stderr.contains("failed to parse .env"),
+        "stderr must identify the malformed file; got: {stderr}"
     );
 }
 

--- a/unraid-rs/tests/real_binary.rs
+++ b/unraid-rs/tests/real_binary.rs
@@ -124,6 +124,37 @@ fn binary_refuses_to_start_on_separator_only_tool_selector_value() {
     );
 }
 
+/// Unknown keys under `[mcp.tools]` are security-sensitive typos and must
+/// fail closed instead of silently leaving actions exposed.
+#[test]
+fn binary_refuses_unknown_mcp_tools_toml_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("config.toml"),
+        "[mcp.tools]\ndisable = [\"vm_reset\"]\n",
+    )
+    .unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_runraid"))
+        .arg("mcp")
+        .current_dir(dir.path())
+        .env("UNRAID_API_URL", "http://localhost:1/graphql")
+        .env("UNRAID_API_KEY", "test")
+        .env_remove("UNRAID_RMCP_ENABLED_TOOLS")
+        .env_remove("UNRAID_RMCP_DISABLED_TOOLS")
+        .output()
+        .expect("spawn runraid");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "runraid must reject unknown [mcp.tools] keys; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("unknown field") && stderr.contains("disable"),
+        "parse error must identify the typo; got: {stderr}"
+    );
+}
+
 #[tokio::test]
 async fn binary_passes_id_argument() {
     let server = mock_server("healthy").await;

--- a/unraid-rs/tests/stdio_mcp.rs
+++ b/unraid-rs/tests/stdio_mcp.rs
@@ -10,7 +10,7 @@ use rmcp::{
     ClientHandler, ErrorData,
     model::{
         CallToolRequestParams, ClientCapabilities, ClientInfo, ElicitRequestParams, ElicitResult,
-        ElicitationAction, Implementation, ReadResourceRequestParams,
+        ElicitationAction, GetPromptRequestParams, Implementation, ReadResourceRequestParams,
     },
     service::{RequestContext, RoleClient, RunningService, ServiceExt},
     transport::{ConfigureCommandExt, TokioChildProcess},
@@ -66,6 +66,7 @@ where
             .env("UNRAID_API_KEY", "test")
             .env("UNRAID_RMCP_NO_AUTH", "true")
             .env("RUST_LOG", "warn")
+            .env_remove("UNRAID_HOME")
             .env_remove("UNRAID_RMCP_TOKEN")
             .env_remove("UNRAID_RMCP_ENABLED_TOOLS")
             .env_remove("UNRAID_RMCP_DISABLED_TOOLS");
@@ -259,10 +260,44 @@ async fn stdio_filters_advertised_actions_and_rejects_disabled_calls() {
         )
         .await
         .unwrap();
-    assert_eq!(
-        text_content_json(&help)["enabled_actions"],
-        json!(["status", "help"])
+    let help = text_content_json(&help);
+    assert_eq!(help["enabled_actions"], json!(["status", "help"]));
+    let filtered_help = help["help"].as_str().unwrap_or_default();
+    assert!(filtered_help.contains("`status`") && filtered_help.contains("`help`"));
+    assert!(
+        !filtered_help.contains("`array`"),
+        "primary help must not advertise a disabled action: {filtered_help}"
     );
+    assert!(
+        help.get("full_reference").is_none(),
+        "disabled action catalog must not be exposed through help"
+    );
+
+    let prompts = service.list_prompts(Default::default()).await.unwrap();
+    assert!(
+        prompts.prompts.is_empty(),
+        "server_summary must not be advertised when none of its data actions are enabled"
+    );
+    let prompt_error = service
+        .get_prompt(GetPromptRequestParams::new("server_summary"))
+        .await
+        .unwrap_err();
+    assert!(
+        prompt_error.to_string().contains("prompt unavailable"),
+        "disabled prompt error was: {prompt_error}"
+    );
+
+    let counters = service
+        .call_tool(
+            CallToolRequestParams::new("unraid")
+                .with_arguments(json!({"action": "status"}).as_object().unwrap().clone()),
+        )
+        .await
+        .unwrap();
+    let counters = text_content_json(&counters);
+    assert_eq!(counters["counters"]["requests_total"], 4);
+    assert_eq!(counters["counters"]["errors_total"], 1);
+    assert_eq!(counters["counters"]["upstream_calls"], 0);
 
     cancel_and_drain(service, stderr).await;
 }
@@ -305,7 +340,10 @@ async fn stdio_can_disable_the_entire_mcp_tool() {
 /// full canonical action enum. Breaking this bricks default plugin installs.
 #[tokio::test]
 async fn stdio_empty_policy_env_vars_expose_the_full_action_enum() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().to_string_lossy().into_owned();
     let (service, stderr) = stdio_client_with_env(&[
+        ("HOME", &home),
         ("UNRAID_RMCP_ENABLED_TOOLS", ""),
         ("UNRAID_RMCP_DISABLED_TOOLS", ""),
     ])
@@ -318,6 +356,103 @@ async fn stdio_empty_policy_env_vars_expose_the_full_action_enum() {
     assert_eq!(
         tool["inputSchema"]["properties"]["action"]["enum"],
         serde_json::to_value(unraid_rmcp::mcp::all_action_names()).unwrap()
+    );
+
+    cancel_and_drain(service, stderr).await;
+}
+
+#[tokio::test]
+async fn stdio_empty_plugin_values_inherit_dotenv_policy() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join(".env"),
+        "UNRAID_RMCP_ENABLED_TOOLS=status,help\n",
+    )
+    .unwrap();
+    let unraid_home = temp.path().to_string_lossy().into_owned();
+    let (service, stderr) = stdio_client_with_env(&[
+        ("UNRAID_HOME", &unraid_home),
+        ("UNRAID_RMCP_ENABLED_TOOLS", ""),
+        ("UNRAID_RMCP_DISABLED_TOOLS", ""),
+    ])
+    .await
+    .unwrap();
+
+    let tools = service.list_tools(Default::default()).await.unwrap();
+    let tool = serde_json::to_value(&tools.tools[0]).unwrap();
+    assert_eq!(
+        tool["inputSchema"]["properties"]["action"]["enum"],
+        json!(["status", "help"])
+    );
+
+    cancel_and_drain(service, stderr).await;
+}
+
+#[tokio::test]
+async fn stdio_prompt_mentions_only_enabled_summary_actions() {
+    let (service, stderr) =
+        stdio_client_with_env(&[("UNRAID_RMCP_ENABLED_TOOLS", "info,array,help")])
+            .await
+            .unwrap();
+
+    let prompts = service.list_prompts(Default::default()).await.unwrap();
+    assert_eq!(prompts.prompts.len(), 1);
+    assert_eq!(prompts.prompts[0].name, "server_summary");
+
+    let prompt = service
+        .get_prompt(GetPromptRequestParams::new("server_summary"))
+        .await
+        .unwrap();
+    let prompt = serde_json::to_string(&prompt).unwrap();
+    for enabled in ["action=info", "action=array"] {
+        assert!(
+            prompt.contains(enabled),
+            "prompt omitted {enabled}: {prompt}"
+        );
+    }
+    for disabled in [
+        "action=disks",
+        "action=vms",
+        "action=docker",
+        "action=notifications",
+    ] {
+        assert!(
+            !prompt.contains(disabled),
+            "prompt referenced disabled {disabled}: {prompt}"
+        );
+    }
+
+    cancel_and_drain(service, stderr).await;
+}
+
+#[tokio::test]
+async fn stdio_validation_guidance_respects_enabled_actions() {
+    let (service, stderr) = stdio_client_with_env(&[("UNRAID_RMCP_ENABLED_TOOLS", "status")])
+        .await
+        .unwrap();
+
+    let tools = service.list_tools(Default::default()).await.unwrap();
+    let tool = serde_json::to_value(&tools.tools[0]).unwrap();
+    assert!(
+        !tool["description"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("action=help"),
+        "tool description must not recommend disabled help: {tool}"
+    );
+
+    let error = service
+        .call_tool(CallToolRequestParams::new("unraid"))
+        .await
+        .unwrap_err();
+    let error = error.to_string();
+    assert!(
+        error.contains("Example") && error.contains("status"),
+        "missing-action error must use an enabled example: {error}"
+    );
+    assert!(
+        !error.contains("action=help") && !error.contains("docker"),
+        "missing-action error referenced a disabled action: {error}"
     );
 
     cancel_and_drain(service, stderr).await;

--- a/unraid-rs/tests/stdio_mcp.rs
+++ b/unraid-rs/tests/stdio_mcp.rs
@@ -212,6 +212,14 @@ async fn stdio_filters_advertised_actions_and_rejects_disabled_calls() {
         tool["inputSchema"]["properties"]["action"]["enum"],
         json!(["status", "help"])
     );
+    assert_eq!(
+        tool["inputSchema"]["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .collect::<Vec<_>>(),
+        vec!["action"]
+    );
 
     let status = service
         .call_tool(
@@ -250,6 +258,14 @@ async fn stdio_filters_advertised_actions_and_rejects_disabled_calls() {
     assert_eq!(
         schema[0]["inputSchema"]["properties"]["action"]["enum"],
         json!(["status", "help"])
+    );
+    assert_eq!(
+        schema[0]["inputSchema"]["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .collect::<Vec<_>>(),
+        vec!["action"]
     );
 
     // action=help reports the same filtered subset in enabled_actions.
@@ -383,6 +399,41 @@ async fn stdio_empty_plugin_values_inherit_dotenv_policy() {
     assert_eq!(
         tool["inputSchema"]["properties"]["action"]["enum"],
         json!(["status", "help"])
+    );
+
+    cancel_and_drain(service, stderr).await;
+}
+
+#[tokio::test]
+async fn stdio_nonempty_process_policy_overrides_dotenv_policy() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join(".env"),
+        "UNRAID_RMCP_ENABLED_TOOLS=status,help\n",
+    )
+    .unwrap();
+    let unraid_home = temp.path().to_string_lossy().into_owned();
+    let (service, stderr) = stdio_client_with_env(&[
+        ("UNRAID_HOME", &unraid_home),
+        ("UNRAID_RMCP_ENABLED_TOOLS", "docker_logs"),
+        ("UNRAID_RMCP_DISABLED_TOOLS", ""),
+    ])
+    .await
+    .unwrap();
+
+    let tools = service.list_tools(Default::default()).await.unwrap();
+    let tool = serde_json::to_value(&tools.tools[0]).unwrap();
+    assert_eq!(
+        tool["inputSchema"]["properties"]["action"]["enum"],
+        json!(["docker_logs"])
+    );
+    assert_eq!(
+        tool["inputSchema"]["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .collect::<Vec<_>>(),
+        vec!["action", "id", "tail"]
     );
 
     cancel_and_drain(service, stderr).await;

--- a/unraid-rs/xtask/src/main.rs
+++ b/unraid-rs/xtask/src/main.rs
@@ -111,6 +111,14 @@ fn check_env() -> anyhow::Result<()> {
 
     let optional = [
         ("UNRAID_RMCP_TOKEN", "Bearer token for MCP auth"),
+        (
+            "UNRAID_RMCP_ENABLED_TOOLS",
+            "MCP tool/action allowlist",
+        ),
+        (
+            "UNRAID_RMCP_DISABLED_TOOLS",
+            "MCP tool/action denylist",
+        ),
         ("RUST_LOG", "Log filter (default: info)"),
     ];
 


### PR DESCRIPTION
## Summary

- add granular MCP action allow/deny policy enforcement across discovery, resources, prompts, help, and execution
- fail closed on policy configuration typos and malformed persisted environment files
- minimize advertised schemas to enabled actions and their exact parameters
- add exhaustive selector, dispatcher/schema drift, auth, transport, plugin, and precedence coverage

## Validation

- cargo check --locked --all-targets --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features: 162 passed
- Unraid MCP runtime contracts passed
- MCP plugin web tests: 9 passed
- npm audit: 0 vulnerabilities
- formatting, JSON, TOML, README parity, and diff checks passed