### PR TITLE
fix(codex): harden appserver socket startup

### DIFF
--- a/plugins/codex/source/usr/local/emhttp/plugins/unraid-codex/event/disks_mounted
+++ b/plugins/codex/source/usr/local/emhttp/plugins/unraid-codex/event/disks_mounted
@@ -1,2 +1,22 @@
 #!/bin/bash
-/usr/local/emhttp/plugins/unraid-codex/scripts/start-appserver.sh
+set -u
+
+START_APPSERVER="${CODEX_START_APPSERVER:-/usr/local/emhttp/plugins/unraid-codex/scripts/start-appserver.sh}"
+MAX_ATTEMPTS="${CODEX_START_MAX_ATTEMPTS:-12}"
+RETRY_DELAY_SECONDS="${CODEX_START_RETRY_DELAY_SECONDS:-5}"
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  if "$START_APPSERVER"; then
+    exit 0
+  fi
+
+  logger -t unraid-codex \
+    "Array-start app-server attempt ${attempt}/${MAX_ATTEMPTS} failed"
+  if ((attempt < MAX_ATTEMPTS)); then
+    sleep "$RETRY_DELAY_SECONDS"
+  fi
+done
+
+logger -t unraid-codex \
+  "App-server failed to start after ${MAX_ATTEMPTS} array-start attempts"
+exit 1

--- a/plugins/codex/source/usr/local/emhttp/plugins/unraid-codex/scripts/start-appserver.sh
+++ b/plugins/codex/source/usr/local/emhttp/plugins/unraid-codex/scripts/start-appserver.sh
@@ -87,7 +87,6 @@ fi
 incus </dev/null exec "$CONTAINER" -- chown agent:agent "$CONTAINER_SOCKET_DIR"
 incus </dev/null exec "$CONTAINER" -- chmod 0711 "$CONTAINER_SOCKET_DIR"
 ln -sfn "$SOCKET_PATH" "$WEBGUI_SOCKET"
-/usr/local/emhttp/plugins/unraid-codex/scripts/configure-nginx.sh install
 
 incus </dev/null exec "$CONTAINER" -- install -d -o agent -g agent -m 0700 \
   "$CONTAINER_CONFIG_DIR" "$CODEX_CONFIG_DIR"
@@ -171,7 +170,15 @@ incus </dev/null exec "$CONTAINER" -- sh -c \
 incus </dev/null file push \
   /usr/local/emhttp/plugins/unraid-codex/container/codex-appserver.service \
   "$CONTAINER/etc/systemd/system/codex-appserver.service"
+
 incus </dev/null exec "$CONTAINER" -- systemctl daemon-reload
+effective_execstart="$(incus </dev/null exec "$CONTAINER" -- \
+  systemctl show codex-appserver.service --property=ExecStart --value)"
+if ! grep -Fq -- '--listen unix:///mnt/unraid-codex/appserver.sock' <<<"$effective_execstart"; then
+  logger -t unraid-codex \
+    "Codex service transport is overridden; expected Unix socket ExecStart"
+  exit 1
+fi
 [[ -x "$UPDATE_CLI" ]] || { logger -t unraid-codex "Codex updater is unavailable: $UPDATE_CLI"; exit 1; }
 "$UPDATE_CLI"
 incus </dev/null exec "$CONTAINER" -- systemctl enable codex-appserver.service
@@ -194,5 +201,8 @@ python3 "$APPSERVER_SMOKE" "$SOCKET_PATH" || {
   exit 1
 }
 
+# Publish the browser route only after the backend has completed a real protocol
+# handshake. A failed service start must not leave nginx pointing at a dead socket.
+/usr/local/emhttp/plugins/unraid-codex/scripts/configure-nginx.sh install
 /usr/local/emhttp/plugins/unraid-codex/scripts/configure-schedule.sh install
 logger -t unraid-codex "Codex app-server restarted in $CONTAINER and the WebGUI socket is ready"

--- a/plugins/codex/tests/contract.sh
+++ b/plugins/codex/tests/contract.sh
@@ -153,9 +153,17 @@ grep -Fq 'UNRAID_MCP_URL' "${source_dir}/scripts/start-appserver.sh"
 grep -Fq 'UNRAID_MCP_PROXY_HOST' "${source_dir}/scripts/start-appserver.sh"
 grep -Fq '# unraid-codex-mcp' "${source_dir}/scripts/start-appserver.sh"
 grep -Fq 'systemctl restart codex-appserver.service' "${source_dir}/scripts/start-appserver.sh"
+grep -Fq 'systemctl show codex-appserver.service --property=ExecStart --value' "${source_dir}/scripts/start-appserver.sh"
+grep -Fq -- '--listen unix:///mnt/unraid-codex/appserver.sock' "${source_dir}/scripts/start-appserver.sh"
 grep -Fq 'INCUS_START_HELPER=/usr/local/emhttp/plugins/incus/scripts/start-instance.sh' "${source_dir}/scripts/start-appserver.sh"
 grep -Fq '"$INCUS_START_HELPER" "$CONTAINER"' "${source_dir}/scripts/start-appserver.sh"
 grep -Fq 'App-server service started but $SOCKET_PATH did not become ready' "${source_dir}/scripts/start-appserver.sh"
+smoke_line="$(grep -n -m1 'python3 "$APPSERVER_SMOKE" "$SOCKET_PATH"' "${source_dir}/scripts/start-appserver.sh" | cut -d: -f1)"
+nginx_line="$(grep -n -m1 'configure-nginx.sh install' "${source_dir}/scripts/start-appserver.sh" | cut -d: -f1)"
+[[ -n "$smoke_line" && -n "$nginx_line" && "$nginx_line" -gt "$smoke_line" ]] || {
+  echo "nginx route must only be published after app-server protocol smoke succeeds" >&2
+  exit 1
+}
 grep -Fq 'ENSURE_STATE=/usr/local/emhttp/plugins/unraid-codex/scripts/ensure-state-volume.sh' "${source_dir}/scripts/start-appserver.sh"
 grep -Fq 'PROVISION_CONTAINER=/usr/local/emhttp/plugins/unraid-codex/scripts/provision-container.sh' "${source_dir}/scripts/start-appserver.sh"
 grep -Fq '"$PROVISION_CONTAINER"' "${source_dir}/scripts/start-appserver.sh"
@@ -202,7 +210,7 @@ if find "${source_dir}" -type f \( -name codex-version -o -name codex-release.en
   exit 1
 fi
 test_output_dir="$(mktemp -d)"
-test_names=(install-codex-cli update-codex-cli provision-container configure-nginx backup-restore-state package-verifier ca-metadata)
+test_names=(install-codex-cli update-codex-cli provision-container configure-nginx backup-restore-state package-verifier ca-metadata disks-mounted)
 test_pids=()
 for test_name in "${test_names[@]}"; do
   "${plugin_dir}/tests/$test_name.sh" >"$test_output_dir/$test_name.log" 2>&1 &

--- a/plugins/codex/tests/disks-mounted.sh
+++ b/plugins/codex/tests/disks-mounted.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+hook="$plugin_dir/source/usr/local/emhttp/plugins/unraid-codex/event/disks_mounted"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cat >"$tmp/start-appserver" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+attempts_file="${CODEX_TEST_ATTEMPTS:?}"
+attempts="$(wc -l <"$attempts_file")"
+printf 'attempt\n' >>"$attempts_file"
+[[ "$attempts" -ge "${CODEX_TEST_FAILURES:-0}" ]]
+EOF
+chmod 0755 "$tmp/start-appserver"
+
+: >"$tmp/attempts"
+CODEX_START_APPSERVER="$tmp/start-appserver" \
+  CODEX_START_RETRY_DELAY_SECONDS=0 \
+  CODEX_TEST_ATTEMPTS="$tmp/attempts" \
+  CODEX_TEST_FAILURES=2 \
+  "$hook"
+[[ "$(wc -l <"$tmp/attempts")" -eq 3 ]]
+
+: >"$tmp/attempts"
+if CODEX_START_APPSERVER="$tmp/start-appserver" \
+  CODEX_START_RETRY_DELAY_SECONDS=0 \
+  CODEX_START_MAX_ATTEMPTS=4 \
+  CODEX_TEST_ATTEMPTS="$tmp/attempts" \
+  CODEX_TEST_FAILURES=10 \
+  "$hook"; then
+  echo 'disks_mounted unexpectedly succeeded after retry exhaustion' >&2
+  exit 1
+fi
+[[ "$(wc -l <"$tmp/attempts")" -eq 4 ]]
+
+echo 'Codex disks_mounted retry tests passed'


### PR DESCRIPTION
## Summary
- retry Codex app-server startup during the Unraid disks_mounted lifecycle so transient array/Incus readiness does not leave the chathead unavailable
- verify systemd's effective app-server ExecStart still matches this plugin's Unix-socket contract before restarting the service
- publish the nginx WebSocket route only after the app-server Unix socket passes a real protocol initialization smoke
- add regression coverage for successful retry and retry exhaustion

## Scope boundary
The live TOOTIE incident also contained host-local runtime state that does not belong to this version of the Unraid codebase. That state was repaired directly on the host and is intentionally **not** migrated, modeled, named, or cleaned up by this plugin.

This PR contains only startup/lifecycle hardening that is native to the current Unraid Codex implementation.

## Verification
- repo scan for unrelated implementation contamination: clean
- bash syntax + ShellCheck: pass
- git diff --check: pass
- plugins/codex/tests/disks-mounted.sh: pass
- plugins/codex/tests/configure-nginx.sh: pass
- live TOOTIE Codex app-server: active
- live Unix-socket app-server initialize smoke: pass
- nginx error storm stopped after the repaired runtime was reloaded
