### PR TITLE
Fix runraid plugin launcher to use published npm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         run: uv build --no-sources
       - name: Validate package metadata and contents
         run: |
-          uv tool run --from twine==6.2.0 twine check dist/*
+          uv tool run --from twine==7.0.0 twine check dist/*
           unzip -l dist/*.whl | tee wheel-contents.txt
           grep -q 'unraid_mcp/server.py' wheel-contents.txt
           grep -q 'licenses/LICENSE' wheel-contents.txt

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -78,7 +78,7 @@ jobs:
         run: uv build --no-sources
       - name: Validate metadata, wheel contents, and installed stdio server
         run: |
-          uv tool run --from twine==6.2.0 twine check dist/*
+          uv tool run --from twine==7.0.0 twine check dist/*
           unzip -l dist/*.whl | tee wheel-contents.txt
           grep -q 'unraid_mcp/server.py' wheel-contents.txt
           grep -q 'licenses/LICENSE' wheel-contents.txt

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Optional, for **non-plugin** installs (systemd, Docker) that want `~/.unraid/.en
 written to disk:
 
 ```bash
-runraid setup plugin-hook          # or: crgx unraid-rmcp -- setup plugin-hook
+runraid setup plugin-hook          # or: npx -y @dinglebear/unraid setup plugin-hook
 ```
 
 ## unraid-py quickstart (Python MCP server)

--- a/agents/unraid-rs/.mcp.json
+++ b/agents/unraid-rs/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "unraid": {
-      "command": "crgx",
-      "args": ["unraid-rmcp", "--", "mcp"],
+      "command": "npx",
+      "args": ["-y", "@dinglebear/unraid", "mcp"],
       "env": {
         "UNRAID_API_URL": "${user_config.unraid_api_url}",
         "UNRAID_API_KEY": "${user_config.unraid_api_key}",

--- a/agents/unraid-rs/scripts/plugin-setup.sh
+++ b/agents/unraid-rs/scripts/plugin-setup.sh
@@ -8,10 +8,10 @@ if command -v "${binary}" >/dev/null 2>&1; then
   exec "${binary}" setup plugin-hook "$@"
 fi
 
-if command -v crgx >/dev/null 2>&1; then
-  exec crgx unraid-rmcp -- setup plugin-hook "$@"
+if command -v npx >/dev/null 2>&1; then
+  exec npx -y @dinglebear/unraid setup plugin-hook "$@"
 fi
 
-printf 'unraid plugin setup: neither runraid nor crgx is installed or on PATH.\n' >&2
-printf 'Install crgx, then retry; it will fetch unraid-rmcp from crates.io.\n' >&2
+printf 'unraid plugin setup: neither runraid nor npx is installed or on PATH.\n' >&2
+printf 'Install Node.js with npx, then retry; it will fetch @dinglebear/unraid from npm.\n' >&2
 exit 0

--- a/agents/unraid-rs/skills/unraid/SKILL.md
+++ b/agents/unraid-rs/skills/unraid/SKILL.md
@@ -116,7 +116,7 @@ unraid(action="parity_history")
 
 ## Tier 2 — CLI Binary
 
-Binary: `runraid` — invoked on demand through `crgx unraid-rmcp -- ...`, installed persistently with `cargo install unraid-rmcp`, or built locally with `cargo build --release`.
+Binary: `runraid` — invoked on demand through `npx -y @dinglebear/unraid ...`, installed persistently from npm, or built locally with `cargo build --release`.
 
 All commands accept `--json` for machine-readable output.
 

--- a/plugins/mcp/web/package-lock.json
+++ b/plugins/mcp/web/package-lock.json
@@ -2061,9 +2061,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/unraid-rs/README.md
+++ b/unraid-rs/README.md
@@ -436,8 +436,8 @@ CLI shim      (src/cli.rs)           argv -> service -> stdout
 - The npm package remains a compatibility surface only. Automatic npm publishing
   is enabled only when `NPM_TRUSTED_PUBLISHING_ENABLED=true`.
 - Docker/OCI metadata uses `ghcr.io/dinglebear-ai/unraid-rmcp:<version>`.
-- `agents/unraid-rs/.mcp.json` must launch `crgx unraid-rmcp -- mcp` so stdio
-  clients resolve the crates.io package without requiring Node.
+- `agents/unraid-rs/.mcp.json` must launch `npx -y @dinglebear/unraid mcp` so
+  stdio clients resolve the published npm package.
 - The root README is curated. `docs/INVENTORY.md` is the curated inventory for
   actions, CLI commands, env vars, HTTP endpoints, and dependencies.
 

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -343,6 +343,7 @@ inherit persisted `.env` values instead of clearing them. A present but malforme
 | `UNRAID_API_URL` | unset | Full Unraid GraphQL endpoint URL. |
 | `UNRAID_API_KEY` | unset | API key for the `x-api-key` header. |
 | `UNRAID_API_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification for self-signed endpoints. |
+| `UNRAID_API_CA_BUNDLE` | _(unset)_ | Path to a PEM CA bundle to trust. Prefer this over skipping verification for a private CA; startup fails if the file is unreadable or not a PEM bundle. |
 | `UNRAID_HOME` | platform default | Exact data directory for `.env`, auth DB, and JWT key; overrides `/data` or `~/.unraid`. |
 | `UNRAID_RMCP_HOST` | `0.0.0.0` | HTTP bind host. |
 | `UNRAID_RMCP_PORT` | `40010` | HTTP bind port. |
@@ -435,8 +436,8 @@ CLI shim      (src/cli.rs)           argv -> service -> stdout
 - The npm package remains a compatibility surface only. Automatic npm publishing
   is enabled only when `NPM_TRUSTED_PUBLISHING_ENABLED=true`.
 - Docker/OCI metadata uses `ghcr.io/dinglebear-ai/unraid-rmcp:<version>`.
-- `agents/unraid-rs/.mcp.json` must launch `npx -y @dinglebear/unraid mcp` so stdio
-  clients resolve the crates.io package without requiring Node.
+- `agents/unraid-rs/.mcp.json` must launch `npx -y @dinglebear/unraid mcp` so
+  stdio clients resolve the published npm package.
 - The root README is curated. `docs/INVENTORY.md` is the curated inventory for
   actions, CLI commands, env vars, HTTP endpoints, and dependencies.
 
@@ -499,7 +500,7 @@ gateway.
 | Symptom | Check |
 |---|---|
 | `UNRAID_API_URL` or `UNRAID_API_KEY` is missing | Set it in env or `~/.unraid/.env`. |
-| TLS errors against Unraid | Set `UNRAID_API_SKIP_TLS_VERIFY=true` only for self-signed endpoints. |
+| TLS errors against Unraid | Point `UNRAID_API_CA_BUNDLE` at your CA's PEM bundle to keep verification on. Use `UNRAID_API_SKIP_TLS_VERIFY=true` only when you have no bundle. |
 | HTTP `/mcp` returns unauthorized | Set `UNRAID_RMCP_TOKEN` and send `Authorization: Bearer <token>`. |
 | Stdio client hangs or logs JSON errors | Ensure client config runs `unraid-rmcp mcp`, not the default HTTP server mode. |
 | Large list response is truncated | Use `limit`, `offset`, `name`, or `state` filters on MCP list actions. |

--- a/unraid-rs/packages/unraid-rmcp/README.md
+++ b/unraid-rs/packages/unraid-rmcp/README.md
@@ -435,7 +435,7 @@ CLI shim      (src/cli.rs)           argv -> service -> stdout
 - The npm package remains a compatibility surface only. Automatic npm publishing
   is enabled only when `NPM_TRUSTED_PUBLISHING_ENABLED=true`.
 - Docker/OCI metadata uses `ghcr.io/dinglebear-ai/unraid-rmcp:<version>`.
-- `agents/unraid-rs/.mcp.json` must launch `crgx unraid-rmcp -- mcp` so stdio
+- `agents/unraid-rs/.mcp.json` must launch `npx -y @dinglebear/unraid mcp` so stdio
   clients resolve the crates.io package without requiring Node.
 - The root README is curated. `docs/INVENTORY.md` is the curated inventory for
   actions, CLI commands, env vars, HTTP endpoints, and dependencies.

--- a/unraid-rs/scripts/validate-plugin-layout.sh
+++ b/unraid-rs/scripts/validate-plugin-layout.sh
@@ -48,6 +48,7 @@ for file in "${claude_manifest}" "${codex_manifest}"; do
 done
 
 jq -er '.mcpServers | type == "object" and length > 0' "${mcp_json}" >/dev/null
+jq -er '.mcpServers.unraid.command == "npx" and .mcpServers.unraid.args == ["-y", "@dinglebear/unraid", "mcp"]' "${mcp_json}" >/dev/null
 
 # Neither manifest may declare a `hooks` key — Claude Code hooks are retired here.
 for file in "${claude_manifest}" "${codex_manifest}"; do

--- a/unraid-rs/tests/setup_contract.rs
+++ b/unraid-rs/tests/setup_contract.rs
@@ -83,10 +83,10 @@ fn setup_repair_creates_env_file_without_upstream_contact() {
 /// invokes this script automatically any more — it is the manual credential-setup
 /// entry point. The contract on its contents still holds.
 #[test]
-fn plugin_setup_script_prefers_binary_then_crgx() {
+fn plugin_setup_script_prefers_binary_then_npx() {
     let setup = std::fs::read_to_string("../agents/unraid-rs/scripts/plugin-setup.sh").unwrap();
-    assert!(setup.contains("command -v crgx"));
-    assert!(setup.contains("exec crgx unraid-rmcp -- setup plugin-hook"));
+    assert!(setup.contains("command -v npx"));
+    assert!(setup.contains("exec npx -y @dinglebear/unraid setup plugin-hook"));
 }
 
 /// The agent plugin must ship no Claude Code hooks: no `hooks/` directory and no
@@ -111,14 +111,14 @@ fn agent_plugin_declares_no_claude_hooks() {
 }
 
 #[test]
-fn claude_mcp_config_uses_crgx() {
+fn claude_mcp_config_uses_published_npm_package() {
     let mcp: Value =
         serde_json::from_str(&std::fs::read_to_string("../agents/unraid-rs/.mcp.json").unwrap())
             .unwrap();
-    assert_eq!(mcp["mcpServers"]["unraid"]["command"], "crgx");
+    assert_eq!(mcp["mcpServers"]["unraid"]["command"], "npx");
     assert_eq!(
         mcp["mcpServers"]["unraid"]["args"],
-        serde_json::json!(["unraid-rmcp", "--", "mcp"])
+        serde_json::json!(["-y", "@dinglebear/unraid", "mcp"])
     );
 }
 


### PR DESCRIPTION
The runraid plugin used a CRGX crate that is not published on crates.io. Route plugin startup and setup through the valid scoped npm package and lock the launcher contract in validation and tests.\n\nValidated with the plugin layout validator, the setup contract test, Claude plugin validation, and a live npm launcher version check.