### PR TITLE
feat(unraid-rs): trust a private CA, and verify update provenance

### DIFF
--- a/plugins/mcp/README.md
+++ b/plugins/mcp/README.md
@@ -62,6 +62,43 @@ selectors win.
   keys this plugin writes. To roll back to the old Python `.plg`, delete
   `/boot/config/plugins/unraid-mcp/.env` first and let the Python plugin
   re-bootstrap its config.
+- **Private CA / TLS**: the Python server overloaded `UNRAID_VERIFY_SSL` as
+  either a boolean *or* a path to a CA bundle. runraid splits those: booleans map
+  to `UNRAID_API_SKIP_TLS_VERIFY`, and a readable bundle path migrates to
+  `UNRAID_API_CA_BUNDLE` ("CA bundle path" in Settings), which keeps verification
+  **on** while trusting your CA. If the old value is neither a boolean nor a
+  readable file it cannot be migrated, and the service log says so at startup —
+  set the bundle path yourself rather than disabling verification.
+
+## Update integrity
+
+`Update` in Settings downloads the release binary and checks it three ways
+before installing:
+
+1. the co-uploaded `.sha256` (catches a corrupted or truncated download),
+2. **GitHub build provenance** — the binary's digest must have an attestation in
+   GitHub's attestation store naming this repo and `rust-release.yml` as its
+   builder, and
+3. the binary's own `--version` must match the tag.
+
+Step 2 matters because step 1 alone proves nothing about authenticity: the
+binary and its checksum are uploaded by the same job to the same release, so
+anyone able to replace one can replace both. Attestations live in a separate,
+GitHub-controlled store, are keyed by digest, and are minted by the
+OIDC-authenticated workflow run, so swapped release assets cannot produce a
+matching record.
+
+What this is **not**: the check confirms a provenance record exists and names
+the expected builder — it does not verify the Sigstore signature chain, which
+would require `cosign` or `gh` (neither ships with Unraid). It closes the
+swapped-asset hole, not a compromise of GitHub's attestation store itself.
+
+Releases published before provenance existed have no attestation and will be
+refused. Install one only if you have verified it another way:
+
+```bash
+UNRAID_MCP_SKIP_ATTESTATION=true unraid-mcp-update.sh update <version>
+```
 
 ## Build
 

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php
@@ -51,6 +51,7 @@ const ALLOWED_KEYS = [
     'UNRAID_API_URL',
     'UNRAID_API_KEY',
     'UNRAID_API_SKIP_TLS_VERIFY',
+    'UNRAID_API_CA_BUNDLE',
     'UNRAID_RMCP_HOST',
     'UNRAID_RMCP_PORT',
     'UNRAID_MCP_TAILSCALE_SERVE',
@@ -226,6 +227,13 @@ function is_true_value(string $value): bool
     return in_array(strtolower($value), ['1', 'true', 'yes'], true);
 }
 
+/** Whether a value is boolean-shaped at all. UNRAID_VERIFY_SSL was overloaded:
+ *  a boolean OR a CA bundle path, so the two cases must be told apart. */
+function is_bool_value(string $value): bool
+{
+    return in_array(strtolower($value), ['1', '0', 'true', 'false', 'yes', 'no'], true);
+}
+
 function validate_bool_value(array $env, string $key): void
 {
     $value = resolve_value($env, $key);
@@ -310,6 +318,18 @@ function validate_env(array $env): void
 
     foreach (['UNRAID_API_SKIP_TLS_VERIFY', 'UNRAID_MCP_TAILSCALE_SERVE', 'UNRAID_RMCP_DISABLE_HTTP_AUTH', 'UNRAID_NOAUTH'] as $key) {
         validate_bool_value($env, $key);
+    }
+
+    // runraid refuses to start on an unreadable bundle, so reject it here where
+    // the operator still sees a message instead of a service that won't come up.
+    $caBundle = resolve_value($env, 'UNRAID_API_CA_BUNDLE');
+    if ($caBundle !== '') {
+        if ($caBundle[0] !== '/') {
+            fail(400, 'UNRAID_API_CA_BUNDLE must be an absolute path to a PEM bundle');
+        }
+        if (!is_readable($caBundle)) {
+            fail(400, 'UNRAID_API_CA_BUNDLE is not readable: ' . $caBundle);
+        }
     }
 
     $logLevel = strtolower(resolve_value($env, 'RUST_LOG'));
@@ -442,6 +462,15 @@ function current_payload(): array
         if ($key === 'UNRAID_API_SKIP_TLS_VERIFY' && $value === '') {
             $value = (!is_true_value($env['UNRAID_VERIFY_SSL'] ?? 'true')
                 && is_true_value($env['UNRAID_ALLOW_INSECURE_TLS'] ?? 'false')) ? 'true' : 'false';
+        }
+        if ($key === 'UNRAID_API_CA_BUNDLE' && $value === '') {
+            // Mirror unraid-mcp-env.sh: the Python-era UNRAID_VERIFY_SSL doubled
+            // as a CA bundle path. Surface the migrated value so the field shows
+            // what the server is actually using, not a misleading blank.
+            $legacy = $env['UNRAID_VERIFY_SSL'] ?? '';
+            if ($legacy !== '' && !is_bool_value($legacy) && is_readable($legacy)) {
+                $value = $legacy;
+            }
         }
         if (in_array($key, ['UNRAID_API_SKIP_TLS_VERIFY', 'UNRAID_MCP_TAILSCALE_SERVE', 'UNRAID_RMCP_DISABLE_HTTP_AUTH', 'UNRAID_NOAUTH'], true)) {
             $value = is_true_value($value) ? 'true' : 'false';

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp
@@ -172,6 +172,23 @@ warn_legacy_oauth() {
     fi
 }
 
+# The Python server accepted a CA bundle PATH in UNRAID_VERIFY_SSL. env.sh
+# migrates a readable one onto UNRAID_API_CA_BUNDLE; anything else would leave
+# the server verifying against the system store only, which fails every request
+# against a private CA with no clue that a setting was dropped.
+warn_legacy_ca_bundle() {
+    local value="${UNRAID_VERIFY_SSL:-}"
+    [ -n "${value}" ] || return 0
+    case "${value}" in
+        true | True | TRUE | 1 | yes | false | False | FALSE | 0 | no) return 0 ;;
+    esac
+    if [ -r "${value}" ]; then
+        log "migrated legacy UNRAID_VERIFY_SSL CA bundle to UNRAID_API_CA_BUNDLE: ${value}"
+    else
+        log "WARNING: UNRAID_VERIFY_SSL is '${value}', which is neither a boolean nor a readable CA bundle; TLS will use the system trust store only. Set UNRAID_API_CA_BUNDLE to a readable PEM bundle if this server uses a private CA."
+    fi
+}
+
 start() {
     if is_running; then
         log "already running (pid $(cat "${PID_FILE}"))"
@@ -180,6 +197,7 @@ start() {
     validate_required_config || return 1
     prepare_appdata || return 1
     warn_legacy_oauth
+    warn_legacy_ca_bundle
 
     if [ -e "${OVERLAY_BIN}" ] && ! overlay_valid; then
         log "WARNING: ignoring unsafe overlay binary (must be a root-owned regular executable): ${OVERLAY_BIN}"

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
@@ -97,6 +97,23 @@ if [ -z "${UNRAID_API_SKIP_TLS_VERIFY:-}" ] \
     export UNRAID_API_SKIP_TLS_VERIFY="true"
 fi
 
+# The Python server also accepted a CA *bundle path* in UNRAID_VERIFY_SSL, which
+# is neither true nor false. Such an install has TLS working via a private CA;
+# dropping the value would have broken every GraphQL call with a bare
+# certificate error and no hint that a setting had been silently discarded.
+# runraid expresses the same intent as UNRAID_API_CA_BUNDLE.
+if [ -z "${UNRAID_API_CA_BUNDLE:-}" ] \
+    && [ -n "${UNRAID_VERIFY_SSL:-}" ] \
+    && ! unraid_mcp_is_true "${UNRAID_VERIFY_SSL}" \
+    && ! unraid_mcp_is_false "${UNRAID_VERIFY_SSL}"; then
+    # Only adopt a bundle that actually exists; an unreadable path is reported by
+    # rc.unraid-mcp at service start (this file is also sourced by config.php,
+    # which must stay quiet).
+    if [ -r "${UNRAID_VERIFY_SSL}" ]; then
+        export UNRAID_API_CA_BUNDLE="${UNRAID_VERIFY_SSL}"
+    fi
+fi
+
 # A legacy trusted-proxy opt-in is the equivalent explicit acknowledgement
 # required by runraid before allowing no-auth on a non-loopback bind.
 if unraid_mcp_is_true "${UNRAID_RMCP_DISABLE_HTTP_AUTH}" \

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
@@ -24,9 +24,72 @@ PREVIOUS_BIN="${OVERLAY_DIR}/runraid.previous"
 PREVIOUS_ABSENT="${OVERLAY_DIR}/runraid.previous.absent"
 REPO="dinglebear-ai/unraid"
 ASSET="runraid-linux-x86_64"
+RELEASE_WORKFLOW=".github/workflows/rust-release.yml"
+# Set UNRAID_MCP_SKIP_ATTESTATION=true only to install from a release predating
+# build provenance, and only when you have verified the binary another way.
+SKIP_ATTESTATION="${UNRAID_MCP_SKIP_ATTESTATION:-false}"
 
 array_mounted() {
     grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts
+}
+
+# Confirm GitHub holds a build-provenance attestation binding this exact digest
+# to this repo's release workflow.
+#
+# Why this is worth doing on top of the .sha256 check: the binary and its
+# checksum sidecar are uploaded by the same job to the same release, so anyone
+# able to overwrite one can overwrite both and the checksum still "passes". It
+# only ever proved the download was not corrupted in transit. Attestations live
+# in a separate GitHub-controlled store, are keyed by digest, and are minted by
+# the OIDC-authenticated workflow run — so replacing release assets cannot
+# produce a matching record.
+#
+# Scope, stated plainly: this checks that a provenance record EXISTS for the
+# digest and names the expected repo and workflow. It does not verify the
+# Sigstore signature chain — that needs cosign or gh, neither of which exists on
+# Unraid. It closes the "swapped release asset" hole, not a compromise of
+# GitHub's own attestation store.
+verify_attestation() {
+    local digest="$1" response payload decoded
+    response="$(curl -fsS -S \
+        -H 'Accept: application/vnd.github+json' \
+        "https://api.github.com/repos/${REPO}/attestations/sha256:${digest}" 2>&1)" || {
+        echo "error: no build provenance found for ${ASSET} (sha256:${digest})" >&2
+        echo "GitHub returned: ${response}" >&2
+        echo "A tampered or unattested binary looks exactly like this. Refusing to install." >&2
+        return 1
+    }
+
+    # Each attestation carries a base64 DSSE payload; decode and inspect the
+    # in-toto statement. sed/grep/base64 only — the plugin ships no jq or python.
+    payload="$(printf '%s' "${response}" | tr -d ' \n' \
+        | grep -o '"payload":"[A-Za-z0-9+/=]*"' \
+        | sed 's/.*"payload":"//; s/"$//' | head -n1)"
+    if [ -z "${payload}" ]; then
+        echo "error: provenance response for sha256:${digest} contained no attestation payload" >&2
+        return 1
+    fi
+
+    decoded="$(printf '%s' "${payload}" | base64 -d 2>/dev/null | tr -d ' \n')" || {
+        echo "error: could not decode the provenance payload for sha256:${digest}" >&2
+        return 1
+    }
+
+    # The statement must bind THIS digest, and name our repo and release
+    # workflow as the builder.
+    if ! printf '%s' "${decoded}" | grep -q "\"sha256\":\"${digest}\""; then
+        echo "error: provenance does not cover sha256:${digest}" >&2
+        return 1
+    fi
+    if ! printf '%s' "${decoded}" | grep -q "\"repository\":\"https://github.com/${REPO}\""; then
+        echo "error: provenance for sha256:${digest} was not produced by ${REPO}" >&2
+        return 1
+    fi
+    if ! printf '%s' "${decoded}" | grep -qF "\"path\":\"${RELEASE_WORKFLOW}\""; then
+        echo "error: provenance for sha256:${digest} did not come from ${RELEASE_WORKFLOW}" >&2
+        return 1
+    fi
+    echo "provenance verified: ${REPO} ${RELEASE_WORKFLOW} built sha256:${digest}" >&2
 }
 
 prepare_overlay_dir() {
@@ -171,6 +234,13 @@ do_update() {
         echo "expected: ${expected:-<missing>}" >&2
         echo "actual:   ${actual}" >&2
         exit 1
+    fi
+
+    # Independent of the co-uploaded checksum above; see verify_attestation.
+    if [ "${SKIP_ATTESTATION}" = "true" ]; then
+        echo "warning: UNRAID_MCP_SKIP_ATTESTATION=true — installing ${tag} without provenance verification" >&2
+    else
+        verify_attestation "${actual}" || exit 1
     fi
 
     chmod 755 "${candidate}"

--- a/plugins/mcp/tests/runtime-contract.sh
+++ b/plugins/mcp/tests/runtime-contract.sh
@@ -75,6 +75,42 @@ if ! grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts; then
     rm -f /tmp/unraid-mcp-reset.out /tmp/unraid-mcp-reset.err
 fi
 
+# The Python server overloaded UNRAID_VERIFY_SSL as boolean OR CA bundle path.
+# A readable path must migrate onto runraid's UNRAID_API_CA_BUNDLE; a boolean must
+# not, and an unreadable path must not invent a bundle.
+ca_tmp="$(mktemp -d)"
+mkdir -p "${ca_tmp}/appdata"
+printf '%s\n' '-----BEGIN CERTIFICATE-----' > "${ca_tmp}/ca.pem"
+run_env_case() {
+    # $1 = UNRAID_VERIFY_SSL value; echoes the resulting UNRAID_API_CA_BUNDLE
+    printf "UNRAID_VERIFY_SSL='%s'\n" "$1" >"${ca_tmp}/.env"
+    (
+        unset UNRAID_API_CA_BUNDLE UNRAID_VERIFY_SSL UNRAID_MCP_ENV_FILE
+        unset UNRAID_MCP_CONFIG_DIR UNRAID_MCP_APPDATA_DIR
+        export UNRAID_MCP_CONFIG_DIR="${ca_tmp}"
+        export UNRAID_MCP_APPDATA_DIR="${ca_tmp}/appdata"
+        # shellcheck source=/dev/null
+        source "$env_script" >/dev/null 2>&1
+        printf '%s' "${UNRAID_API_CA_BUNDLE:-}"
+    )
+}
+test "$(run_env_case "${ca_tmp}/ca.pem")" = "${ca_tmp}/ca.pem"
+test -z "$(run_env_case true)"
+test -z "$(run_env_case false)"
+test -z "$(run_env_case /nonexistent/ca.pem)"
+rm -rf "$ca_tmp"
+
+# An unmappable legacy value must be reported, not silently dropped.
+grep -Fq 'warn_legacy_ca_bundle' "$rc_script"
+grep -Fq 'UNRAID_API_CA_BUNDLE' "$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/include/config.php"
+grep -Fq 'UNRAID_API_CA_BUNDLE' "$plugin_dir/web/src/fields.ts"
+
+# The co-uploaded .sha256 only proves transit integrity; provenance must be
+# checked against GitHub's attestation store before a binary is installed.
+grep -Fq 'verify_attestation' "$update_script"
+grep -Fq 'attestations/sha256:' "$update_script"
+grep -Fq 'verify_attestation "${actual}" || exit 1' "$update_script"
+
 grep -Fq "curl -fsS --noproxy '*' --max-time 2" "$rc_script"
 grep -Fq 'TAILSCALE_PORT_FILE=' "$rc_script"
 grep -Fq 'validate_required_config || return 1' "$rc_script"

--- a/plugins/mcp/web/src/fields.ts
+++ b/plugins/mcp/web/src/fields.ts
@@ -42,6 +42,12 @@ export const SECTIONS: Section[] = [
         help: "Disable certificate verification for the Unraid API. Use only with a trusted private endpoint.",
         kind: "toggle",
       },
+      {
+        key: "UNRAID_API_CA_BUNDLE",
+        label: "CA bundle path",
+        help: "Path to a PEM bundle to trust for the Unraid API, e.g. /boot/config/ssl/certs/ca.pem. Prefer this over skipping verification for a private CA.",
+        kind: "text",
+      },
     ],
   },
   {

--- a/unraid-rs/.env.example
+++ b/unraid-rs/.env.example
@@ -24,6 +24,11 @@ UNRAID_RMCP_PORT=40010
 # Optional: skip TLS verification for self-signed certs (not recommended)
 # UNRAID_API_SKIP_TLS_VERIFY=true
 
+# Optional: trust a private CA instead of disabling verification. Preferred over
+# the flag above — the connection stays verified. Startup fails if the path is
+# unreadable or is not a PEM bundle.
+# UNRAID_API_CA_BUNDLE=/boot/config/ssl/certs/ca.pem
+
 # Logging
 # RUST_LOG=info
 

--- a/unraid-rs/CLAUDE.md
+++ b/unraid-rs/CLAUDE.md
@@ -51,6 +51,7 @@
 UNRAID_API_URL                Unraid GraphQL endpoint (required)
 UNRAID_API_KEY                API key for x-api-key header (required)
 UNRAID_API_SKIP_TLS_VERIFY    Skip TLS cert check (default false)
+UNRAID_API_CA_BUNDLE          PEM CA bundle to trust; verifies instead of skipping
 UNRAID_HOME                   Exact data directory; overrides /data or ~/.unraid
 UNRAID_RMCP_HOST               Bind host (default 0.0.0.0)
 UNRAID_RMCP_PORT               Bind port (default 40010)

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -343,6 +343,7 @@ inherit persisted `.env` values instead of clearing them. A present but malforme
 | `UNRAID_API_URL` | unset | Full Unraid GraphQL endpoint URL. |
 | `UNRAID_API_KEY` | unset | API key for the `x-api-key` header. |
 | `UNRAID_API_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification for self-signed endpoints. |
+| `UNRAID_API_CA_BUNDLE` | _(unset)_ | Path to a PEM CA bundle to trust. Prefer this over skipping verification for a private CA; startup fails if the file is unreadable or not a PEM bundle. |
 | `UNRAID_HOME` | platform default | Exact data directory for `.env`, auth DB, and JWT key; overrides `/data` or `~/.unraid`. |
 | `UNRAID_RMCP_HOST` | `0.0.0.0` | HTTP bind host. |
 | `UNRAID_RMCP_PORT` | `40010` | HTTP bind port. |
@@ -499,7 +500,7 @@ gateway.
 | Symptom | Check |
 |---|---|
 | `UNRAID_API_URL` or `UNRAID_API_KEY` is missing | Set it in env or `~/.unraid/.env`. |
-| TLS errors against Unraid | Set `UNRAID_API_SKIP_TLS_VERIFY=true` only for self-signed endpoints. |
+| TLS errors against Unraid | Point `UNRAID_API_CA_BUNDLE` at your CA's PEM bundle to keep verification on. Use `UNRAID_API_SKIP_TLS_VERIFY=true` only when you have no bundle. |
 | HTTP `/mcp` returns unauthorized | Set `UNRAID_RMCP_TOKEN` and send `Authorization: Bearer <token>`. |
 | Stdio client hangs or logs JSON errors | Ensure client config runs `unraid-rmcp mcp`, not the default HTTP server mode. |
 | Large list response is truncated | Use `limit`, `offset`, `name`, or `state` filters on MCP list actions. |

--- a/unraid-rs/config.toml
+++ b/unraid-rs/config.toml
@@ -7,6 +7,9 @@
 # Override with UNRAID_API_SKIP_TLS_VERIFY=true in .env if the server
 # uses a self-signed certificate.
 skip_tls_verify = false
+# For a private CA, prefer trusting its bundle over disabling verification:
+# set UNRAID_API_CA_BUNDLE=/path/to/ca.pem (or ca_bundle here).
+# ca_bundle = "/boot/config/ssl/certs/ca.pem"
 
 [mcp]
 host = "0.0.0.0"

--- a/unraid-rs/src/config.rs
+++ b/unraid-rs/src/config.rs
@@ -19,6 +19,13 @@ pub struct UnraidConfig {
     pub api_key: String,
     /// Skip TLS certificate verification (UNRAID_API_SKIP_TLS_VERIFY)
     pub skip_tls_verify: bool,
+    /// Path to an extra PEM CA bundle to trust (UNRAID_API_CA_BUNDLE).
+    ///
+    /// This is the verifying counterpart to `skip_tls_verify`: it lets a
+    /// self-signed or private-CA endpoint be trusted *without* disabling
+    /// verification. The Python server accepted a bundle path in
+    /// `UNRAID_VERIFY_SSL`, so upgraded plugin installs migrate onto this key.
+    pub ca_bundle: Option<String>,
 }
 
 /// MCP HTTP server configuration
@@ -317,6 +324,7 @@ impl Config {
             "UNRAID_API_SKIP_TLS_VERIFY",
             &mut config.unraid.skip_tls_verify,
         )?;
+        env_opt_str("UNRAID_API_CA_BUNDLE", &mut config.unraid.ca_bundle);
 
         // Honour UNRAID_RMCP_DISABLE_HTTP_AUTH from the existing .env
         if std::env::var("UNRAID_RMCP_DISABLE_HTTP_AUTH")

--- a/unraid-rs/src/graphql.rs
+++ b/unraid-rs/src/graphql.rs
@@ -96,11 +96,29 @@ impl UnraidClient {
                  attackers. Only use this for self-signed certificates on a trusted network."
             );
         }
-        let client = reqwest::ClientBuilder::new()
+        let mut builder = reqwest::ClientBuilder::new()
             .danger_accept_invalid_certs(cfg.skip_tls_verify)
-            .connect_timeout(Duration::from_secs(5))
-            .build()
-            .context("failed to build HTTP client")?;
+            .connect_timeout(Duration::from_secs(5));
+        // A private-CA endpoint should be *verified against that CA*, not waved
+        // through with skip_tls_verify. Every failure here is fatal: silently
+        // falling back to the system roots would turn a deliberate trust
+        // decision into an unexplained connection error at first request.
+        if let Some(path) = cfg.ca_bundle.as_deref() {
+            let pem = std::fs::read(path)
+                .with_context(|| format!("failed to read UNRAID_API_CA_BUNDLE at {path}"))?;
+            let certs = reqwest::Certificate::from_pem_bundle(&pem).with_context(|| {
+                format!("UNRAID_API_CA_BUNDLE at {path} is not a valid PEM certificate bundle")
+            })?;
+            if certs.is_empty() {
+                anyhow::bail!("UNRAID_API_CA_BUNDLE at {path} contains no certificates");
+            }
+            let count = certs.len();
+            for cert in certs {
+                builder = builder.add_root_certificate(cert);
+            }
+            tracing::info!(path, count, "trusting extra CA certificates from bundle");
+        }
+        let client = builder.build().context("failed to build HTTP client")?;
         Ok(Self {
             client,
             url: cfg.api_url.clone(),
@@ -1658,5 +1676,74 @@ impl UnraidClient {
         use cynic::QueryBuilder;
         self.run_typed(crate::gql_typed::ConnectReadQuery::build(()))
             .await
+    }
+}
+
+#[cfg(test)]
+mod ca_bundle_tests {
+    use super::*;
+
+    fn cfg(ca_bundle: Option<&str>) -> UnraidConfig {
+        UnraidConfig {
+            api_url: "http://localhost:1/graphql".into(),
+            api_key: "k".into(),
+            skip_tls_verify: false,
+            ca_bundle: ca_bundle.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn no_bundle_builds_a_client() {
+        assert!(UnraidClient::new(&cfg(None)).is_ok());
+    }
+
+    // Each of these must be fatal: falling back to the system roots would turn a
+    // deliberate private-CA trust decision into a confusing per-request failure.
+    #[test]
+    fn missing_bundle_file_is_fatal() {
+        let err = UnraidClient::new(&cfg(Some("/nonexistent/ca.pem")))
+            .err()
+            .expect("a missing bundle must fail");
+        assert!(
+            err.to_string()
+                .contains("failed to read UNRAID_API_CA_BUNDLE"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn non_pem_bundle_is_fatal() {
+        let dir = std::env::temp_dir().join("unraid-ca-bundle-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("garbage.pem");
+        std::fs::write(&path, b"definitely not a certificate").unwrap();
+        let err = UnraidClient::new(&cfg(Some(path.to_str().unwrap())))
+            .err()
+            .expect("an invalid bundle must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("valid PEM certificate bundle")
+                || msg.contains("contains no certificates"),
+            "unexpected error: {msg}"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn empty_file_is_fatal() {
+        let dir = std::env::temp_dir().join("unraid-ca-bundle-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("empty.pem");
+        std::fs::write(&path, b"").unwrap();
+        let err = UnraidClient::new(&cfg(Some(path.to_str().unwrap())))
+            .err()
+            .expect("an invalid bundle must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("contains no certificates")
+                || msg.contains("valid PEM certificate bundle"),
+            "unexpected error: {msg}"
+        );
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/unraid-rs/src/lib.rs
+++ b/unraid-rs/src/lib.rs
@@ -35,6 +35,7 @@ pub mod testing {
             api_url: "http://localhost:1/graphql".into(),
             api_key: "test".into(),
             skip_tls_verify: true,
+            ca_bundle: None,
         })
         .expect("stub client should build");
         UnraidService::new(client)
@@ -139,6 +140,7 @@ pub mod testing {
             api_url: url.to_string(),
             api_key: "test".into(),
             skip_tls_verify: true,
+            ca_bundle: None,
         })
         .expect("stub client should build");
         AppState {

--- a/unraid-rs/tests/cynic_spike.rs
+++ b/unraid-rs/tests/cynic_spike.rs
@@ -33,6 +33,7 @@ async fn healthy_client() -> (MockServer, UnraidClient) {
         api_url: server.uri(),
         api_key: "test".into(),
         skip_tls_verify: true,
+        ca_bundle: None,
     })
     .unwrap();
     (server, client)

--- a/unraid-rs/xtask/src/main.rs
+++ b/unraid-rs/xtask/src/main.rs
@@ -111,14 +111,8 @@ fn check_env() -> anyhow::Result<()> {
 
     let optional = [
         ("UNRAID_RMCP_TOKEN", "Bearer token for MCP auth"),
-        (
-            "UNRAID_RMCP_ENABLED_TOOLS",
-            "MCP tool/action allowlist",
-        ),
-        (
-            "UNRAID_RMCP_DISABLED_TOOLS",
-            "MCP tool/action denylist",
-        ),
+        ("UNRAID_RMCP_ENABLED_TOOLS", "MCP tool/action allowlist"),
+        ("UNRAID_RMCP_DISABLED_TOOLS", "MCP tool/action denylist"),
         ("RUST_LOG", "Log filter (default: info)"),
     ];
 


### PR DESCRIPTION
Closes the last two follow-ups from the #343 review (bead `unraid-mcp-i7a`).

## 1. `UNRAID_API_CA_BUNDLE` — a private CA can be trusted, not just ignored

The Python server overloaded `UNRAID_VERIFY_SSL` as **either** a boolean **or** a path to a CA bundle. runraid had no equivalent for the path case — only the boolean `UNRAID_API_SKIP_TLS_VERIFY` (there is no `add_root_certificate` anywhere in `unraid-rs/src`). So an upgraded box pointing at a private CA had that setting silently discarded and every GraphQL call failed TLS, with nothing saying a value had been dropped.

- New `UNRAID_API_CA_BUNDLE` (config `[unraid].ca_bundle`), wired into the reqwest client via `Certificate::from_pem_bundle` + `add_root_certificate`. Verification stays **on**.
- Every failure is fatal — missing file, non-PEM, empty bundle. Falling back to the system roots would turn a deliberate trust decision into an unexplained per-request error later.
- `unraid-mcp-env.sh` migrates a *readable* legacy path onto the new key; booleans keep going to `UNRAID_API_SKIP_TLS_VERIFY`; `rc.unraid-mcp` logs a value that can't be migrated instead of dropping it.
- Settings UI exposes it ("CA bundle path") with absolute-path + readability validation, so a bad value is a 400 rather than a service that won't start. `current_payload` surfaces the migrated legacy value so the field isn't misleadingly blank.

## 2. Update provenance verification

The updater checked only the `.sha256` uploaded **by the same job to the same release**. Anyone able to replace the binary could replace its checksum too — it proved the download wasn't corrupted in transit, not that it was authentic.

`unraid-mcp-update.sh` now also requires a **GitHub build-provenance attestation** for the downloaded digest, naming this repo and `rust-release.yml` as builder. Attestations live in a separate GitHub-controlled store, are keyed by digest, and are minted by the OIDC-authenticated workflow run — so swapped release assets cannot produce a matching record. Parsed with `curl`/`sed`/`base64` only; the plugin deliberately ships no `jq` or `python`.

**Scope, stated honestly in the README rather than oversold:** this proves a provenance record *exists* and names the expected builder. It does not verify the Sigstore signature chain — that needs `cosign` or `gh`, neither of which exists on Unraid. It closes the swapped-asset hole, not a compromise of GitHub's attestation store. `UNRAID_MCP_SKIP_ATTESTATION=true` is the documented escape hatch for pre-provenance releases.

## Second commit

`style(unraid-rs): rustfmt the xtask env table` — the rows added in #358 landed unformatted, so `cargo fmt --check` (and rust-ci's Formatting job) **currently fails on main for every branch**. Split into its own commit since it's unrelated to this feature.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets --features test-support -- -D warnings`, full `cargo test` — all green, zero failures
- [x] 4 new `ca_bundle_tests`: builds without a bundle; missing file, non-PEM, and empty bundle each fatal with a distinct message
- [x] 4 new behavioral cases in `runtime-contract.sh` driving the real `unraid-mcp-env.sh`: readable path migrates, `true`/`false` do not, unreadable path does not invent a bundle
- [x] Attestation logic exercised against the **live** GitHub API: the published `unraid-rs-v0.4.2` binary digest verifies (repo + workflow matched); a tampered digest is refused (404, no payload)
- [x] `php -l`, `bash -n`, `shellcheck -S warning`, `ca-metadata.sh`, web typecheck + 9 web tests