### PR TITLE
fix(mcp): support exclusive appdata shares

### DIFF
--- a/plugins/mcp/scripts/verify-package.sh
+++ b/plugins/mcp/scripts/verify-package.sh
@@ -67,6 +67,7 @@ required=(
   usr/local/emhttp/plugins/unraid-mcp/include/config.php
   usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp
   usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
+  usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-paths.sh
   usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
   usr/local/emhttp/plugins/unraid-mcp/event/disks_mounted
   usr/local/emhttp/plugins/unraid-mcp/event/unmounting_disks
@@ -80,7 +81,7 @@ required=(
 for path in "${required[@]}"; do
   grep -Fxq "$path" "$list" || { echo "package missing required member: $path" >&2; exit 1; }
 done
-for path in usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh usr/local/emhttp/plugins/unraid-mcp/event/disks_mounted usr/local/emhttp/plugins/unraid-mcp/event/unmounting_disks usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp usr/local/unraid-mcp/bin/runraid; do
+for path in usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-paths.sh usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh usr/local/emhttp/plugins/unraid-mcp/event/disks_mounted usr/local/emhttp/plugins/unraid-mcp/event/unmounting_disks usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp usr/local/unraid-mcp/bin/runraid; do
   [[ -x "$tree/$path" ]] || { echo "required package executable lacks execute mode: $path" >&2; exit 1; }
 done
 

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp
@@ -19,6 +19,11 @@ TAILSCALE_BIN="/usr/local/sbin/tailscale"
 # shellcheck source=unraid-mcp-env.sh
 source "${EMHTTP_DIR}/scripts/unraid-mcp-env.sh"
 
+# The environment may override the persistent data directory. Keep every path
+# used by the service aligned with UNRAID_HOME after loading it.
+APPDATA_DIR="${UNRAID_MCP_APPDATA_DIR}"
+OVERLAY_BIN="${APPDATA_DIR}/bin/runraid"
+
 log() {
     mkdir -p "${LOG_DIR}" 2>/dev/null || true
     echo "$(date '+%Y-%m-%d %H:%M:%S') rc.${PLUGIN_NAME}: $*" >>"${LOG_FILE}" 2>/dev/null
@@ -29,18 +34,38 @@ array_mounted() {
     grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts
 }
 
+appdata_share_safe() {
+    local path="$1" mount_root="${2:-/mnt}" resolved relative pool
+    [ -L "${path}" ] || return 0
+    resolved="$(readlink -f -- "${path}" 2>/dev/null)" || return 1
+    [ -d "${resolved}" ] || return 1
+
+    # Unraid exclusive shares are represented as
+    # /mnt/user/<share> -> /mnt/<pool>/<share>. Permit that exact shape, but
+    # not arbitrary symlinks into the host filesystem or another user share.
+    case "${resolved}" in
+        "${mount_root}"/*/appdata) ;;
+        *) return 1 ;;
+    esac
+    relative="${resolved#"${mount_root}"/}"
+    pool="${relative%%/*}"
+    [ -n "${pool}" ] && [ "${relative}" = "${pool}/appdata" ] \
+        && [ "${pool}" != "user" ] && [ "${pool}" != "user0" ]
+}
+
 prepare_appdata() {
     if ! array_mounted; then
         log "FATAL: /mnt/user is not mounted; refusing to create appdata in the RAM rootfs"
         return 1
     fi
-    local path
-    for path in /mnt/user/appdata "${APPDATA_DIR}"; do
-        if [ -L "${path}" ]; then
-            log "FATAL: refusing symlinked appdata path ${path}"
-            return 1
-        fi
-    done
+    if ! appdata_share_safe /mnt/user/appdata; then
+        log "FATAL: refusing unsafe symlinked appdata share /mnt/user/appdata"
+        return 1
+    fi
+    if [ -L "${APPDATA_DIR}" ]; then
+        log "FATAL: refusing symlinked appdata path ${APPDATA_DIR}"
+        return 1
+    fi
     mkdir -p "${APPDATA_DIR}"
     if [ ! -d "${APPDATA_DIR}" ] || [ -L "${APPDATA_DIR}" ]; then
         log "FATAL: appdata directory is not a real directory: ${APPDATA_DIR}"

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp
@@ -18,9 +18,10 @@ TAILSCALE_BIN="/usr/local/sbin/tailscale"
 
 # shellcheck source=unraid-mcp-env.sh
 source "${EMHTTP_DIR}/scripts/unraid-mcp-env.sh"
+# shellcheck source=unraid-mcp-paths.sh
+source "${EMHTTP_DIR}/scripts/unraid-mcp-paths.sh"
 
-# The environment may override the persistent data directory. Keep every path
-# used by the service aligned with UNRAID_HOME after loading it.
+# Recompute the plugin overlay paths after loading the appdata override.
 APPDATA_DIR="${UNRAID_MCP_APPDATA_DIR}"
 OVERLAY_BIN="${APPDATA_DIR}/bin/runraid"
 
@@ -30,48 +31,12 @@ log() {
     echo "rc.${PLUGIN_NAME}: $*"
 }
 
-array_mounted() {
-    grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts
-}
-
-appdata_share_safe() {
-    local path="$1" mount_root="${2:-/mnt}" resolved relative pool
-    [ -L "${path}" ] || return 0
-    resolved="$(readlink -f -- "${path}" 2>/dev/null)" || return 1
-    [ -d "${resolved}" ] || return 1
-
-    # Unraid exclusive shares are represented as
-    # /mnt/user/<share> -> /mnt/<pool>/<share>. Permit that exact shape, but
-    # not arbitrary symlinks into the host filesystem or another user share.
-    case "${resolved}" in
-        "${mount_root}"/*/appdata) ;;
-        *) return 1 ;;
-    esac
-    relative="${resolved#"${mount_root}"/}"
-    pool="${relative%%/*}"
-    [ -n "${pool}" ] && [ "${relative}" = "${pool}/appdata" ] \
-        && [ "${pool}" != "user" ] && [ "${pool}" != "user0" ]
-}
-
 prepare_appdata() {
-    if ! array_mounted; then
-        log "FATAL: /mnt/user is not mounted; refusing to create appdata in the RAM rootfs"
+    local error
+    if ! error="$(unraid_mcp_prepare_persistent_paths "${APPDATA_DIR}" 2>&1)"; then
+        log "FATAL: ${error}"
         return 1
     fi
-    if ! appdata_share_safe /mnt/user/appdata; then
-        log "FATAL: refusing unsafe symlinked appdata share /mnt/user/appdata"
-        return 1
-    fi
-    if [ -L "${APPDATA_DIR}" ]; then
-        log "FATAL: refusing symlinked appdata path ${APPDATA_DIR}"
-        return 1
-    fi
-    mkdir -p "${APPDATA_DIR}"
-    if [ ! -d "${APPDATA_DIR}" ] || [ -L "${APPDATA_DIR}" ]; then
-        log "FATAL: appdata directory is not a real directory: ${APPDATA_DIR}"
-        return 1
-    fi
-    chmod 700 "${APPDATA_DIR}" 2>/dev/null || true
 }
 
 pid_matches() {

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
@@ -21,7 +21,7 @@ unraid_mcp_is_false() {
 }
 
 # Do not create anything under /mnt/user while merely loading configuration.
-# Persistent paths are prepared only by explicit start, update, or reset actions.
+# Persistent paths are prepared only by explicit mutating service/updater actions.
 # Load dotenv assignments as literal data. Never source the file: even a
 # root-owned config can be manually malformed, and command substitutions must
 # not become executable shell syntax. The parser supports the plugin writer's

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Scoped runtime environment for the native runraid server. Sourced only by
-# rc.unraid-mcp so plugin settings never leak into login shells or other services.
+# Scoped runtime environment shared by the native runraid service and updater.
+# Plugin settings never leak into login shells or unrelated services.
 
 UNRAID_MCP_CONFIG_DIR="${UNRAID_MCP_CONFIG_DIR:-/boot/config/plugins/unraid-mcp}"
 UNRAID_MCP_APPDATA_DIR="${UNRAID_MCP_APPDATA_DIR:-/mnt/user/appdata/unraid-mcp}"
@@ -20,8 +20,8 @@ unraid_mcp_is_false() {
     esac
 }
 
-# Do not create anything under /mnt/user while merely running status/stop. The
-# rc script prepares this directory only when starting with the array mounted.
+# Do not create anything under /mnt/user while merely loading configuration.
+# Persistent paths are prepared only by explicit start, update, or reset actions.
 # Load dotenv assignments as literal data. Never source the file: even a
 # root-owned config can be manually malformed, and command substitutions must
 # not become executable shell syntax. The parser supports the plugin writer's

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh
@@ -22,10 +22,6 @@ unraid_mcp_is_false() {
 
 # Do not create anything under /mnt/user while merely running status/stop. The
 # rc script prepares this directory only when starting with the array mounted.
-# runraid honors UNRAID_HOME as its exact data directory, avoiding the former
-# accidental /mnt/user/appdata/unraid-mcp/.unraid nesting.
-export UNRAID_HOME="${UNRAID_MCP_APPDATA_DIR}"
-
 # Load dotenv assignments as literal data. Never source the file: even a
 # root-owned config can be manually malformed, and command substitutions must
 # not become executable shell syntax. The parser supports the plugin writer's
@@ -70,6 +66,12 @@ unraid_mcp_load_env() {
 if [ -r "${UNRAID_MCP_ENV_FILE}" ]; then
     unraid_mcp_load_env "${UNRAID_MCP_ENV_FILE}"
 fi
+
+# Assign this after dotenv loading so a persistent appdata override cannot
+# split the directory prepared by rc.unraid-mcp from runraid's data directory.
+# runraid honors UNRAID_HOME as its exact data directory, avoiding the former
+# accidental /mnt/user/appdata/unraid-mcp/.unraid nesting.
+export UNRAID_HOME="${UNRAID_MCP_APPDATA_DIR}"
 
 # Preserve existing installations while the settings page migrates from the
 # Python server's UNRAID_MCP_* names to runraid's UNRAID_RMCP_* contract.

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-paths.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-paths.sh
@@ -8,7 +8,7 @@ unraid_mcp_array_mounted() {
 
 unraid_mcp_appdata_share_safe() {
     local path="$1" mount_root="${2:-/mnt}" pools_dir="${3:-/boot/config/pools}"
-    local resolved relative pool
+    local mounts_file="${4:-/proc/mounts}" resolved relative pool
     [ -L "${path}" ] || return 0
     resolved="$(readlink -f -- "${path}" 2>/dev/null)" || return 1
     [ -d "${resolved}" ] || return 1
@@ -22,7 +22,8 @@ unraid_mcp_appdata_share_safe() {
     pool="${relative%%/*}"
     [ -n "${pool}" ] && [ "${relative}" = "${pool}/appdata" ] \
         && [ -f "${pools_dir}/${pool}.cfg" ] \
-        && [ ! -L "${pools_dir}/${pool}.cfg" ]
+        && [ ! -L "${pools_dir}/${pool}.cfg" ] \
+        && grep -qsE "[[:space:]]${mount_root}/${pool}[[:space:]]" "${mounts_file}"
 }
 
 unraid_mcp_prepare_persistent_paths() {
@@ -34,7 +35,8 @@ unraid_mcp_prepare_persistent_paths() {
         echo "${mount_root}/user is not mounted; refusing to create appdata in the RAM rootfs" >&2
         return 1
     fi
-    if ! unraid_mcp_appdata_share_safe "${share}" "${mount_root}" "${pools_dir}"; then
+    if ! unraid_mcp_appdata_share_safe \
+        "${share}" "${mount_root}" "${pools_dir}" "${mounts_file}"; then
         echo "refusing unsafe symlinked appdata share ${share}" >&2
         return 1
     fi

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-paths.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-paths.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Shared persistent-path validation for the runraid service and updater.
+
+unraid_mcp_array_mounted() {
+    local mount_root="${1:-/mnt}" mounts_file="${2:-/proc/mounts}"
+    grep -qsE "[[:space:]]${mount_root}/user[[:space:]]" "${mounts_file}"
+}
+
+unraid_mcp_appdata_share_safe() {
+    local path="$1" mount_root="${2:-/mnt}" pools_dir="${3:-/boot/config/pools}"
+    local resolved relative pool
+    [ -L "${path}" ] || return 0
+    resolved="$(readlink -f -- "${path}" 2>/dev/null)" || return 1
+    [ -d "${resolved}" ] || return 1
+
+    # An Unraid exclusive share resolves directly into a configured named pool.
+    case "${resolved}" in
+        "${mount_root}"/*/appdata) ;;
+        *) return 1 ;;
+    esac
+    relative="${resolved#"${mount_root}"/}"
+    pool="${relative%%/*}"
+    [ -n "${pool}" ] && [ "${relative}" = "${pool}/appdata" ] \
+        && [ -f "${pools_dir}/${pool}.cfg" ] \
+        && [ ! -L "${pools_dir}/${pool}.cfg" ]
+}
+
+unraid_mcp_prepare_persistent_paths() {
+    local appdata_dir="$1" leaf_dir="${2:-}" mount_root="${3:-/mnt}"
+    local pools_dir="${4:-/boot/config/pools}" mounts_file="${5:-/proc/mounts}"
+    local share="${mount_root}/user/appdata" path
+
+    if ! unraid_mcp_array_mounted "${mount_root}" "${mounts_file}"; then
+        echo "${mount_root}/user is not mounted; refusing to create appdata in the RAM rootfs" >&2
+        return 1
+    fi
+    if ! unraid_mcp_appdata_share_safe "${share}" "${mount_root}" "${pools_dir}"; then
+        echo "refusing unsafe symlinked appdata share ${share}" >&2
+        return 1
+    fi
+    for path in "${appdata_dir}" ${leaf_dir:+"${leaf_dir}"}; do
+        if [ -L "${path}" ]; then
+            echo "refusing symlinked persistent path ${path}" >&2
+            return 1
+        fi
+    done
+
+    mkdir -p "${leaf_dir:-${appdata_dir}}"
+    for path in "${appdata_dir}" ${leaf_dir:+"${leaf_dir}"}; do
+        if [ ! -d "${path}" ] || [ -L "${path}" ]; then
+            echo "persistent path is not a real directory: ${path}" >&2
+            return 1
+        fi
+        chown 0:0 "${path}" 2>/dev/null || true
+        chmod 700 "${path}" 2>/dev/null || true
+    done
+}

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
@@ -33,6 +33,21 @@ array_mounted() {
     grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts
 }
 
+appdata_share_safe() {
+    local path="$1" mount_root="${2:-/mnt}" resolved relative pool
+    [ -L "${path}" ] || return 0
+    resolved="$(readlink -f -- "${path}" 2>/dev/null)" || return 1
+    [ -d "${resolved}" ] || return 1
+    case "${resolved}" in
+        "${mount_root}"/*/appdata) ;;
+        *) return 1 ;;
+    esac
+    relative="${resolved#"${mount_root}"/}"
+    pool="${relative%%/*}"
+    [ -n "${pool}" ] && [ "${relative}" = "${pool}/appdata" ] \
+        && [ "${pool}" != "user" ] && [ "${pool}" != "user0" ]
+}
+
 # Confirm GitHub holds a build-provenance attestation binding this exact digest
 # to this repo's release workflow.
 #
@@ -98,8 +113,12 @@ prepare_overlay_dir() {
         return 1
     fi
 
+    if ! appdata_share_safe /mnt/user/appdata; then
+        echo "error: refusing unsafe symlinked appdata share /mnt/user/appdata" >&2
+        return 1
+    fi
     local path
-    for path in /mnt/user/appdata "${APPDATA_DIR}" "${OVERLAY_DIR}"; do
+    for path in "${APPDATA_DIR}" "${OVERLAY_DIR}"; do
         if [ -L "${path}" ]; then
             echo "error: refusing symlinked overlay path ${path}" >&2
             return 1

--- a/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
+++ b/plugins/mcp/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh
@@ -16,8 +16,16 @@
 set -euo pipefail
 
 PREFIX="/usr/local/unraid-mcp"
+EMHTTP_DIR="/usr/local/emhttp/plugins/unraid-mcp"
 BUNDLED_BIN="${PREFIX}/bin/runraid"
-APPDATA_DIR="/mnt/user/appdata/unraid-mcp"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_SCRIPTS_DIR="${EMHTTP_DIR}/scripts"
+[ -r "${RUNTIME_SCRIPTS_DIR}/unraid-mcp-env.sh" ] || RUNTIME_SCRIPTS_DIR="${SCRIPT_DIR}"
+# shellcheck source=unraid-mcp-env.sh
+source "${RUNTIME_SCRIPTS_DIR}/unraid-mcp-env.sh"
+# shellcheck source=unraid-mcp-paths.sh
+source "${RUNTIME_SCRIPTS_DIR}/unraid-mcp-paths.sh"
+APPDATA_DIR="${UNRAID_MCP_APPDATA_DIR}"
 OVERLAY_DIR="${APPDATA_DIR}/bin"
 OVERLAY_BIN="${OVERLAY_DIR}/runraid"
 PREVIOUS_BIN="${OVERLAY_DIR}/runraid.previous"
@@ -28,25 +36,6 @@ RELEASE_WORKFLOW=".github/workflows/rust-release.yml"
 # Set UNRAID_MCP_SKIP_ATTESTATION=true only to install from a release predating
 # build provenance, and only when you have verified the binary another way.
 SKIP_ATTESTATION="${UNRAID_MCP_SKIP_ATTESTATION:-false}"
-
-array_mounted() {
-    grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts
-}
-
-appdata_share_safe() {
-    local path="$1" mount_root="${2:-/mnt}" resolved relative pool
-    [ -L "${path}" ] || return 0
-    resolved="$(readlink -f -- "${path}" 2>/dev/null)" || return 1
-    [ -d "${resolved}" ] || return 1
-    case "${resolved}" in
-        "${mount_root}"/*/appdata) ;;
-        *) return 1 ;;
-    esac
-    relative="${resolved#"${mount_root}"/}"
-    pool="${relative%%/*}"
-    [ -n "${pool}" ] && [ "${relative}" = "${pool}/appdata" ] \
-        && [ "${pool}" != "user" ] && [ "${pool}" != "user0" ]
-}
 
 # Confirm GitHub holds a build-provenance attestation binding this exact digest
 # to this repo's release workflow.
@@ -108,32 +97,7 @@ verify_attestation() {
 }
 
 prepare_overlay_dir() {
-    if ! array_mounted; then
-        echo "error: /mnt/user is not mounted; refusing to write an overlay into the RAM rootfs" >&2
-        return 1
-    fi
-
-    if ! appdata_share_safe /mnt/user/appdata; then
-        echo "error: refusing unsafe symlinked appdata share /mnt/user/appdata" >&2
-        return 1
-    fi
-    local path
-    for path in "${APPDATA_DIR}" "${OVERLAY_DIR}"; do
-        if [ -L "${path}" ]; then
-            echo "error: refusing symlinked overlay path ${path}" >&2
-            return 1
-        fi
-    done
-
-    mkdir -p "${OVERLAY_DIR}"
-    for path in "${APPDATA_DIR}" "${OVERLAY_DIR}"; do
-        if [ ! -d "${path}" ] || [ -L "${path}" ]; then
-            echo "error: overlay path is not a real directory: ${path}" >&2
-            return 1
-        fi
-        chown 0:0 "${path}" 2>/dev/null || true
-        chmod 700 "${path}" 2>/dev/null || true
-    done
+    unraid_mcp_prepare_persistent_paths "${APPDATA_DIR}" "${OVERLAY_DIR}"
 }
 
 overlay_valid() {
@@ -287,7 +251,7 @@ do_reset() {
 }
 
 do_commit() {
-    if ! array_mounted; then
+    if ! unraid_mcp_array_mounted; then
         echo "error: /mnt/user is not mounted; refusing to commit an overlay transaction" >&2
         exit 1
     fi

--- a/plugins/mcp/tests/runtime-contract.sh
+++ b/plugins/mcp/tests/runtime-contract.sh
@@ -5,6 +5,7 @@ plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 env_script="$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-env.sh"
 rc_script="$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/scripts/rc.unraid-mcp"
 update_script="$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-update.sh"
+paths_script="$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/scripts/unraid-mcp-paths.sh"
 nchan_script="$plugin_dir/source/usr/local/emhttp/plugins/unraid-mcp/nchan/unraid_mcp"
 verifier="$plugin_dir/scripts/verify-package.sh"
 
@@ -64,52 +65,72 @@ if [ "$existed" = false ]; then
     test ! -e "$appdata" || { echo "env script created appdata while the array was unavailable" >&2; exit 1; }
 fi
 
-# Unraid represents an exclusive appdata share as a symlink directly into its
-# pool. Both startup and updater must accept that exact shape while rejecting
-# arbitrary, nested, dangling, and /mnt/user targets.
-test_appdata_share_validator() {
-    local script="$1" fixture share
+# An override loaded from .env must update UNRAID_HOME after parsing, not leave
+# the runtime using the pre-parse default while rc and the updater use another
+# directory.
+override_tmp="$(mktemp -d)"
+printf "UNRAID_MCP_APPDATA_DIR='%s'\n" "${override_tmp}/custom" >"${override_tmp}/.env"
+(
+    unset UNRAID_HOME UNRAID_MCP_APPDATA_DIR UNRAID_MCP_ENV_FILE
+    export UNRAID_MCP_CONFIG_DIR="${override_tmp}"
+    # shellcheck source=/dev/null
+    source "$env_script"
+    test "$UNRAID_HOME" = "${override_tmp}/custom"
+    test "$UNRAID_MCP_APPDATA_DIR" = "${override_tmp}/custom"
+)
+rm -rf "$override_tmp"
+
+# Exercise the shared preparation boundary used by both rc.unraid-mcp and the
+# updater. A configured named-pool target succeeds and creates the requested
+# directories; unsafe targets fail before writing anything.
+# shellcheck source=/dev/null
+source "$paths_script"
+test_persistent_path_preparation() {
+    local fixture share appdata overlay mounts pools target
     fixture="$(mktemp -d)"
-    mkdir -p "${fixture}/user" "${fixture}/cache/appdata" \
-        "${fixture}/cache/nested/appdata" "${fixture}/user0/appdata"
+    mounts="${fixture}/mounts"
+    pools="${fixture}/pools"
+    mkdir -p "${fixture}/user" "${fixture}/cache/appdata" "${pools}"
+    printf 'shfs %s/user fuse.shfs rw 0 0\n' "${fixture}" >"${mounts}"
+    : >"${pools}/cache.cfg"
     share="${fixture}/user/appdata"
+    appdata="${share}/unraid-mcp"
+    overlay="${appdata}/bin"
 
-    eval "$(sed -n '/^appdata_share_safe() {/,/^}/p' "${script}")"
     ln -s ../cache/appdata "${share}"
-    appdata_share_safe "${share}" "${fixture}"
+    unraid_mcp_prepare_persistent_paths \
+        "${appdata}" "${overlay}" "${fixture}" "${pools}" "${mounts}"
+    test -d "${appdata}"
+    test -d "${overlay}"
 
-    rm "${share}"
-    ln -s ../cache/nested/appdata "${share}"
-    if appdata_share_safe "${share}" "${fixture}"; then
-        echo "nested pool path was accepted as an exclusive share" >&2
-        return 1
-    fi
-    rm "${share}"
-    ln -s ../user0/appdata "${share}"
-    if appdata_share_safe "${share}" "${fixture}"; then
-        echo "user0 path was accepted as an exclusive share" >&2
-        return 1
-    fi
-    rm "${share}"
-    ln -s /etc "${share}"
-    if appdata_share_safe "${share}" "${fixture}"; then
-        echo "host path was accepted as an exclusive share" >&2
-        return 1
-    fi
-    rm "${share}"
-    ln -s ../missing/appdata "${share}"
-    if appdata_share_safe "${share}" "${fixture}"; then
-        echo "dangling path was accepted as an exclusive share" >&2
-        return 1
-    fi
+    for target in \
+        ../cache/nested/appdata \
+        ../disk1/appdata \
+        ../remotes/appdata \
+        ../arbitrary/appdata \
+        /etc \
+        ../missing/appdata; do
+        rm -rf "${share}" "${fixture}/cache/appdata/unraid-mcp"
+        mkdir -p "${fixture}/cache/nested/appdata" \
+            "${fixture}/disk1/appdata" "${fixture}/remotes/appdata" \
+            "${fixture}/arbitrary/appdata"
+        ln -s "${target}" "${share}"
+        if unraid_mcp_prepare_persistent_paths \
+            "${appdata}" "${overlay}" "${fixture}" "${pools}" "${mounts}" 2>/dev/null; then
+            echo "unsafe appdata target was accepted: ${target}" >&2
+            return 1
+        fi
+        test ! -e "${appdata}"
+    done
     rm -rf "${fixture}"
 }
-test_appdata_share_validator "$rc_script"
-test_appdata_share_validator "$update_script"
+test_persistent_path_preparation
 
-# The rc script must apply an appdata override consistently, rather than only
-# exporting it as UNRAID_HOME while continuing to prepare the hardcoded path.
+# Both runtime entry points must use the shared boundary and the same override.
 grep -Fq 'APPDATA_DIR="${UNRAID_MCP_APPDATA_DIR}"' "$rc_script"
+grep -Fq 'APPDATA_DIR="${UNRAID_MCP_APPDATA_DIR}"' "$update_script"
+grep -Fq 'unraid_mcp_prepare_persistent_paths' "$rc_script"
+grep -Fq 'unraid_mcp_prepare_persistent_paths' "$update_script"
 
 # CI runners have no Unraid FUSE mount. In that state update/reset must fail
 # closed rather than constructing a convincing /mnt/user tree in RAM.

--- a/plugins/mcp/tests/runtime-contract.sh
+++ b/plugins/mcp/tests/runtime-contract.sh
@@ -91,7 +91,10 @@ test_persistent_path_preparation() {
     mounts="${fixture}/mounts"
     pools="${fixture}/pools"
     mkdir -p "${fixture}/user" "${fixture}/cache/appdata" "${pools}"
-    printf 'shfs %s/user fuse.shfs rw 0 0\n' "${fixture}" >"${mounts}"
+    {
+        printf 'shfs %s/user fuse.shfs rw 0 0\n' "${fixture}"
+        printf '/dev/cache %s/cache btrfs rw 0 0\n' "${fixture}"
+    } >"${mounts}"
     : >"${pools}/cache.cfg"
     share="${fixture}/user/appdata"
     appdata="${share}/unraid-mcp"
@@ -102,6 +105,19 @@ test_persistent_path_preparation() {
         "${appdata}" "${overlay}" "${fixture}" "${pools}" "${mounts}"
     test -d "${appdata}"
     test -d "${overlay}"
+
+    # Pool configuration alone is insufficient: an unavailable pool can leave
+    # a stale directory in the RAM rootfs that must never receive appdata.
+    rm -rf "${share}" "${fixture}/cache/appdata/unraid-mcp"
+    ln -s ../cache/appdata "${share}"
+    printf 'shfs %s/user fuse.shfs rw 0 0\n' "${fixture}" >"${mounts}"
+    if unraid_mcp_prepare_persistent_paths \
+        "${appdata}" "${overlay}" "${fixture}" "${pools}" "${mounts}" 2>/dev/null; then
+        echo "configured but unmounted pool was accepted" >&2
+        return 1
+    fi
+    test ! -e "${appdata}"
+    printf '/dev/cache %s/cache btrfs rw 0 0\n' "${fixture}" >>"${mounts}"
 
     for target in \
         ../cache/nested/appdata \

--- a/plugins/mcp/tests/runtime-contract.sh
+++ b/plugins/mcp/tests/runtime-contract.sh
@@ -64,6 +64,53 @@ if [ "$existed" = false ]; then
     test ! -e "$appdata" || { echo "env script created appdata while the array was unavailable" >&2; exit 1; }
 fi
 
+# Unraid represents an exclusive appdata share as a symlink directly into its
+# pool. Both startup and updater must accept that exact shape while rejecting
+# arbitrary, nested, dangling, and /mnt/user targets.
+test_appdata_share_validator() {
+    local script="$1" fixture share
+    fixture="$(mktemp -d)"
+    mkdir -p "${fixture}/user" "${fixture}/cache/appdata" \
+        "${fixture}/cache/nested/appdata" "${fixture}/user0/appdata"
+    share="${fixture}/user/appdata"
+
+    eval "$(sed -n '/^appdata_share_safe() {/,/^}/p' "${script}")"
+    ln -s ../cache/appdata "${share}"
+    appdata_share_safe "${share}" "${fixture}"
+
+    rm "${share}"
+    ln -s ../cache/nested/appdata "${share}"
+    if appdata_share_safe "${share}" "${fixture}"; then
+        echo "nested pool path was accepted as an exclusive share" >&2
+        return 1
+    fi
+    rm "${share}"
+    ln -s ../user0/appdata "${share}"
+    if appdata_share_safe "${share}" "${fixture}"; then
+        echo "user0 path was accepted as an exclusive share" >&2
+        return 1
+    fi
+    rm "${share}"
+    ln -s /etc "${share}"
+    if appdata_share_safe "${share}" "${fixture}"; then
+        echo "host path was accepted as an exclusive share" >&2
+        return 1
+    fi
+    rm "${share}"
+    ln -s ../missing/appdata "${share}"
+    if appdata_share_safe "${share}" "${fixture}"; then
+        echo "dangling path was accepted as an exclusive share" >&2
+        return 1
+    fi
+    rm -rf "${fixture}"
+}
+test_appdata_share_validator "$rc_script"
+test_appdata_share_validator "$update_script"
+
+# The rc script must apply an appdata override consistently, rather than only
+# exporting it as UNRAID_HOME while continuing to prepare the hardcoded path.
+grep -Fq 'APPDATA_DIR="${UNRAID_MCP_APPDATA_DIR}"' "$rc_script"
+
 # CI runners have no Unraid FUSE mount. In that state update/reset must fail
 # closed rather than constructing a convincing /mnt/user tree in RAM.
 if ! grep -qsE '[[:space:]]/mnt/user[[:space:]]' /proc/mounts; then


### PR DESCRIPTION
Closes #370

## Summary

- accept Unraid exclusive-share appdata symlinks only when they resolve to `/mnt/<pool>/appdata`
- preserve fail-closed validation for arbitrary, nested, dangling, user0, and host filesystem targets
- apply the same validation to service startup and binary updates
- keep runtime appdata overrides aligned with `UNRAID_HOME`

## Verification

- `bash -n` for the changed service, updater, and contract scripts
- `shellcheck -S warning` for the changed shell scripts
- `./plugins/mcp/tests/ca-metadata.sh`
- `./plugins/mcp/tests/runtime-contract.sh`
- `git diff --check`