### PR TITLE
chore(kache): pin kache 0.15.1

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Connect shared MinIO Kache
         uses: kunobi-ninja/kache-action@a257c055543c2840700a9bbca8f9c3094a421b1b # v0.13.0
         with:
-          version: "0.13.0"
+          version: "0.15.1"
           s3-bucket: ${{ vars.KACHE_S3_BUCKET }}
           s3-region: us-east-1
           s3-prefix: ${{ vars.KACHE_S3_PREFIX }}


### PR DESCRIPTION
Bumps the CI kache pin to **0.15.1**.

### Verified against the 0.15.1 binary before bumping

| Risk from the 0.14/0.15 notes | Result |
|---|---|
| 0.15.0 stops auto-started daemons inheriting `KACHE_S3_*` | Unaffected — the remote is written into `[cache.remote]` in `config.toml`, which is what the upgrade note prescribes |
| 0.15.0 versioned the report JSON schema | Unaffected — `kache-gate.sh` already reads `.summary.*`; ran its real jq pipeline against 0.15.1 output |
| CI-written config keys rejected | `local_store`, `daemon_idle_timeout_secs`, `prefetch_max_bytes`, `local_max_size` all accepted, no unknown-key warnings |

### Notes

- The cache-key schema reaches **v27**, so pre-0.14 entries cold-miss and are eligible for reclamation.
- Runner images ship no systemd `kache.service`, so the action owns the daemon and client/daemon versions always match — no version-split risk.