### PR TITLE
fix(release): restore primary latest after component releases

### DIFF
--- a/.github/scripts/ensure_primary_latest.py
+++ b/.github/scripts/ensure_primary_latest.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Restore the newest primary Unraid MCP release as repository Latest.
+
+Component releases (Rust, Incus, and Codex) must never become the repository-wide
+Latest release because legacy Python-era plugin manifests resolve their update
+metadata through releases/latest. The primary lane uses unprefixed vX.Y.Z tags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+PRIMARY_TAG_RE = re.compile(r"^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
+
+
+class LatestReleaseError(RuntimeError):
+    """Raised when the primary release cannot be selected or restored."""
+
+
+def semver_key(tag: str) -> tuple[int, int, int]:
+    match = PRIMARY_TAG_RE.fullmatch(tag)
+    if not match:
+        raise ValueError(f"not a primary release tag: {tag}")
+    return tuple(int(match.group(part)) for part in ("major", "minor", "patch"))
+
+
+def select_primary_release(releases: list[dict[str, Any]]) -> dict[str, Any]:
+    candidates = [
+        release
+        for release in releases
+        if release.get("draft") is False
+        and release.get("prerelease") is False
+        and isinstance(release.get("tag_name"), str)
+        and PRIMARY_TAG_RE.fullmatch(release["tag_name"])
+    ]
+    if not candidates:
+        raise LatestReleaseError("no published primary vX.Y.Z release exists")
+    return max(candidates, key=lambda release: semver_key(release["tag_name"]))
+
+
+def gh_json(*args: str, input_text: str | None = None) -> Any:
+    result = subprocess.run(
+        ["gh", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        input=input_text,
+    )
+    return json.loads(result.stdout)
+
+
+def list_releases(repo: str) -> list[dict[str, Any]]:
+    releases: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        batch = gh_json("api", f"repos/{repo}/releases?per_page=100&page={page}")
+        if not isinstance(batch, list):
+            raise LatestReleaseError("GitHub releases API returned a non-list payload")
+        releases.extend(batch)
+        if len(batch) < 100:
+            return releases
+        page += 1
+
+
+def patch_make_latest(repo: str, release_id: int, value: bool) -> None:
+    payload = json.dumps({"make_latest": "true" if value else "false"})
+    subprocess.run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "PATCH",
+            f"repos/{repo}/releases/{release_id}",
+            "--input",
+            "-",
+        ],
+        check=True,
+        text=True,
+        input=payload,
+        stdout=subprocess.DEVNULL,
+    )
+
+
+def write_github_output(tag: str, release_id: int) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as output:
+        output.write(f"tag={tag}\nrelease_id={release_id}\n")
+
+
+def restore_primary_latest(
+    repo: str,
+    current_tag: str,
+    *,
+    retries: int = 10,
+    delay_seconds: float = 1.0,
+) -> dict[str, Any]:
+    current = gh_json("api", f"repos/{repo}/releases/tags/{current_tag}")
+    if not isinstance(current, dict) or not isinstance(current.get("id"), int):
+        raise LatestReleaseError(f"could not resolve current release {current_tag}")
+
+    primary = select_primary_release(list_releases(repo))
+    primary_id = primary.get("id")
+    primary_tag = primary.get("tag_name")
+    if not isinstance(primary_id, int) or not isinstance(primary_tag, str):
+        raise LatestReleaseError("selected primary release is missing id or tag_name")
+
+    patch_make_latest(repo, primary_id, True)
+    if current["id"] != primary_id:
+        patch_make_latest(repo, current["id"], False)
+
+    for attempt in range(1, retries + 1):
+        latest = gh_json("api", f"repos/{repo}/releases/latest")
+        if isinstance(latest, dict) and latest.get("tag_name") == primary_tag:
+            write_github_output(primary_tag, primary_id)
+            print(
+                f"restored primary Latest release: {primary_tag} "
+                f"(release id {primary_id})"
+            )
+            return primary
+        if attempt < retries:
+            time.sleep(delay_seconds)
+
+    observed = gh_json("api", f"repos/{repo}/releases/latest")
+    observed_tag = observed.get("tag_name") if isinstance(observed, dict) else observed
+    raise LatestReleaseError(
+        f"Latest release did not converge to {primary_tag}; observed {observed_tag!r}"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "current_tag", help="component release tag that triggered the workflow"
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="owner/repo (default: GITHUB_REPOSITORY)",
+    )
+    parser.add_argument("--retries", type=int, default=10)
+    parser.add_argument("--delay", type=float, default=1.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.repo:
+        print("error: --repo or GITHUB_REPOSITORY is required", file=sys.stderr)
+        return 2
+    if args.retries < 1 or args.delay < 0:
+        print("error: retries must be positive and delay non-negative", file=sys.stderr)
+        return 2
+    try:
+        restore_primary_latest(
+            args.repo,
+            args.current_tag,
+            retries=args.retries,
+            delay_seconds=args.delay,
+        )
+    except (
+        LatestReleaseError,
+        subprocess.CalledProcessError,
+        json.JSONDecodeError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release_contract.py
+++ b/.github/scripts/release_contract.py
@@ -142,7 +142,8 @@ def validate_release_please(repo_root: Path, errors: list[str]) -> list[ReleaseU
     tag_prefixes = {"unraid-py": "v", "unraid-rs": "unraid-rs-v"}
     assert_true(
         python_server.get("version") == versions["unraid-py"]
-        and python_server.get("packages", [{}])[0].get("version") == versions["unraid-py"],
+        and python_server.get("packages", [{}])[0].get("version")
+        == versions["unraid-py"],
         "Unraid Python Registry manifest versions must match pyproject.toml",
         errors,
     )
@@ -173,7 +174,10 @@ def validate_release_please(repo_root: Path, errors: list[str]) -> list[ReleaseU
         errors,
     )
     assert_true(
-        all(not (isinstance(spec, dict) and "git" in spec) for spec in rust_dependencies.values()),
+        all(
+            not (isinstance(spec, dict) and "git" in spec)
+            for spec in rust_dependencies.values()
+        ),
         "unraid-rmcp dependencies must not use Git sources",
         errors,
     )
@@ -228,7 +232,7 @@ def validate_release_please(repo_root: Path, errors: list[str]) -> list[ReleaseU
         and 'curl -A "$CRATES_IO_USER_AGENT"' in workflow_text
         and "cargo publish --package lab-auth" in workflow_text
         and "cargo publish --package unraid-rmcp" in workflow_text
-        and "crgx \"unraid-rmcp@${VERSION}\" -- --version" in workflow_text,
+        and 'crgx "unraid-rmcp@${VERSION}" -- --version' in workflow_text,
         "crates.io workflow must publish both crates, identify API polling, and smoke CRGX",
         errors,
     )
@@ -337,10 +341,49 @@ def validate_plugins(repo_root: Path, errors: list[str]) -> list[ReleaseUnit]:
     return units
 
 
+def validate_primary_latest_workflows(repo_root: Path, errors: list[str]) -> None:
+    helper = repo_root / ".github/scripts/ensure_primary_latest.py"
+    assert_true(
+        helper.is_file(),
+        "component release workflows require ensure_primary_latest.py",
+        errors,
+    )
+
+    expected_invocations = {
+        "codex-release.yml": 'python3 ../../.github/scripts/ensure_primary_latest.py "$TAG"',
+        "incus-release.yml": 'python3 ../../.github/scripts/ensure_primary_latest.py "$TAG"',
+        "rust-release.yml": 'python3 ../.github/scripts/ensure_primary_latest.py "$TAG"',
+    }
+    for workflow_name, invocation in expected_invocations.items():
+        workflow = repo_root / ".github/workflows" / workflow_name
+        text = workflow.read_text(encoding="utf-8") if workflow.exists() else ""
+        assert_true(
+            invocation in text,
+            f"{workflow_name} must restore the primary Unraid MCP Latest release",
+            errors,
+        )
+        assert_true(
+            "-f make_latest=false" not in text,
+            f"{workflow_name} must not rely on demoting only the component release",
+            errors,
+        )
+
+    rust_workflow = (repo_root / ".github/workflows/rust-release.yml").read_text(
+        encoding="utf-8"
+    )
+    assert_true(
+        "steps.primary-release.outputs.tag" in rust_workflow
+        and 'gh release upload "$PRIMARY_TAG"' in rust_workflow,
+        "rust-release.yml must bridge the plugin manifest to the verified primary tag",
+        errors,
+    )
+
+
 def validate(repo_root: Path) -> tuple[list[str], list[ReleaseUnit]]:
     errors: list[str] = []
     units = validate_release_please(repo_root, errors)
     units.extend(validate_plugins(repo_root, errors))
+    validate_primary_latest_workflows(repo_root, errors)
     return errors, units
 
 

--- a/.github/scripts/tests/test_release_tools.py
+++ b/.github/scripts/tests/test_release_tools.py
@@ -6,10 +6,12 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
+import ensure_primary_latest  # noqa: E402
 import plugin_calver  # noqa: E402
 import release_contract  # noqa: E402
 import release_pr_fixup  # noqa: E402
@@ -47,7 +49,7 @@ class PluginCalverTests(unittest.TestCase):
             path.write_text(
                 '<!ENTITY name "demo">\n'
                 '<!ENTITY version "2026.7.24"> '
-                '<!-- x-release-please-version -->\n',
+                "<!-- x-release-please-version -->\n",
                 encoding="utf-8",
             )
             plugin_calver.update_plugin_version(path, "20260726.001")
@@ -79,6 +81,102 @@ class ReleaseContractTests(unittest.TestCase):
         )
 
 
+class PrimaryLatestTests(unittest.TestCase):
+    def test_selects_highest_numeric_primary_semver(self):
+        selected = ensure_primary_latest.select_primary_release(
+            [
+                {
+                    "id": 1,
+                    "tag_name": "unraid-rs-v9.0.0",
+                    "draft": False,
+                    "prerelease": False,
+                },
+                {
+                    "id": 2,
+                    "tag_name": "v2.9.9",
+                    "draft": False,
+                    "prerelease": False,
+                },
+                {
+                    "id": 3,
+                    "tag_name": "v2.10.1",
+                    "draft": False,
+                    "prerelease": False,
+                },
+                {
+                    "id": 4,
+                    "tag_name": "v9.0.0",
+                    "draft": True,
+                    "prerelease": False,
+                },
+                {
+                    "id": 5,
+                    "tag_name": "v3.0.0",
+                    "draft": False,
+                    "prerelease": True,
+                },
+            ]
+        )
+        self.assertEqual(selected["id"], 3)
+        self.assertEqual(selected["tag_name"], "v2.10.1")
+
+    def test_rejects_missing_primary_release(self):
+        with self.assertRaisesRegex(
+            ensure_primary_latest.LatestReleaseError,
+            "no published primary",
+        ):
+            ensure_primary_latest.select_primary_release(
+                [
+                    {
+                        "id": 1,
+                        "tag_name": "codex-v20260805.001",
+                        "draft": False,
+                        "prerelease": False,
+                    }
+                ]
+            )
+
+    def test_promotes_primary_before_demoting_component(self):
+        primary = {
+            "id": 20,
+            "tag_name": "v2.10.1",
+            "draft": False,
+            "prerelease": False,
+        }
+        with (
+            mock.patch.object(
+                ensure_primary_latest,
+                "gh_json",
+                side_effect=[{"id": 10}, {"tag_name": "v2.10.1"}],
+            ),
+            mock.patch.object(
+                ensure_primary_latest,
+                "list_releases",
+                return_value=[primary],
+            ),
+            mock.patch.object(
+                ensure_primary_latest,
+                "patch_make_latest",
+            ) as patch_latest,
+            mock.patch.object(ensure_primary_latest, "write_github_output"),
+            mock.patch("builtins.print"),
+        ):
+            selected = ensure_primary_latest.restore_primary_latest(
+                "dinglebear-ai/unraid",
+                "codex-v20260805.001",
+                delay_seconds=0,
+            )
+
+        self.assertEqual(selected, primary)
+        self.assertEqual(
+            patch_latest.call_args_list,
+            [
+                mock.call("dinglebear-ai/unraid", 20, True),
+                mock.call("dinglebear-ai/unraid", 10, False),
+            ],
+        )
+
+
 class ReleasePrFixupTests(unittest.TestCase):
     def test_restores_compatibility_crate_and_npm_distribution(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -89,25 +187,19 @@ class ReleasePrFixupTests(unittest.TestCase):
                 encoding="utf-8",
             )
             (root / "unraid-rs/Cargo.toml").write_text(
-                '[package]\n'
+                "[package]\n"
                 'name = "unraid-rmcp"\n'
                 'version = "0.3.0"\n'
-                '[dependencies]\n'
+                "[dependencies]\n"
                 'lab-auth = { version = "0.3.0", path = "crates/lab-auth" }\n',
                 encoding="utf-8",
             )
             (root / "unraid-rs/crates/lab-auth/Cargo.toml").write_text(
-                '[package]\n'
-                'name = "lab-auth"\n'
-                'version = "0.3.0"\n'
-                'license = "MIT"\n',
+                '[package]\nname = "lab-auth"\nversion = "0.3.0"\nlicense = "MIT"\n',
                 encoding="utf-8",
             )
             (root / "unraid-rs/Cargo.lock").write_text(
-                'version = 4\n\n'
-                '[[package]]\n'
-                'name = "lab-auth"\n'
-                'version = "0.3.0"\n',
+                'version = 4\n\n[[package]]\nname = "lab-auth"\nversion = "0.3.0"\n',
                 encoding="utf-8",
             )
             (root / "unraid-rs/server.json").write_text(
@@ -115,9 +207,7 @@ class ReleasePrFixupTests(unittest.TestCase):
                     {
                         "_meta": {
                             "io.modelcontextprotocol.registry/publisher-provided": {
-                                "distribution": {
-                                    "npm": "@dinglebear/unraid@0.2.5"
-                                }
+                                "distribution": {"npm": "@dinglebear/unraid@0.2.5"}
                             }
                         }
                     }
@@ -149,9 +239,9 @@ class ReleasePrFixupTests(unittest.TestCase):
             )
             server = json.loads((root / "unraid-rs/server.json").read_text())
             self.assertEqual(
-                server["_meta"][
-                    "io.modelcontextprotocol.registry/publisher-provided"
-                ]["distribution"]["npm"],
+                server["_meta"]["io.modelcontextprotocol.registry/publisher-provided"][
+                    "distribution"
+                ]["npm"],
                 "@dinglebear/unraid@0.3.0",
             )
             self.assertEqual(release_pr_fixup.apply(root), [])

--- a/.github/workflows/codex-release.yml
+++ b/.github/workflows/codex-release.yml
@@ -92,5 +92,5 @@ jobs:
             "dist/unraid-codex-${VERSION}-checksums.txt" \
             unraid-codex.plg --clobber
 
-      - name: Keep the primary Unraid MCP release marked latest
-        run: gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${{ github.event.release.id }}" -f make_latest=false >/dev/null
+      - name: Restore the primary Unraid MCP release as Latest
+        run: python3 ../../.github/scripts/ensure_primary_latest.py "$TAG"

--- a/.github/workflows/incus-release.yml
+++ b/.github/workflows/incus-release.yml
@@ -161,5 +161,5 @@ jobs:
       - name: Attach the publication manifest
         run: gh release upload "$TAG" incus.plg --clobber
 
-      - name: Keep the primary Unraid MCP release marked latest
-        run: gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${{ github.event.release.id }}" -f make_latest=false >/dev/null
+      - name: Restore the primary Unraid MCP release as Latest
+        run: python3 ../../.github/scripts/ensure_primary_latest.py "$TAG"

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -130,12 +130,12 @@ jobs:
             runraid-x86_64.tar.gz runraid-x86_64.tar.gz.sha256 \
             "../plugins/mcp/packages/unraid-mcp-${plugin_version}-x86_64-2.txz" \
             ../plugins/mcp/packages/unraid-mcp.plg --clobber
-          if [ "${{ github.event_name }}" = "release" ]; then
-            release_id="${{ github.event.release.id }}"
-          else
-            release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq .id)"
-          fi
-          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" -f make_latest=false >/dev/null
+
+      - name: Restore the primary Unraid MCP release as Latest
+        id: primary-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 ../.github/scripts/ensure_primary_latest.py "$TAG"
 
       - name: Publish rolling Community Applications manifest
         env:
@@ -173,27 +173,19 @@ jobs:
           gh release upload "$rolling" "$plg" --clobber
 
       # One-time-per-release bridge for legacy installs: Python-era plugins poll
-      # the "latest release" asset-download URL for unraid-mcp.plg (their
-      # baked-in pluginURL). Rust releases are marked make_latest=false
-      # and the .plg otherwise lives only on the rolling prerelease, so that
-      # legacy URL would keep 404ing forever. Attaching the new .plg to
-      # whatever release GitHub currently calls "latest" makes the legacy URL
-      # serve it; once a box upgrades, its stored pluginURL becomes the fixed
-      # unraid-plugin-latest URL and this bridge is no longer needed for it.
+      # the repository Latest asset URL for unraid-mcp.plg (their baked-in
+      # pluginURL). The step above explicitly restores the newest primary vX.Y.Z
+      # release as Latest; attach the rolling manifest to that exact release
+      # rather than resolving a potentially stale or component-owned pointer.
       - name: Bridge legacy releases/latest pluginURL
         env:
           GH_TOKEN: ${{ github.token }}
+          PRIMARY_TAG: ${{ steps.primary-release.outputs.tag }}
         run: |
           set -euo pipefail
-          latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name || true)"
-          if [ -z "$latest_tag" ]; then
-            echo "::warning::could not resolve the repository's latest release — legacy pluginURL bridge skipped"
-            exit 0
-          fi
-          # If "latest" is this rust release itself, the upload is a harmless
-          # re-clobber of the asset attached earlier.
-          echo "bridging legacy pluginURL: uploading unraid-mcp.plg to latest release ${latest_tag}"
-          gh release upload "$latest_tag" ../plugins/mcp/packages/unraid-mcp.plg --clobber
+          [ -n "$PRIMARY_TAG" ] || { echo "::error::primary release tag output is empty"; exit 1; }
+          echo "bridging legacy pluginURL: uploading unraid-mcp.plg to primary release ${PRIMARY_TAG}"
+          gh release upload "$PRIMARY_TAG" ../plugins/mcp/packages/unraid-mcp.plg --clobber
 
   npm:
     needs: build


### PR DESCRIPTION
## Summary

Fixes the release-routing failure exposed while publishing Codex build 35 and permanently addresses #357.

- add a tested `ensure_primary_latest.py` helper that selects the highest published primary `vX.Y.Z` release numerically
- promote the primary release before demoting the triggering Codex, Incus, or Rust component release
- verify `/releases/latest` converges and expose the verified primary tag through `GITHUB_OUTPUT`
- make the Rust legacy updater bridge upload `unraid-mcp.plg` to that exact primary tag instead of resolving a potentially stale Latest pointer
- enforce the helper invocation and bridge contract in meta CI

## Live repair already applied

- restored `v2.10.1` as repository Latest
- attached rolling `unraid-mcp.plg` version `3.000.004.002` to `v2.10.1`
- verified the legacy `releases/latest/download/unraid-mcp.plg` path now resolves through the primary release

## Validation

- 11 release-tool unit tests
- live idempotent helper run against `codex-v20260805.001`
- release contract
- Ruff check + format
- YAML parse
- Actionlint 1.7.12
- action allowlist and SHA-comment contracts
- `git diff --check`
